### PR TITLE
Prepare Neat SDK image, Insight, and DevKit sync

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,19 +46,19 @@ jobs:
         run: |
           owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           if [[ "${GITHUB_REF}" == refs/heads/main || "${GITHUB_REF}" == refs/tags/v* ]]; then
-            repo="elxr"
+            repo="sdk"
           else
             branch="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')"
             branch="$(echo "${branch}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
             if [[ -z "${branch}" ]]; then
               branch="branch"
             fi
-            repo="elxr-${branch}"
+            repo="sdk-${branch}"
           fi
           echo "name=ghcr.io/${owner}/${repo}" >> "${GITHUB_OUTPUT}"
 
       - name: Build Docker image
-        run: ./build.sh elxr "${IMAGE_TAG}"
+        run: ./build.sh sdk "${IMAGE_TAG}"
         env:
           IMAGE_TAG: ci-${{ matrix.image_suffix }}
           NEAT_GITHUB_PAT: ${{ secrets.NEAT_GITHUB_PAT }}
@@ -74,7 +74,7 @@ jobs:
       - name: Publish architecture image
         if: github.event_name != 'pull_request'
         run: |
-          docker tag elxr:ci-${IMAGE_SUFFIX} "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
+          docker tag sdk:ci-${IMAGE_SUFFIX} "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
           docker push "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
         env:
           IMAGE_NAME: ${{ steps.image.outputs.name }}
@@ -94,14 +94,14 @@ jobs:
         run: |
           owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           if [[ "${GITHUB_REF}" == refs/heads/main || "${GITHUB_REF}" == refs/tags/v* ]]; then
-            repo="elxr"
+            repo="sdk"
           else
             branch="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')"
             branch="$(echo "${branch}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
             if [[ -z "${branch}" ]]; then
               branch="branch"
             fi
-            repo="elxr-${branch}"
+            repo="sdk-${branch}"
           fi
           echo "name=ghcr.io/${owner}/${repo}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build on ${{ matrix.arch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,6 +179,8 @@ RUN printf 'SDK Version = 2.0.0_Palette_SDK_neat_%s_%s\neLXr Version = 2.0.0_rel
     "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
     > /etc/sdk-release
 
+WORKDIR /workspace
+
 RUN --mount=type=secret,id=neat_github_pat \
     mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src && \
     wget -O /tmp/install-neat-from-a-branch.sh https://tools.modalix.info/install-neat-from-a-branch.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,17 @@ ARG SDK_GIT_HASH=nogit
 ARG MINIMAL_IMAGE=0
 ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
+ARG NEAT_INSIGHT_BRANCH=main
+ARG NEAT_INSIGHT_VERSION=latest
 ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libgfortran5 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev liblapack-dev liblapack3 libopenblas-pthread-dev libopenblas0-pthread libqt5gui5 libsuperlu-dev libsuperlu5"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
 	protobuf-compiler-grpc,\
 	${SDK_PKG_LIST}"
+ENV NEAT_INSIGHT_VENV_DIR=/opt/neat-insight/venv
+ENV NEAT_INSIGHT_PORT=9900
+ENV NEAT_INSIGHT_SUPERVISED=1
+ENV PATH="${NEAT_INSIGHT_VENV_DIR}/bin:${PATH}"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -75,6 +81,11 @@ RUN apt-get update --allow-releaseinfo-change && \
       libgnutls28-dev \
       openssh-client \
       python3-dev \
+      python3-venv \
+      ffmpeg \
+      libffi8 \
+      libmediainfo0v5 \
+      supervisor \
       simaai-sdk-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -117,10 +128,14 @@ RUN if [ "${MINIMAL_IMAGE}" != "1" ]; then \
 
 COPY scripts/install-sysroot-overlay.sh /usr/local/bin/install-sysroot-overlay.sh
 COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
+COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/insight-admin && \
+    ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
     if [ "${MINIMAL_IMAGE}" != "1" ]; then \
       /bin/bash -lc 'set -euo pipefail; \
@@ -133,11 +148,13 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
       echo "Skipping sysroot overlay for minimal image build"; \
     fi
 
-RUN cat > /etc/profile.d/neat-elxr-prompt.sh <<'EOF'
+RUN /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH}" "${NEAT_INSIGHT_VERSION}"
+
+RUN cat > /etc/profile.d/neat-sdk-prompt.sh <<'EOF'
 #!/usr/bin/env bash
 if [[ $- == *i* ]]; then
   export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-version}"
-  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-elxr-${SDK_IMAGE_TAG}}"
+  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-${SDK_IMAGE_TAG}}"
   _sdk_rewrite_prompt_hostname() {
     local prompt="${1-}"
     prompt="${prompt//\\h/${SDK_PROMPT_HOSTNAME}}"
@@ -157,7 +174,7 @@ if [[ $- == *i* ]]; then
   fi
 fi
 EOF
-RUN chmod 755 /etc/profile.d/neat-elxr-prompt.sh
+RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh
 
 RUN cat > /etc/profile.d/pkg-config-sysroot.sh <<'EOF'
 #!/usr/bin/env bash
@@ -197,6 +214,9 @@ RUN --mount=type=secret,id=neat_github_pat \
       echo "Skipping sima-neat/core clone; neat_github_pat build secret not provided"; \
     fi && \
     git clone --depth 1 https://github.com/sima-neat/apps.git /neat-resources/apps-src
+
+# Expose required ports
+EXPOSE 9900 9000-9079 9100-9179 8081 8554
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/bin/bash", "-l"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN apt-get update --allow-releaseinfo-change && \
       libffi8 \
       libmediainfo0v5 \
       supervisor \
+      mkcert \
       simaai-sdk-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,7 +150,8 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
       echo "Skipping sysroot overlay for minimal image build"; \
     fi
 
-RUN /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH}" "${NEAT_INSIGHT_VERSION}"
+RUN /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH}" "${NEAT_INSIGHT_VERSION}" && \
+    chmod -R a+rwX "${NEAT_INSIGHT_VENV_DIR}"
 
 RUN cat > /etc/profile.d/neat-sdk-prompt.sh <<'EOF'
 #!/usr/bin/env bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN if [ "${MINIMAL_IMAGE}" != "1" ]; then \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/*
 
 COPY scripts/install-sysroot-overlay.sh /usr/local/bin/install-sysroot-overlay.sh
+COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -199,12 +199,13 @@ RUN printf 'SDK Version = 2.0.0_Palette_SDK_neat_%s_%s\neLXr Version = 2.0.0_rel
 
 WORKDIR /workspace
 
+# Preinstall Neat Framework and resources
 RUN --mount=type=secret,id=neat_github_pat \
     mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src && \
-    wget -O /tmp/install-neat-from-a-branch.sh https://tools.modalix.info/install-neat-from-a-branch.sh && \
+    wget -O /tmp/install-neat.sh https://tools.sima-neat.com/install-neat.sh && \
     cd /neat-resources/core-extra && \
-    bash /tmp/install-neat-from-a-branch.sh --minimum "${NEAT_BRANCH}" "${NEAT_VERSION}" && \
-    rm -f /tmp/install-neat-from-a-branch.sh && \
+    bash /tmp/install-neat.sh --minimum "${NEAT_BRANCH}" "${NEAT_VERSION}" && \
+    rm -f /tmp/install-neat.sh && \
     find /neat-resources/core-extra -type f \
       \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.whl' \) -delete && \
     if [ -f /run/secrets/neat_github_pat ] && [ -s /run/secrets/neat_github_pat ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,7 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
           overlay_pkgs+=("${pkg}:arm64"); \
         done; \
         /usr/local/bin/install-sysroot-overlay.sh /opt/toolchain/aarch64/modalix "${overlay_pkgs[@]}"'; \
+      chmod -R a+rX /opt/toolchain/aarch64/modalix/usr/include; \
     else \
       echo "Skipping sysroot overlay for minimal image build"; \
     fi

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ source devkit.sh
 
 This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables a watchdog timer for stale mount recovery, and sets Git `safe.directory` for the mounted workspace path.
 
+To open a direct SSH shell to the paired DevKit from inside the SDK container:
+
+```bash
+dk shell
+```
+
 ## Build Software
 
 ### Linux Kernel

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ source devkit.sh
 
 This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables a watchdog timer for stale mount recovery, and sets Git `safe.directory` for the mounted workspace path.
 
+During setup, `devkit.sh` also compares the SDK NEAT framework package versions cached under `${SYSROOT:-/opt/toolchain/aarch64/modalix}/neat-install-packages` with the versions installed on the DevKit. If the DevKit is missing NEAT framework packages or has different versions, the SDK copies its cached artifacts to the DevKit and runs the cached installer locally there.
+
+Optional controls:
+
+```bash
+DEVKIT_NEAT_SYNC=OFF          # skip NEAT framework version check/sync
+DEVKIT_NEAT_SYNC_REQUIRED=ON  # fail setup if NEAT framework sync fails
+DEVKIT_NEAT_SYNC_CACHE_DIR=... # override SDK artifact cache directory
+```
+
 To open a direct SSH shell to the paired DevKit from inside the SDK container:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # SiMa.ai eLxr Software Development Kit (SDK) Manual
 
-[![Build Docker Image](https://github.com/sima-neat/elxr-sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/elxr-sdk/actions/workflows/docker-build.yml)
+[![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
 
 > This is a user guide for the SiMa.ai eLxr Board Support Package (BSP).
 
@@ -58,7 +58,7 @@ Along with this manual, SiMa.ai SDK Dockerfiles, one for each platform, are prov
 
 The SDK Docker image contains all toolchains, headers, libraries, and related dependencies needed to build software for the SiMa.ai platform.
 
-CI-built `elxr` images are available for both `aarch64` and `x86_64` machine types.
+CI-built `sdk` images are available for both `aarch64` and `x86_64` machine types.
 
 ### Building SDK Docker
 
@@ -79,12 +79,12 @@ sudo apt install qemu-user-static
 ./build.sh
 ```
 
-- By default, this builds the `elxr:latest` image.
+- By default, this builds the `sdk:latest` image.
 - The local build workflow supports both `aarch64` and `x86_64` hosts and automatically selects the matching Docker platform for the current machine.
 - A custom image name and tag can be provided:
 
 ```bash
-./build.sh elxr 2.0.0
+./build.sh sdk 2.0.0
 ```
 
 > A comma-separated package list can be provided to install additional packages into the sysroot during Docker build. Example:
@@ -92,7 +92,7 @@ sudo apt install qemu-user-static
 > `SDK_PKG_LIST=libzix-dev,vxi-dev ./build.sh`
 
 ```text
-Building elxr:latest
+Building sdk:latest
 Host architecture: arm64
 Docker platform: linux/arm64
 ```
@@ -105,16 +105,16 @@ Use the helper script:
 ./run.sh
 ```
 
-This will try to pull `ghcr.io/sima-neat/elxr:<tag>` from GitHub Packages first and fall back to a matching local image if present.
+This will try to pull `ghcr.io/sima-neat/sdk:<tag>` from GitHub Packages first and fall back to a matching local image if present.
 
 You can also use standard Docker commands directly:
 
 ```bash
-docker pull ghcr.io/sima-neat/elxr:latest
-docker run --rm -it --name elxr --privileged \
+docker pull ghcr.io/sima-neat/sdk:latest
+docker run --rm -it --name sdk --privileged \
   -p 9900:9900 -p 9000-9079:9000-9079 -p 9100-9179:9100-9179 -p 8081:8081 -p 8554:8554 \
   -v "$(pwd):/workspace" -w /workspace -v /dev:/dev --pid=host \
-  ghcr.io/sima-neat/elxr:latest /bin/bash -l
+  ghcr.io/sima-neat/sdk:latest /bin/bash -l
 ```
 
 > Notes:
@@ -147,7 +147,7 @@ insight-admin restart
 That change only affects the current container. To make an Insight upgrade permanent, rebuild the SDK image with the desired channel and version:
 
 ```bash
-NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh elxr 2.0.0
+NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh sdk 2.0.0
 ```
 
 ### DevKit Workspace (NFS)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > This is a user guide for the SiMa.ai eLxr Board Support Package (BSP).
 
-This repository provides a custom build of the eLxr SDK for SiMa.ai platforms. It supports both `x86_64` and `arm64` host builds, prepares the sysroot with NEAT-required dependencies during Docker build, installs `sima-cli`, and remains compatible with the official eLxr SDK `2.0` release.
+This repository provides a custom build of the Neat SDK for SiMa.ai platforms. It supports both `x86_64` and `arm64` host builds, prepares the sysroot with NEAT-required dependencies during Docker build, installs `sima-cli`, and remains compatible with the official eLxr SDK `2.0` release.
 
 ## About eLxr Project
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ You can also use standard Docker commands directly:
 
 ```bash
 docker pull ghcr.io/sima-neat/elxr:latest
-docker run --rm -it --name elxr --privileged -v "$(pwd):/workspace" -w /workspace -v /dev:/dev --pid=host ghcr.io/sima-neat/elxr:latest /bin/bash -l
+docker run --rm -it --name elxr --privileged \
+  -p 9900:9900 -p 9000-9079:9000-9079 -p 9100-9179:9100-9179 -p 8081:8081 -p 8554:8554 \
+  -v "$(pwd):/workspace" -w /workspace -v /dev:/dev --pid=host \
+  ghcr.io/sima-neat/elxr:latest /bin/bash -l
 ```
 
 > Notes:
@@ -121,6 +124,32 @@ docker run --rm -it --name elxr --privileged -v "$(pwd):/workspace" -w /workspac
 > - Although the build environment is automatically configured when the container launches, it can also be set manually:
 >   `source /opt/bin/simaai-init-build-env <platform>`
 
+### NEAT Insight
+
+The SDK image installs `neat-insight` into `/opt/neat-insight/venv` and starts it automatically under `supervisord` when the container starts. By default it listens on port `9900`.
+
+Useful commands inside the running container:
+
+```bash
+insight-admin status
+insight-admin logs
+insight-admin restart
+insight-admin stop
+```
+
+To temporarily upgrade Insight inside an existing container:
+
+```bash
+insight-admin update main latest
+insight-admin restart
+```
+
+That change only affects the current container. To make an Insight upgrade permanent, rebuild the SDK image with the desired channel and version:
+
+```bash
+NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh elxr 2.0.0
+```
+
 ### DevKit Workspace (NFS)
 
 The workspace sharing flow is now NFS-based.
@@ -129,6 +158,12 @@ The workspace sharing flow is now NFS-based.
 
 ```bash
 ./run.sh --prefer-local --devkit-ip 10.0.0.244
+```
+
+If the host IP selected for NFS is not reachable from the DevKit, provide the host interface IP explicitly:
+
+```bash
+./run.sh --prefer-local --devkit-ip 10.0.0.244 --hostip 10.0.0.10
 ```
 
 2. Inside the container, source the setup helper:

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCKERFILE="${DOCKERFILE:-${SCRIPT_DIR}/Dockerfile}"
 CONTEXT_DIR="${CONTEXT_DIR:-${SCRIPT_DIR}}"
-IMAGE_NAME="${IMAGE_NAME:-elxr}"
+IMAGE_NAME="${IMAGE_NAME:-sdk}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 MINIMAL_IMAGE="${MINIMAL_IMAGE:-0}"
 NEAT_BRANCH="${NEAT_BRANCH:-main}"

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ IMAGE_TAG="${IMAGE_TAG:-latest}"
 MINIMAL_IMAGE="${MINIMAL_IMAGE:-0}"
 NEAT_BRANCH="${NEAT_BRANCH:-main}"
 NEAT_VERSION="${NEAT_VERSION:-latest}"
+NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH:-main}"
+NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION:-latest}"
 NEAT_GITHUB_PAT="${NEAT_GITHUB_PAT:-${GITHUB_PAT:-}}"
 
 usage() {
@@ -26,6 +28,8 @@ Environment overrides:
   MINIMAL_IMAGE  If set to 1, skip rustup/setup-sdk/sysroot-overlay and install sima-cli only for /neat-resources baking (default: ${MINIMAL_IMAGE})
   NEAT_BRANCH  NEAT Framework branch to bake into /neat-resources (default: ${NEAT_BRANCH})
   NEAT_VERSION  NEAT Framework version/tag to bake into /neat-resources (default: ${NEAT_VERSION})
+  NEAT_INSIGHT_BRANCH  neat-insight branch/release channel to install (default: ${NEAT_INSIGHT_BRANCH})
+  NEAT_INSIGHT_VERSION  neat-insight version/tag to install, or latest (default: ${NEAT_INSIGHT_VERSION})
   NEAT_GITHUB_PAT  Secret token for cloning sima-neat/core during image build (default: from GITHUB_PAT or unset)
 EOF
 }
@@ -105,6 +109,8 @@ if [[ "${MINIMAL_IMAGE}" == "1" ]]; then
 fi
 echo "NEAT branch: ${NEAT_BRANCH}"
 echo "NEAT version: ${NEAT_VERSION}"
+echo "NEAT Insight branch: ${NEAT_INSIGHT_BRANCH}"
+echo "NEAT Insight version: ${NEAT_INSIGHT_VERSION}"
 
 if docker buildx version >/dev/null 2>&1; then
   buildx_cmd=(
@@ -114,6 +120,8 @@ if docker buildx version >/dev/null 2>&1; then
     --build-arg MINIMAL_IMAGE="${MINIMAL_IMAGE}"
     --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
     --build-arg NEAT_VERSION="${NEAT_VERSION}"
+    --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
+    --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
     --build-arg SDK_GIT_BRANCH="${git_branch}"
     --build-arg SDK_GIT_HASH="${git_hash}"
     -f "${DOCKERFILE}"
@@ -132,6 +140,8 @@ build_cmd=(
   --build-arg MINIMAL_IMAGE="${MINIMAL_IMAGE}"
   --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
   --build-arg NEAT_VERSION="${NEAT_VERSION}"
+  --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
+  --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
   --build-arg SDK_GIT_BRANCH="${git_branch}"
   --build-arg SDK_GIT_HASH="${git_hash}"
   -f "${DOCKERFILE}"

--- a/config/supervisor-neat-insight.conf
+++ b/config/supervisor-neat-insight.conf
@@ -1,0 +1,16 @@
+[program:neat-insight]
+command=/opt/neat-insight/venv/bin/neat-insight --port %(ENV_NEAT_INSIGHT_PORT)s
+directory=/workspace
+autostart=true
+autorestart=true
+startsecs=3
+startretries=3
+stopsignal=TERM
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/var/log/supervisor/neat-insight.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=3
+stderr_logfile=/var/log/supervisor/neat-insight.err.log
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=3

--- a/config/sysroot-overlay.conf
+++ b/config/sysroot-overlay.conf
@@ -1,0 +1,2 @@
+# Modalix 2.0 official SDK sysroot uses 6.1.22 Linux UAPI headers.
+linux_libc_dev_arm64_version=6.1.22-modalix-827

--- a/run.py
+++ b/run.py
@@ -189,7 +189,7 @@ def make_hostname(image_name: str, image_tag: str) -> str:
     cleaned = re.sub(r"[^a-z0-9-]", "-", raw)
     cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-")
     if not cleaned:
-        cleaned = "elxr-sdk"
+        cleaned = "neat-sdk"
     return cleaned[:63]
 
 
@@ -212,7 +212,7 @@ def main() -> int:
     p.add_argument("--devkit-ip", default=os.getenv("DEVKIT_IP", ""), help="DevKit IP used to restrict host NFS export")
     p.add_argument("--hostip", default=os.getenv("HOST_IP", ""), help="Override detected host IP")
     p.add_argument("--share-backend", choices=["auto", "nfs", "smb", "none"], default="auto")
-    p.add_argument("image_name", nargs="?", default=os.getenv("IMAGE_NAME", "elxr"))
+    p.add_argument("image_name", nargs="?", default=os.getenv("IMAGE_NAME", "sdk"))
     p.add_argument("image_tag", nargs="?", default=os.getenv("IMAGE_TAG", "latest"))
     args = p.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -195,6 +195,7 @@ def make_hostname(image_name: str, image_tag: str) -> str:
 
 def interactive_shell_argv() -> list[str]:
     init = """
+cd "${CONTAINER_WORKDIR:-/workspace}" 2>/dev/null || true
 if [ -n "${DEVKIT_SYNC_DEVKIT_IP:-}" ] && [ -f /usr/local/bin/devkit.sh ] && [ ! -f "${HOME}/.devkit-sync.rc" ]; then
   source /usr/local/bin/devkit.sh "${DEVKIT_SYNC_DEVKIT_IP}"
 fi
@@ -285,6 +286,7 @@ def main() -> int:
         "-e", f"DEVKIT_HOST_PLATFORM={host_os}",
         "-e", f"DEVKIT_SYNC_DEVKIT_IP={args.devkit_ip}",
         "-e", f"SDK_IMAGE_TAG={args.image_tag}",
+        "-e", f"CONTAINER_WORKDIR={workdir}",
         chosen_image,
     ]
 

--- a/run.py
+++ b/run.py
@@ -24,22 +24,44 @@ def _is_linux_virtual_iface(iface: str) -> bool:
     return iface.startswith(prefixes)
 
 
-def _detect_physical_ipv4s_macos() -> list[tuple[str, str]]:
+def _is_macos_virtual_iface(iface: str) -> bool:
+    prefixes = ("lo", "utun", "tun", "tap", "gif", "stf", "bridge", "awdl", "llw", "vboxnet", "vmnet")
+    return iface.startswith(prefixes)
+
+
+def _netmask_to_prefix(netmask: str) -> int:
+    if netmask.startswith("0x"):
+        value = int(netmask, 16)
+        return bin(value).count("1")
+    return ipaddress.IPv4Network(f"0.0.0.0/{netmask}").prefixlen
+
+
+def _parse_devkit_ip(devkit_ip: str | None) -> ipaddress.IPv4Address | None:
+    if not devkit_ip:
+        return None
+    try:
+        return ipaddress.IPv4Address(devkit_ip)
+    except ipaddress.AddressValueError:
+        return None
+
+
+def _detect_physical_ipv4s_macos() -> list[tuple[str, str, int]]:
     try:
         out = run(["ifconfig"], capture=True).stdout or ""
     except Exception:
         return []
 
-    found: list[tuple[str, str]] = []
+    found: list[tuple[str, str, int]] = []
     iface = ""
     status = ""
     inet: str | None = None
+    prefix = 24
     is_physical = False
 
     def flush_current() -> None:
-        nonlocal iface, status, inet, is_physical
+        nonlocal iface, status, inet, prefix, is_physical
         if iface and is_physical and status == "active" and inet and not inet.startswith("127."):
-            found.append((iface, inet))
+            found.append((iface, inet, prefix))
 
     for line in out.splitlines():
         m = re.match(r"^([a-zA-Z0-9]+): flags=", line)
@@ -48,7 +70,8 @@ def _detect_physical_ipv4s_macos() -> list[tuple[str, str]]:
             iface = m.group(1)
             status = ""
             inet = None
-            is_physical = iface.startswith("en")
+            prefix = 24
+            is_physical = iface.startswith("en") and not _is_macos_virtual_iface(iface)
             continue
         if not iface:
             continue
@@ -59,12 +82,19 @@ def _detect_physical_ipv4s_macos() -> list[tuple[str, str]]:
             parts = s.split()
             if len(parts) >= 2:
                 inet = parts[1]
+            if "netmask" in parts:
+                mask_index = parts.index("netmask") + 1
+                if mask_index < len(parts):
+                    try:
+                        prefix = _netmask_to_prefix(parts[mask_index])
+                    except Exception:
+                        prefix = 24
 
     flush_current()
     return found
 
 
-def _detect_physical_ipv4s_linux() -> list[tuple[str, str]]:
+def _detect_physical_ipv4s_linux() -> list[tuple[str, str, int]]:
     if not has_cmd("ip"):
         return []
     try:
@@ -72,29 +102,70 @@ def _detect_physical_ipv4s_linux() -> list[tuple[str, str]]:
     except Exception:
         return []
 
-    found: list[tuple[str, str]] = []
+    found: list[tuple[str, str, int]] = []
     for line in out.splitlines():
         # Example: "2: eth0    inet 192.168.1.10/24 ..."
-        m = re.match(r"^\d+:\s+([^\s]+)\s+inet\s+(\d+\.\d+\.\d+\.\d+)/\d+", line)
+        m = re.match(r"^\d+:\s+([^\s]+)\s+inet\s+(\d+\.\d+\.\d+\.\d+)/(\d+)", line)
         if not m:
             continue
-        iface, ip = m.group(1), m.group(2)
+        iface, ip, prefix = m.group(1), m.group(2), int(m.group(3))
         if _is_linux_virtual_iface(iface):
             continue
         if iface.startswith(("en", "eth")):
-            found.append((iface, ip))
+            found.append((iface, ip, prefix))
     return found
 
 
+def _route_iface_macos(devkit_ip: str | None) -> str:
+    if not devkit_ip:
+        return ""
+    try:
+        out = run(["route", "-n", "get", devkit_ip], capture=True).stdout or ""
+    except Exception:
+        return ""
+    for line in out.splitlines():
+        parts = line.strip().split(":", 1)
+        if len(parts) == 2 and parts[0].strip() == "interface":
+            return parts[1].strip()
+    return ""
+
+
+def _route_iface_linux(devkit_ip: str | None) -> str:
+    if not devkit_ip or not has_cmd("ip"):
+        return ""
+    try:
+        out = run(["ip", "route", "get", devkit_ip], capture=True).stdout or ""
+    except Exception:
+        return ""
+    m = re.search(r"\bdev\s+(\S+)", out)
+    return m.group(1) if m else ""
+
+
 def detect_host_ip(devkit_ip: str | None) -> tuple[str, str, list[tuple[str, str]]]:
-    candidates: list[tuple[str, str]] = []
+    candidates: list[tuple[str, str, int]] = []
+    route_iface = ""
     if sys.platform == "darwin":
         candidates = _detect_physical_ipv4s_macos()
+        route_iface = _route_iface_macos(devkit_ip)
     elif sys.platform.startswith("linux"):
         candidates = _detect_physical_ipv4s_linux()
+        route_iface = _route_iface_linux(devkit_ip)
+
+    devkit_addr = _parse_devkit_ip(devkit_ip)
+    if devkit_addr:
+        for iface, ip, prefix in candidates:
+            network = ipaddress.IPv4Network(f"{ip}/{prefix}", strict=False)
+            if devkit_addr in network:
+                return ip, iface, [(i, addr) for i, addr, _ in candidates]
+
+    if route_iface:
+        for iface, ip, _ in candidates:
+            if iface == route_iface:
+                return ip, iface, [(i, addr) for i, addr, _ in candidates]
+
     if candidates:
-        iface, ip = candidates[0]
-        return ip, iface, candidates
+        iface, ip, _ = candidates[0]
+        return ip, iface, [(i, addr) for i, addr, _ in candidates]
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
@@ -185,7 +256,10 @@ def container_exists(name: str, running_only: bool = False) -> bool:
 
 
 def make_hostname(image_name: str, image_tag: str) -> str:
-    raw = f"{image_name}-{image_tag}".lower()
+    if image_name == "sdk":
+        raw = f"neat-sdk-{image_tag}".lower()
+    else:
+        raw = f"{image_name}-{image_tag}".lower()
     cleaned = re.sub(r"[^a-z0-9-]", "-", raw)
     cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-")
     if not cleaned:
@@ -205,7 +279,7 @@ exec /bin/bash -l
 
 
 def main() -> int:
-    p = argparse.ArgumentParser(description="Start eLxr SDK container + host share setup")
+    p = argparse.ArgumentParser(description="Start Neat SDK + DevKit Sync Setup")
     p.add_argument("--prefer-local", action="store_true")
     p.add_argument("--background", action="store_true")
     p.add_argument("--connect", action="store_true")
@@ -221,7 +295,7 @@ def main() -> int:
     if modes > 1:
         raise SystemExit("Use only one of --background/--connect/--stop")
 
-    container_name = os.getenv("CONTAINER_NAME", "elxr")
+    container_name = os.getenv("CONTAINER_NAME", "sdk")
     workdir = os.getenv("CONTAINER_WORKDIR", "/workspace")
     host_dir = Path.cwd()
     ghcr_owner = os.getenv("GHCR_OWNER", "sima-neat")
@@ -292,6 +366,14 @@ def main() -> int:
 
     if host_os.startswith("linux"):
         docker_cmd[2:2] = ["--network", "host"]
+    else:
+        docker_cmd[2:2] = [
+            "-p", "9900:9900",
+            "-p", "9000-9079:9000-9079",
+            "-p", "9100-9179:9100-9179",
+            "-p", "8081:8081",
+            "-p", "8554:8554",
+        ]
 
     if args.background:
         docker_cmd.insert(2, "-d")

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -18,6 +18,61 @@ check_remote_passwordless_sudo() {
   ssh -tt -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "sudo -n true" >/dev/null 2>&1
 }
 
+check_devkit_sdk_version_compatibility() {
+  local user="$1"
+  local ip="$2"
+  local port="$3"
+  local sdk_release="/etc/sdk-release"
+  local devkit_distro_version=""
+  local c_warn="" c_reset=""
+
+  if [[ -t 2 ]]; then
+    c_warn=$'\033[1;31m'
+    c_reset=$'\033[0m'
+  fi
+
+  echo "Checking DevKit/SDK version compatibility..."
+
+  if [[ ! -r "${sdk_release}" ]]; then
+    printf "%bWARNING:%b SDK release file not found or unreadable: %s\n" "${c_warn}" "${c_reset}" "${sdk_release}" >&2
+    printf "Please use an SDK image that includes /etc/sdk-release before connecting a DevKit.\n" >&2
+    return 0
+  fi
+
+  devkit_distro_version="$(
+    ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" sh -s 2>/dev/null <<'EOS'
+if [ ! -r /etc/buildinfo ]; then
+  exit 2
+fi
+awk -F= '
+  /^[[:space:]]*DISTRO_VERSION[[:space:]]*=/ {
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+    print $2
+    exit
+  }
+' /etc/buildinfo
+EOS
+  )"
+
+  if [[ -z "${devkit_distro_version}" ]]; then
+    printf "%bWARNING:%b Could not read DISTRO_VERSION from DevKit /etc/buildinfo.\n" "${c_warn}" "${c_reset}" >&2
+    printf "Please update your DevKit to a build that exposes /etc/buildinfo with DISTRO_VERSION.\n" >&2
+    return 0
+  fi
+
+  if grep -Fq "${devkit_distro_version}" "${sdk_release}"; then
+    echo "DevKit DISTRO_VERSION ${devkit_distro_version} is compatible with this SDK."
+    return 0
+  fi
+
+  printf "%bWARNING: DevKit/SDK version mismatch.%b\n" "${c_warn}" "${c_reset}" >&2
+  printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}" >&2
+  printf "  SDK release file     : %s\n" "${sdk_release}" >&2
+  sed 's/^/    /' "${sdk_release}" >&2
+  printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.\n" "${sdk_release}" >&2
+  return 0
+}
+
 _DEVKIT_IP="${1:-${DEVKIT_SYNC_DEVKIT_IP:-}}"
 _DEVKIT_USER="${2:-sima}"
 _DEVKIT_PORT="${3:-22}"
@@ -82,6 +137,8 @@ if ! timeout --foreground 120 ssh-copy-id -i "${HOME}/.ssh/id_ed25519.pub" -p "$
   echo "Hint: verify the DevKit IP/port, that SSH is running, and that the user is reachable before retrying." >&2
   return 1
 fi
+
+check_devkit_sdk_version_compatibility "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"
 
 if [[ "${_DEVKIT_USER}" != "root" ]]; then
   if ! check_remote_passwordless_sudo "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"; then
@@ -751,6 +808,8 @@ ${_c_ok}
 
   You can now run DevKit binaries from this SDK shell:
     dk /workspace/<path-to-arm64-binary> [args...]
+  Or connect to a DevKit shell directly:
+    dk shell
 ============================================================
 ${_c_rst}
 EOF

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -365,6 +365,48 @@ NEAT_INSTALLER_SKIP_DEVKIT_SYNC=ON bash ./install_neat_framework.sh --local"
   return 0
 }
 
+copy_insight_port_map_to_devkit() {
+  local user="$1"
+  local ip="$2"
+  local port="$3"
+  local local_port_map="${HOME}/.insight-config/neat-port-map.json"
+  local remote_config_dir=".insight-config"
+  local remote_port_map="${remote_config_dir}/neat-port-map.json"
+  local c_yellow="" c_green="" c_reset=""
+
+  if [[ ! -f "${local_port_map}" ]]; then
+    return 0
+  fi
+
+  if [[ -t 2 ]]; then
+    c_yellow=$'\033[1;33m'
+    c_reset=$'\033[0m'
+  fi
+  if [[ -t 1 ]]; then
+    c_green=$'\033[1;32m'
+    c_reset=$'\033[0m'
+  fi
+
+  if ! command -v scp >/dev/null 2>&1; then
+    printf "%bWARNING:%b scp is required to copy Insight port map to DevKit.\n" "${c_yellow}" "${c_reset}" >&2
+    return 0
+  fi
+
+  echo "Copying Insight port map to DevKit ${user}@${ip}:${remote_port_map}"
+  if ! ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "mkdir -p '${remote_config_dir}'"; then
+    printf "%bWARNING:%b Failed to create DevKit Insight config directory: ~/%s\n" "${c_yellow}" "${c_reset}" "${remote_config_dir}" >&2
+    return 0
+  fi
+
+  if ! scp -P "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${local_port_map}" "${user}@${ip}:${remote_port_map}"; then
+    printf "%bWARNING:%b Failed to copy Insight port map to DevKit: ~/%s\n" "${c_yellow}" "${c_reset}" "${remote_port_map}" >&2
+    return 0
+  fi
+
+  printf "%bInsight port map copied to DevKit: ~/%s%b\n" "${c_green}" "${remote_port_map}" "${c_reset}"
+  return 0
+}
+
 _DEVKIT_IP="${1:-${DEVKIT_SYNC_DEVKIT_IP:-}}"
 _DEVKIT_USER="${2:-sima}"
 _DEVKIT_PORT="${3:-22}"
@@ -1085,6 +1127,8 @@ EOF
     fi
   done < /etc/passwd
 fi
+
+copy_insight_port_map_to_devkit "${DEVKIT_SYNC_DEVKIT_USER}" "${DEVKIT_SYNC_DEVKIT_IP}" "${DEVKIT_SYNC_DEVKIT_PORT}"
 
 echo "Persisted DevKit shell helpers to ${_persist_file} (auto-loaded by ~/.bashrc and ~/.bash_profile)."
 

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -92,6 +92,279 @@ EOS
   return 0
 }
 
+sync_neat_framework_to_devkit() {
+  local user="$1"
+  local ip="$2"
+  local port="$3"
+  local sync_enabled="${DEVKIT_NEAT_SYNC:-ON}"
+  local sync_required="${DEVKIT_NEAT_SYNC_REQUIRED:-OFF}"
+  local sysroot="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
+  local cache_dir="${DEVKIT_NEAT_SYNC_CACHE_DIR:-${sysroot}/neat-install-packages}"
+  local c_yellow="" c_green="" c_reset=""
+
+  if [[ -t 2 ]]; then
+    c_yellow=$'\033[1;33m'
+    c_reset=$'\033[0m'
+  fi
+  if [[ -t 1 ]]; then
+    c_green=$'\033[1;32m'
+    c_reset=$'\033[0m'
+  fi
+
+  neat_sync_warn() {
+    printf "%b%s%b\n" "${c_yellow}" "$*" "${c_reset}" >&2
+  }
+
+  neat_sync_fail_or_continue() {
+    local msg="$1"
+    neat_sync_warn "${msg}"
+    if [[ "${sync_required}" == "ON" ]]; then
+      return 1
+    fi
+    return 0
+  }
+
+  case "${sync_enabled}" in
+    OFF|off|0|false|FALSE|no|NO)
+      echo "Neat framework DevKit sync disabled by DEVKIT_NEAT_SYNC=${sync_enabled}."
+      return 0
+      ;;
+  esac
+
+  echo "Checking Neat framework versions between SDK and DevKit..."
+
+  if [[ ! -d "${cache_dir}" ]]; then
+    neat_sync_fail_or_continue "WARNING: Neat framework SDK cache not found: ${cache_dir}"
+    return $?
+  fi
+  if [[ ! -f "${cache_dir}/install_neat_framework.sh" ]]; then
+    neat_sync_fail_or_continue "WARNING: Neat framework installer missing from SDK cache: ${cache_dir}/install_neat_framework.sh"
+    return $?
+  fi
+  if ! command -v dpkg-deb >/dev/null 2>&1; then
+    neat_sync_fail_or_continue "WARNING: dpkg-deb is required to inspect SDK Neat framework package versions."
+    return $?
+  fi
+  if ! command -v scp >/dev/null 2>&1; then
+    neat_sync_fail_or_continue "WARNING: scp is required to copy Neat framework install artifacts to the DevKit."
+    return $?
+  fi
+
+  local -a deb_files=()
+  local -a wheel_files=()
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' \) | sort)
+  mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
+
+  if [[ "${#deb_files[@]}" -lt 1 ]]; then
+    neat_sync_fail_or_continue "WARNING: No Neat framework deb packages found in SDK cache: ${cache_dir}"
+    return $?
+  fi
+  if [[ "${#wheel_files[@]}" -lt 1 ]]; then
+    neat_sync_fail_or_continue "WARNING: No Neat framework Python wheel found in SDK cache: ${cache_dir}"
+    return $?
+  fi
+  if [[ "${#wheel_files[@]}" -gt 1 ]]; then
+    neat_sync_warn "WARNING: Multiple wheels found in SDK cache; using $(basename "${wheel_files[0]}")."
+  fi
+
+  local -a expected_entries=()
+  local -a expected_deb_names=()
+  local deb pkg version wheel_file wheel_base wheel_name wheel_version
+  for deb in "${deb_files[@]}"; do
+    pkg="$(dpkg-deb -f "${deb}" Package 2>/dev/null || true)"
+    version="$(dpkg-deb -f "${deb}" Version 2>/dev/null || true)"
+    if [[ -z "${pkg}" || -z "${version}" ]]; then
+      neat_sync_fail_or_continue "WARNING: Could not read package metadata from $(basename "${deb}")."
+      return $?
+    fi
+    expected_entries+=("deb|${pkg}|${version}|$(basename "${deb}")")
+    expected_deb_names+=("${pkg}")
+  done
+
+  wheel_file="${wheel_files[0]}"
+  wheel_base="$(basename "${wheel_file}")"
+  wheel_base="${wheel_base%.whl}"
+  wheel_name="${wheel_base%%-*}"
+  wheel_version="${wheel_base#*-}"
+  wheel_version="${wheel_version%%-*}"
+  if [[ -z "${wheel_name}" || -z "${wheel_version}" || "${wheel_name}" == "${wheel_base}" ]]; then
+    neat_sync_fail_or_continue "WARNING: Could not parse Python wheel name/version from $(basename "${wheel_file}")."
+    return $?
+  fi
+  expected_entries+=("wheel|${wheel_name}|${wheel_version}|$(basename "${wheel_file}")")
+
+  query_devkit_neat_versions() {
+    ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" bash -s -- "${wheel_name}" "${expected_deb_names[@]}" <<'EOS'
+set -euo pipefail
+wheel_name="$1"
+shift || true
+
+for pkg in "$@"; do
+  if version="$(dpkg-query -W -f='${Version}' "${pkg}" 2>/dev/null)"; then
+    printf 'deb|%s|%s\n' "${pkg}" "${version}"
+  else
+    printf 'deb|%s|missing\n' "${pkg}"
+  fi
+done
+
+wheel_version="missing"
+py="${HOME}/pyneat/bin/python"
+if [[ -x "${py}" ]]; then
+  if version="$("${py}" - "${wheel_name}" 2>/dev/null <<'PY'
+import importlib.metadata
+import sys
+
+try:
+    print(importlib.metadata.version(sys.argv[1]))
+except importlib.metadata.PackageNotFoundError:
+    raise SystemExit(1)
+PY
+)"; then
+    if [[ -n "${version}" ]]; then
+      wheel_version="${version}"
+    fi
+  fi
+
+  if [[ "${wheel_version}" == "missing" ]]; then
+    if version="$("${py}" -m pip show "${wheel_name}" 2>/dev/null | awk -F': ' '/^Version:/ { print $2; exit }' || true)"; then
+      if [[ -n "${version}" ]]; then
+        wheel_version="${version}"
+      fi
+    fi
+  fi
+fi
+
+printf 'wheel|%s|%s\n' "${wheel_name}" "${wheel_version}"
+EOS
+  }
+
+  local -a actual_entries=()
+  local actual_output=""
+  if ! actual_output="$(query_devkit_neat_versions)"; then
+    neat_sync_warn "WARNING: Could not query NEAT framework versions from DevKit; treating DevKit as out of sync."
+    actual_entries=()
+  elif [[ -n "${actual_output}" ]]; then
+    mapfile -t actual_entries <<< "${actual_output}"
+  fi
+
+  compare_neat_versions() {
+    local -n _actual_entries_ref="$1"
+    local -n _mismatch_lines_ref="$2"
+    local -n _match_lines_ref="$3"
+    local -A actual_versions=()
+    local entry type name expected file actual
+
+    for entry in "${_actual_entries_ref[@]}"; do
+      IFS='|' read -r type name actual <<< "${entry}"
+      [[ -n "${type}" && -n "${name}" ]] || continue
+      actual_versions["${type}|${name}"]="${actual:-missing}"
+    done
+
+    for entry in "${expected_entries[@]}"; do
+      IFS='|' read -r type name expected file <<< "${entry}"
+      actual="${actual_versions["${type}|${name}"]:-missing}"
+      if [[ "${actual}" == "${expected}" ]]; then
+        _match_lines_ref+=("  ${type} ${name}: ${expected}")
+      else
+        _mismatch_lines_ref+=("  ${type} ${name}: SDK=${expected}, DevKit=${actual}")
+      fi
+    done
+  }
+
+  local -a mismatch_lines=()
+  local -a match_lines=()
+  compare_neat_versions actual_entries mismatch_lines match_lines
+
+  print_neat_sync_success() {
+    {
+      printf "%bNEAT framework versions are in sync between SDK and DevKit.\n" "${c_green}"
+      printf '%s\n' "${match_lines[@]}"
+      printf "%b" "${c_reset}"
+    }
+  }
+
+  if [[ "${#mismatch_lines[@]}" -eq 0 ]]; then
+    print_neat_sync_success
+    return 0
+  fi
+
+  {
+    printf "%bNeat framework is out of sync between SDK and DevKit.\n" "${c_yellow}"
+    printf '%s\n' "${mismatch_lines[@]}"
+    if [[ "${#match_lines[@]}" -gt 0 ]]; then
+      printf "\nAlready in sync:\n"
+      printf '%s\n' "${match_lines[@]}"
+    fi
+    printf "\nInstalling SDK Neat framework packages on the DevKit...%b\n" "${c_reset}"
+  } >&2
+
+  local remote_dir="/tmp/sima-neat-install-$(date +%Y%m%d-%H%M%S)"
+  local -a deploy_files=("${deb_files[@]}" "${wheel_file}" "${cache_dir}/install_neat_framework.sh")
+
+  if ! ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "mkdir -p '${remote_dir}'"; then
+    neat_sync_fail_or_continue "WARNING: Failed to create Neat framework install directory on DevKit: ${remote_dir}"
+    return $?
+  fi
+
+  if ! scp -P "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${deploy_files[@]}" "${user}@${ip}:${remote_dir}/"; then
+    ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "rm -rf '${remote_dir}'" >/dev/null 2>&1 || true
+    neat_sync_fail_or_continue "WARNING: Failed to copy Neat framework install artifacts to DevKit."
+    return $?
+  fi
+
+  local remote_install_cmd
+  remote_install_cmd="set -euo pipefail
+remote_dir=$(printf '%q' "${remote_dir}")
+cleanup_remote_artifacts() {
+  rm -rf \"\${remote_dir}\"
+}
+trap cleanup_remote_artifacts EXIT
+chmod +x \"\${remote_dir}/install_neat_framework.sh\"
+cd \"\${remote_dir}\"
+NEAT_INSTALLER_SKIP_DEVKIT_SYNC=ON bash ./install_neat_framework.sh --local"
+
+  local -a ssh_install_args=(ssh -p "${port}" -o BatchMode=yes -o ConnectTimeout=8)
+  if [[ -t 0 && -t 1 ]]; then
+    ssh_install_args+=(-t)
+  else
+    ssh_install_args+=(-T)
+  fi
+  ssh_install_args+=("${user}@${ip}" "bash -lc $(printf '%q' "${remote_install_cmd}")")
+
+  if ! "${ssh_install_args[@]}"; then
+    ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "rm -rf '${remote_dir}'" >/dev/null 2>&1 || true
+    neat_sync_fail_or_continue "WARNING: Failed to install SDK NEAT framework packages on DevKit."
+    return $?
+  fi
+
+  actual_entries=()
+  actual_output=""
+  if ! actual_output="$(query_devkit_neat_versions)"; then
+    neat_sync_fail_or_continue "WARNING: Could not verify NEAT framework versions after DevKit install."
+    return $?
+  elif [[ -n "${actual_output}" ]]; then
+    mapfile -t actual_entries <<< "${actual_output}"
+  fi
+
+  mismatch_lines=()
+  match_lines=()
+  compare_neat_versions actual_entries mismatch_lines match_lines
+  if [[ "${#mismatch_lines[@]}" -eq 0 ]]; then
+    print_neat_sync_success
+    return 0
+  fi
+
+  {
+    printf "%bWARNING: NEAT framework versions are still out of sync after DevKit install.\n" "${c_yellow}"
+    printf '%s\n' "${mismatch_lines[@]}"
+    printf "%b" "${c_reset}"
+  } >&2
+  if [[ "${sync_required}" == "ON" ]]; then
+    return 1
+  fi
+  return 0
+}
+
 _DEVKIT_IP="${1:-${DEVKIT_SYNC_DEVKIT_IP:-}}"
 _DEVKIT_USER="${2:-sima}"
 _DEVKIT_PORT="${3:-22}"
@@ -209,6 +482,10 @@ EOS
         ;;
     esac
   fi
+fi
+
+if ! sync_neat_framework_to_devkit "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"; then
+  return 1
 fi
 
 echo "Configuring remote NFS mount..."

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -309,12 +309,27 @@ echo "Target: ${DEVKIT_SYNC_TARGET}"
 # Run a local /workspace binary or Python script on the paired DevKit.
 devkit-run() {
   if [[ $# -lt 1 ]]; then
-    echo "Usage: devkit-run <local-executable-path> [args...]" >&2
+    echo "Usage: devkit-run <local-executable-path|shell> [args...]" >&2
     return 2
   fi
 
   local local_path="$1"
   shift
+
+  if [[ "${local_path}" == "shell" ]]; then
+    local -a ssh_args=(
+      ssh
+      -p "${DEVKIT_SYNC_DEVKIT_PORT}"
+      -o BatchMode=yes -o ConnectTimeout=8 \
+    )
+    if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
+      ssh_args+=(-t)
+    fi
+    ssh_args+=("${DEVKIT_SYNC_DEVKIT_USER:-sima}@${DEVKIT_SYNC_DEVKIT_IP}")
+    ssh_args+=("$@")
+    "${ssh_args[@]}"
+    return $?
+  fi
 
   if [[ "${local_path}" != /* ]]; then
     local_path="$(pwd)/${local_path}"
@@ -597,7 +612,7 @@ EOS
 unalias dk >/dev/null 2>&1 || true
 dk() {
   if [[ $# -lt 1 ]]; then
-    echo "Usage: dk <local-executable-path> [args...]" >&2
+    echo "Usage: dk <local-executable-path|shell> [args...]" >&2
     return 0
   fi
   devkit-run "$@"

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -285,7 +285,7 @@ export DEVKIT_SYNC_MOUNT_POINT="${_MOUNT_POINT}"
 export DEVKIT_SYNC_DEVKIT_USER="${_DEVKIT_USER}"
 export DEVKIT_SYNC_DEVKIT_PORT="${_DEVKIT_PORT}"
 export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-version}"
-export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-elxr-${SDK_IMAGE_TAG}}"
+export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-${SDK_IMAGE_TAG}}"
 
 __devkit_rewrite_prompt_hostname() {
   local prompt="${1-}"
@@ -594,7 +594,14 @@ EOS
 }
 
 # Short-hand for remote execution: dk <path> [args...]
-alias dk='devkit-run'
+unalias dk >/dev/null 2>&1 || true
+dk() {
+  if [[ $# -lt 1 ]]; then
+    echo "Usage: dk <local-executable-path> [args...]" >&2
+    return 0
+  fi
+  devkit-run "$@"
+}
 
 # Persist session helpers for future container shells.
 _persist_file="${HOME}/.devkit-sync.rc"
@@ -634,7 +641,8 @@ _persist_file="${HOME}/.devkit-sync.rc"
   echo '}'
   echo '__devkit_apply_prompt'
   declare -f devkit-run
-  echo "alias dk='devkit-run'"
+  echo 'unalias dk >/dev/null 2>&1 || true'
+  declare -f dk
 } > "${_persist_file}"
 
 if ! grep -qF 'source ~/.devkit-sync.rc' "${HOME}/.bashrc"; then
@@ -664,6 +672,50 @@ if [ -f ~/.bashrc ]; then
 fi
 # <<< devkit-sync profile <<<
 EOF
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  while IFS=: read -r _user _passwd _uid _gid _gecos _home _shell; do
+    [[ "${_uid}" != "0" ]] || continue
+    [[ "${_home}" == /home/* && -d "${_home}" ]] || continue
+    [[ "${_shell}" == */bash || "${_shell}" == */sh ]] || continue
+
+    install -o "${_uid}" -g "${_gid}" -m 0644 "${_persist_file}" "${_home}/.devkit-sync.rc"
+    install -o "${_uid}" -g "${_gid}" -m 0700 -d "${_home}/.ssh"
+    if [[ -f "${HOME}/.ssh/id_ed25519" ]]; then
+      install -o "${_uid}" -g "${_gid}" -m 0600 "${HOME}/.ssh/id_ed25519" "${_home}/.ssh/id_ed25519"
+    fi
+    if [[ -f "${HOME}/.ssh/id_ed25519.pub" ]]; then
+      install -o "${_uid}" -g "${_gid}" -m 0644 "${HOME}/.ssh/id_ed25519.pub" "${_home}/.ssh/id_ed25519.pub"
+    fi
+    if [[ -f "${HOME}/.ssh/known_hosts" ]]; then
+      install -o "${_uid}" -g "${_gid}" -m 0600 "${HOME}/.ssh/known_hosts" "${_home}/.ssh/known_hosts"
+    fi
+
+    touch "${_home}/.bashrc"
+    chown "${_uid}:${_gid}" "${_home}/.bashrc"
+    if ! grep -qF 'source ~/.devkit-sync.rc' "${_home}/.bashrc"; then
+      cat >> "${_home}/.bashrc" <<'EOF'
+if [ -f ~/.devkit-sync.rc ]; then
+  source ~/.devkit-sync.rc
+fi
+EOF
+      chown "${_uid}:${_gid}" "${_home}/.bashrc"
+    fi
+
+    touch "${_home}/.bash_profile"
+    chown "${_uid}:${_gid}" "${_home}/.bash_profile"
+    if ! grep -qF '# >>> devkit-sync profile >>>' "${_home}/.bash_profile"; then
+      cat >> "${_home}/.bash_profile" <<'EOF'
+# >>> devkit-sync profile >>>
+if [ -f ~/.bashrc ]; then
+  source ~/.bashrc
+fi
+# <<< devkit-sync profile <<<
+EOF
+      chown "${_uid}:${_gid}" "${_home}/.bash_profile"
+    fi
+  done < /etc/passwd
 fi
 
 echo "Persisted DevKit shell helpers to ${_persist_file} (auto-loaded by ~/.bashrc and ~/.bash_profile)."

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -24,6 +24,7 @@ check_devkit_sdk_version_compatibility() {
   local port="$3"
   local sdk_release="/etc/sdk-release"
   local devkit_distro_version=""
+  local sdk_expected_version=""
   local c_warn="" c_reset=""
 
   if [[ -t 2 ]]; then
@@ -65,11 +66,29 @@ EOS
     return 0
   fi
 
-  printf "%bWARNING: DevKit/SDK version mismatch.%b\n" "${c_warn}" "${c_reset}" >&2
-  printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}" >&2
-  printf "  SDK release file     : %s\n" "${sdk_release}" >&2
-  sed 's/^/    /' "${sdk_release}" >&2
-  printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.\n" "${sdk_release}" >&2
+  sdk_expected_version="$(
+    grep -E '^[[:space:]]*eLXr Version[[:space:]]*=' "${sdk_release}" \
+      | grep -Eo '[0-9]+([.][0-9]+){2}' \
+      | head -n1 || true
+  )"
+  if [[ -z "${sdk_expected_version}" ]]; then
+    sdk_expected_version="$(
+      grep -Eo '[0-9]+([.][0-9]+){2}' "${sdk_release}" \
+        | head -n1 || true
+    )"
+  fi
+
+  {
+    printf "%bWARNING: DevKit/SDK version mismatch.\n" "${c_warn}"
+    printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}"
+    printf "  SDK release file     : %s\n" "${sdk_release}"
+    sed 's/^/    /' "${sdk_release}"
+    if [[ -n "${sdk_expected_version}" ]]; then
+      printf "\nPlease update your DevKit to %s, then reconnect.%b\n" "${sdk_expected_version}" "${c_reset}"
+    else
+      printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.%b\n" "${sdk_release}" "${c_reset}"
+    fi
+  } >&2
   return 0
 }
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -20,4 +20,11 @@ export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:-$SYSROOT/usr/lib/aarch64-linux-gn
 unset PKG_CONFIG_PATH || true
 export LDFLAGS="--sysroot=$SYSROOT -L$SYSROOT/usr/lib/aarch64-linux-gnu -L$SYSROOT/lib/aarch64-linux-gnu ${LDFLAGS:-}"
 
+if [[ "${NEAT_INSIGHT_SUPERVISED:-1}" != "0" ]] && command -v supervisord >/dev/null 2>&1; then
+  mkdir -p /var/log/supervisor
+  if ! supervisorctl status >/dev/null 2>&1; then
+    supervisord -c /etc/supervisor/supervisord.conf
+  fi
+fi
+
 exec "$@"

--- a/scripts/insight-admin.sh
+++ b/scripts/insight-admin.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+program_name="$(basename "$0")"
+command="${1:-}"
+
+usage() {
+  cat <<EOF
+Usage:
+  ${program_name} update [branch] [version]
+  ${program_name} status
+  ${program_name} stop
+  ${program_name} restart
+  ${program_name} logs [lines]
+
+Defaults:
+  branch  = \${NEAT_INSIGHT_BRANCH:-main}
+  version = \${NEAT_INSIGHT_VERSION:-latest}
+EOF
+}
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+    return
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+    return
+  fi
+  echo "This command requires root privileges and sudo is not available." >&2
+  return 1
+}
+
+supervisorctl_if_available() {
+  if ! command -v supervisorctl >/dev/null 2>&1 && ! run_as_root command -v supervisorctl >/dev/null 2>&1; then
+    echo "supervisorctl is not available." >&2
+    return 127
+  fi
+  run_as_root supervisorctl "$@"
+}
+
+show_logs() {
+  local lines="${1:-120}"
+  if [[ ! "${lines}" =~ ^[0-9]+$ ]] || (( lines < 1 )); then
+    echo "Invalid line count: ${lines}" >&2
+    return 2
+  fi
+
+  echo "== neat-insight stdout =="
+  run_as_root tail -n "${lines}" /var/log/supervisor/neat-insight.log 2>/dev/null || true
+  echo "== neat-insight stderr =="
+  run_as_root tail -n "${lines}" /var/log/supervisor/neat-insight.err.log 2>/dev/null || true
+}
+
+is_supervisor_running() {
+  supervisorctl_if_available status >/dev/null 2>&1
+}
+
+update_insight() {
+  local branch="${1:-${NEAT_INSIGHT_BRANCH:-main}}"
+  local version="${2:-${NEAT_INSIGHT_VERSION:-latest}}"
+  local venv_dir="${NEAT_INSIGHT_VENV_DIR:-/opt/neat-insight/venv}"
+  local tmp_script
+
+  tmp_script="$(mktemp /tmp/install-neat-insight.XXXXXX.py)"
+  trap 'rm -f "${tmp_script}"' EXIT
+
+  curl -fsSL https://apps.sima-neat.com/tools/install-neat-insight.py -o "${tmp_script}"
+  run_as_root env NEAT_INSIGHT_VENV_DIR="${venv_dir}" python3 "${tmp_script}" "${branch}" "${version}"
+  run_as_root ln -sf "${venv_dir}/bin/neat-insight" /usr/local/bin/neat-insight
+  rm -f "${tmp_script}"
+  trap - EXIT
+
+  if is_supervisor_running; then
+    echo "Restarting neat-insight..."
+    supervisorctl_if_available restart neat-insight
+  else
+    echo "neat-insight will start under supervisord when the container starts."
+  fi
+}
+
+case "${command}" in
+  update)
+    shift
+    update_insight "$@"
+    ;;
+  status)
+    supervisorctl_if_available status neat-insight
+    ;;
+  stop)
+    supervisorctl_if_available stop neat-insight
+    ;;
+  restart)
+    supervisorctl_if_available restart neat-insight
+    ;;
+  logs)
+    shift
+    show_logs "$@"
+    ;;
+  ""|-h|--help|help)
+    usage
+    ;;
+  *)
+    echo "Unknown command: ${command}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SYSROOT="${1:-/opt/toolchain/aarch64/modalix}"
 LIBDIR="${SYSROOT}/usr/lib/aarch64-linux-gnu"
+LINUX_LIBC_DEV_VERSION="${SDK_SYSROOT_LINUX_LIBC_DEV_VERSION:-6.1.22-modalix-827}"
 
 if [[ $# -lt 2 ]]; then
   echo "Usage: $(basename "$0") SYSROOT package[:arch] [package[:arch] ...]" >&2
@@ -12,6 +13,21 @@ fi
 
 shift
 PACKAGES=("$@")
+TARGET_ARCHES=()
+
+for pkg in "${PACKAGES[@]}"; do
+  if [[ "${pkg}" == *:* ]]; then
+    arch="${pkg##*:}"
+    arch="${arch%%=*}"
+    if [[ " ${TARGET_ARCHES[*]} " != *" ${arch} "* ]]; then
+      TARGET_ARCHES+=("${arch}")
+    fi
+  fi
+done
+
+if [[ ${#TARGET_ARCHES[@]} -eq 0 ]]; then
+  TARGET_ARCHES=("$(dpkg --print-architecture)")
+fi
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -21,10 +37,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives"
+mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives" "${workdir}/linux-libc-dev"
 
 echo "Downloading sysroot overlay packages into ${SYSROOT}"
 printf '  %s\n' "${PACKAGES[@]}"
+
+native_arch="$(dpkg --print-architecture)"
+if [[ " ${TARGET_ARCHES[*]} " != *" ${native_arch} "* ]] &&
+   dpkg-query -W -f='${Status}' linux-libc-dev 2>/dev/null | grep -q "install ok installed"; then
+  native_linux_libc_version="$(dpkg-query -W -f='${Version}' linux-libc-dev)"
+  for arch in "${TARGET_ARCHES[@]}"; do
+    PACKAGES+=("linux-libc-dev:${arch}=${native_linux_libc_version}")
+  done
+fi
 
 apt-get update --allow-releaseinfo-change
 apt-get install -y --download-only --no-install-recommends \
@@ -33,7 +58,30 @@ apt-get install -y --download-only --no-install-recommends \
 
 find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
   | while IFS= read -r -d '' deb; do
+      deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
+      if [[ "${deb_arch}" != "all" && " ${TARGET_ARCHES[*]} " != *" ${deb_arch} "* ]]; then
+        echo "Skipping $(basename "${deb}") for architecture ${deb_arch}"
+        continue
+      fi
       echo "Extracting $(basename "${deb}")"
+      dpkg-deb -x "${deb}" "${SYSROOT}"
+    done
+
+for arch in "${TARGET_ARCHES[@]}"; do
+  if [[ "${arch}" != "arm64" ]]; then
+    continue
+  fi
+
+  echo "Downloading linux-libc-dev:${arch}=${LINUX_LIBC_DEV_VERSION} for final sysroot headers"
+  (
+    cd "${workdir}/linux-libc-dev"
+    apt-get download "linux-libc-dev:${arch}=${LINUX_LIBC_DEV_VERSION}"
+  )
+done
+
+find "${workdir}/linux-libc-dev" -maxdepth 1 -type f -name '*.deb' -print0 \
+  | while IFS= read -r -d '' deb; do
+      echo "Extracting final sysroot headers from $(basename "${deb}")"
       dpkg-deb -x "${deb}" "${SYSROOT}"
     done
 

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -2,9 +2,42 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYSROOT="${1:-/opt/toolchain/aarch64/modalix}"
 LIBDIR="${SYSROOT}/usr/lib/aarch64-linux-gnu"
-LINUX_LIBC_DEV_VERSION="${SDK_SYSROOT_LINUX_LIBC_DEV_VERSION:-6.1.22-modalix-827}"
+LINUX_LIBC_DEV_ARM64_VERSION="${SDK_SYSROOT_LINUX_LIBC_DEV_ARM64_VERSION:-${SDK_SYSROOT_LINUX_LIBC_DEV_VERSION:-}}"
+
+CONFIG_CANDIDATES=()
+if [[ -n "${SDK_SYSROOT_OVERLAY_CONFIG:-}" ]]; then
+  CONFIG_CANDIDATES+=("${SDK_SYSROOT_OVERLAY_CONFIG}")
+fi
+CONFIG_CANDIDATES+=(
+  "/usr/local/share/sima-sdk/sysroot-overlay.conf"
+  "${SCRIPT_DIR}/../config/sysroot-overlay.conf"
+)
+
+for config in "${CONFIG_CANDIDATES[@]}"; do
+  if [[ ! -f "${config}" ]]; then
+    continue
+  fi
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%%#*}"
+    if [[ "${line}" != *=* ]]; then
+      continue
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "${key}" in
+      linux_libc_dev_arm64_version)
+        if [[ -z "${LINUX_LIBC_DEV_ARM64_VERSION}" ]]; then
+          LINUX_LIBC_DEV_ARM64_VERSION="${value}"
+        fi
+        ;;
+    esac
+  done < "${config}"
+  break
+done
 
 if [[ $# -lt 2 ]]; then
   echo "Usage: $(basename "$0") SYSROOT package[:arch] [package[:arch] ...]" >&2
@@ -29,6 +62,12 @@ if [[ ${#TARGET_ARCHES[@]} -eq 0 ]]; then
   TARGET_ARCHES=("$(dpkg --print-architecture)")
 fi
 
+if [[ " ${TARGET_ARCHES[*]} " == *" arm64 "* && -z "${LINUX_LIBC_DEV_ARM64_VERSION}" ]]; then
+  echo "Missing linux_libc_dev_arm64_version in sysroot overlay config" >&2
+  echo "Set SDK_SYSROOT_OVERLAY_CONFIG or SDK_SYSROOT_LINUX_LIBC_DEV_ARM64_VERSION." >&2
+  exit 1
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 
 workdir="$(mktemp -d)"
@@ -42,6 +81,10 @@ mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives" "${workdir}/linux-libc-d
 echo "Downloading sysroot overlay packages into ${SYSROOT}"
 printf '  %s\n' "${PACKAGES[@]}"
 
+# In cross builds, apt treats some packages as Multi-Arch: same and requires
+# the host and target architecture versions to match. Download the target
+# linux-libc-dev version that matches the installed host package here, then
+# replace the sysroot headers with the SDK-pinned version below.
 native_arch="$(dpkg --print-architecture)"
 if [[ " ${TARGET_ARCHES[*]} " != *" ${native_arch} "* ]] &&
    dpkg-query -W -f='${Status}' linux-libc-dev 2>/dev/null | grep -q "install ok installed"; then
@@ -59,6 +102,8 @@ apt-get install -y --download-only --no-install-recommends \
 find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
   | while IFS= read -r -d '' deb; do
       deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
+      # Apt may download host-arch helper packages while solving target deps.
+      # Only target-arch and arch-independent payloads belong in this sysroot.
       if [[ "${deb_arch}" != "all" && " ${TARGET_ARCHES[*]} " != *" ${deb_arch} "* ]]; then
         echo "Skipping $(basename "${deb}") for architecture ${deb_arch}"
         continue
@@ -67,15 +112,18 @@ find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
       dpkg-deb -x "${deb}" "${SYSROOT}"
     done
 
+# The official Modalix 2.0 SDK sysroot uses SiMa's 6.1.22 arm64 UAPI headers.
+# Download this .deb directly so apt's multiarch resolver cannot reject it for
+# differing from the native amd64 linux-libc-dev package installed in the image.
 for arch in "${TARGET_ARCHES[@]}"; do
   if [[ "${arch}" != "arm64" ]]; then
     continue
   fi
 
-  echo "Downloading linux-libc-dev:${arch}=${LINUX_LIBC_DEV_VERSION} for final sysroot headers"
+  echo "Downloading linux-libc-dev:${arch}=${LINUX_LIBC_DEV_ARM64_VERSION} for final sysroot headers"
   (
     cd "${workdir}/linux-libc-dev"
-    apt-get download "linux-libc-dev:${arch}=${LINUX_LIBC_DEV_VERSION}"
+    apt-get download "linux-libc-dev:${arch}=${LINUX_LIBC_DEV_ARM64_VERSION}"
   )
 done
 

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -76,7 +76,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives" "${workdir}/linux-libc-dev"
+mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
+
+# apt downloads as the sandbox user _apt. mktemp creates a 0700 root-owned
+# directory, so make only the download staging paths accessible to avoid
+# "Download is performed unsandboxed as root" warnings during Docker builds.
+chmod 755 "${workdir}" "${workdir}/archives" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
+if id _apt >/dev/null 2>&1; then
+  chown _apt "${workdir}/archives" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
+fi
 
 echo "Downloading sysroot overlay packages into ${SYSROOT}"
 printf '  %s\n' "${PACKAGES[@]}"

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -159,4 +159,8 @@ if [[ -e "${LIBDIR}/libopenblas.so.0" && ! -e "${LIBDIR}/libopenblas.so" ]]; the
   ln -sfn libopenblas.so.0 "${LIBDIR}/libopenblas.so"
 fi
 
+if [[ -d "${SYSROOT}/usr/include" ]]; then
+  chmod -R a+rX "${SYSROOT}/usr/include"
+fi
+
 echo "Sysroot overlay complete"


### PR DESCRIPTION
This PR turns the SDK image into a much more complete Neat development environment: it standardizes the released image around the `sdk` name, bakes in supervised NEAT Insight, hardens the sysroot overlay for reliable cross-builds, and makes DevKit pairing much smoother with smarter host networking, framework sync, and Insight port-map handoff.

## What Changed

### SDK image, build, and publishing
- Renames the default local image/container identity from `elxr` to `sdk` across `build.sh`, `run.py`, and the Docker build workflow.
- Publishes CI images under `ghcr.io/sima-neat/sdk` for `main` and tags, and under branch-specific `sdk-<branch>` repositories for branch builds.
- Adds workflow concurrency so newer pushes cancel stale runs for the same workflow/ref.
- Keeps multi-arch Docker coverage for both `x86_64` and `aarch64`, including branch image publishing and multi-arch manifest creation.
- Updates README examples, badge links, pull/run commands, and build examples to match the `sdk` image name.

### NEAT Insight in the SDK container
- Installs `neat-insight` into `/opt/neat-insight/venv` during image build using configurable `NEAT_INSIGHT_BRANCH` and `NEAT_INSIGHT_VERSION` build arguments.
- Adds supervised startup through `supervisord`, with `neat-insight` listening on `NEAT_INSIGHT_PORT` defaulting to `9900`.
- Adds the `insight-admin` helper for status, logs, restart, stop, and temporary in-container updates.
- Installs runtime support packages including `python3-venv`, `ffmpeg`, `libmediainfo0v5`, `supervisor`, and `mkcert`.
- Exposes Insight, vf viewer, RTSP, video RTP, and metadata UDP ports from the Dockerfile and maps them automatically on non-Linux hosts in `run.py`.

### DevKit setup and workflow
- Improves host IP selection for DevKit NFS by considering the DevKit subnet and route interface before falling back to the first physical interface.
- Adds `--hostip` documentation for cases where automatic host IP selection is not reachable from the DevKit.
- Adds DevKit/SDK version compatibility checks against `/etc/sdk-release` and the DevKit `/etc/buildinfo` `DISTRO_VERSION`.
- Adds automatic NEAT framework version comparison and optional sync from the SDK cache to the DevKit, controlled by `DEVKIT_NEAT_SYNC`, `DEVKIT_NEAT_SYNC_REQUIRED`, and `DEVKIT_NEAT_SYNC_CACHE_DIR`.
- Adds `dk shell` for opening a direct SSH shell to the paired DevKit.
- Persists DevKit shell helpers and SSH material into non-root container users when setup runs as root.
- Copies `${HOME}/.insight-config/neat-port-map.json` to the DevKit user's `~/.insight-config/neat-port-map.json` when present, so Insight host port mappings follow the DevKit session.

### Sysroot overlay robustness
- Moves the pinned Modalix arm64 `linux-libc-dev` version into `config/sysroot-overlay.conf`.
- Makes apt download staging compatible with the `_apt` sandbox user to avoid unsandboxed root download warnings.
- Works around cross-architecture `linux-libc-dev` resolver constraints by downloading the host-matching target package for dependency resolution, then replacing final sysroot headers with the SDK-pinned Modalix arm64 headers.
- Filters extracted `.deb` payloads to target architectures or architecture-independent packages only.
- Ensures sysroot headers are readable after extraction.

## Release Notes

- The default image name is now `sdk`; use `./build.sh` for `sdk:latest` or `./run.sh` for `ghcr.io/sima-neat/sdk:<tag>` with local fallback.
- Existing workflows that explicitly pass a custom image name still work, but published CI images now use the `sdk` naming convention.
- NEAT Insight starts automatically in normal containers unless `NEAT_INSIGHT_SUPERVISED=0` is set.
- DevKit setup remains source-based through `source devkit.sh`; it now performs additional compatibility and framework-sync checks before configuring the NFS mount.

## Validation

- `python3 -m py_compile run.py`
- `bash -n build.sh run.sh scripts/devkit.sh scripts/docker-entrypoint.sh scripts/insight-admin.sh scripts/install-sysroot-overlay.sh`
- `git diff --check`
- GitHub Actions on latest commit `8529a79`:
  - CodeQL `Analyze (python)`: passed
  - Docker `Build on x86_64`: passed for pull request and push workflows
  - Docker `Build on aarch64`: passed for pull request and push workflows
  - `Publish multi-arch manifest`: passed for push workflow; skipped as expected for pull request workflow
