### PR TITLE
Gate SDK image promotion on smoke tests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -105,13 +105,6 @@ jobs:
           fi
           echo "name=ghcr.io/${owner}/${repo}" >> "${GITHUB_OUTPUT}"
 
-      - name: Compute release tag
-        id: release_tag
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "value=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -123,22 +116,40 @@ jobs:
         run: |
           docker buildx imagetools create \
             --tag "${IMAGE_NAME}:${GITHUB_SHA}" \
+            --tag "${IMAGE_NAME}:staged-${GITHUB_SHA}" \
             "${IMAGE_NAME}:${GITHUB_SHA}-x86_64" \
             "${IMAGE_NAME}:${GITHUB_SHA}-aarch64"
-
-          if [[ -n "${RELEASE_TAG}" ]]; then
-            docker buildx imagetools create \
-              --tag "${IMAGE_NAME}:${RELEASE_TAG}" \
-              "${IMAGE_NAME}:${GITHUB_SHA}-x86_64" \
-              "${IMAGE_NAME}:${GITHUB_SHA}-aarch64"
-          fi
-
-          if [[ "${GITHUB_REF}" == refs/heads/* ]]; then
-            docker buildx imagetools create \
-              --tag "${IMAGE_NAME}:latest" \
-              "${IMAGE_NAME}:${GITHUB_SHA}-x86_64" \
-              "${IMAGE_NAME}:${GITHUB_SHA}-aarch64"
-          fi
         env:
           IMAGE_NAME: ${{ steps.image.outputs.name }}
-          RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
+
+      - name: Write image promotion metadata
+        run: |
+          set -euo pipefail
+
+          mkdir -p image-metadata
+
+          release_tag=""
+          promote_latest=false
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            release_tag="${GITHUB_REF_NAME#v}"
+          elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
+            promote_latest=true
+          fi
+
+          {
+            echo "repository=${IMAGE_NAME}"
+            echo "source_ref=${IMAGE_NAME}:staged-${GITHUB_SHA}"
+            echo "staged_tag=staged-${GITHUB_SHA}"
+            echo "commit_sha=${GITHUB_SHA}"
+            echo "release_tag=${release_tag}"
+            echo "promote_latest=${promote_latest}"
+          } > image-metadata/image.env
+        env:
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+
+      - name: Upload image promotion metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: image-metadata/image.env
+          if-no-files-found: error

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -74,7 +74,7 @@ jobs:
       - name: Publish architecture image
         if: github.event_name != 'pull_request'
         run: |
-          docker tag sdk:ci-${IMAGE_SUFFIX} "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
+          docker tag "sdk:ci-${IMAGE_SUFFIX}" "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
           docker push "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
         env:
           IMAGE_NAME: ${{ steps.image.outputs.name }}
@@ -113,7 +113,7 @@ jobs:
           fi
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -55,6 +55,11 @@ jobs:
             docker_arch: arm64
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
       - name: Set up Docker Buildx
         if: runner.os == 'Linux'
         uses: docker/setup-buildx-action@v4
@@ -201,76 +206,13 @@ jobs:
           source .venv/bin/activate
           sima-cli sdk setup -y -n
 
-      - name: Run neat status check
+      - name: Run SDK smoke test suite
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
         run: |
           set -euo pipefail
 
-          source .venv/bin/activate
-          python - <<'PY'
-          import os
-          import pty
-          import subprocess
-          import sys
-
-          command = ["sima-cli", "sdk", "neat", "neat --json"]
-          master_fd, slave_fd = pty.openpty()
-          proc = subprocess.Popen(
-              command,
-              stdin=slave_fd,
-              stdout=slave_fd,
-              stderr=slave_fd,
-              close_fds=True,
-          )
-          os.close(slave_fd)
-
-          with open("neat-status.typescript", "wb") as capture:
-              while True:
-                  try:
-                      data = os.read(master_fd, 4096)
-                  except OSError:
-                      break
-                  if not data:
-                      break
-                  capture.write(data)
-                  sys.stdout.buffer.write(data)
-                  sys.stdout.buffer.flush()
-
-          os.close(master_fd)
-          raise SystemExit(proc.wait())
-          PY
-
-          python - <<'PY'
-          import json
-          import pathlib
-          import re
-          import sys
-
-          text = pathlib.Path("neat-status.typescript").read_text(errors="ignore")
-          text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
-          start = text.find("{")
-          end = text.rfind("}")
-          if start < 0 or end < start:
-              print("No JSON object found in neat status output", file=sys.stderr)
-              print(text, file=sys.stderr)
-              sys.exit(1)
-
-          data = json.loads(text[start : end + 1])
-          required_components = {"core", "insight", "pyneat", "runtime"}
-          missing = required_components - set(data.get("components", {}))
-          if missing:
-              raise SystemExit(f"Missing required components: {sorted(missing)}")
-          if data.get("schema") != "sima.neat.status.v1":
-              raise SystemExit(f"Unexpected schema: {data.get('schema')}")
-          if data.get("environment", {}).get("mode") != "elxr-sdk":
-              raise SystemExit(f"Unexpected environment mode: {data.get('environment', {}).get('mode')}")
-
-          print(json.dumps({
-              "schema": data.get("schema"),
-              "mode": data.get("environment", {}).get("mode"),
-              "sdkVersion": data.get("environment", {}).get("sdkVersion"),
-              "components": sorted(required_components),
-          }, indent=2))
-          PY
+          tests/sdk/run-smoke-tests.sh
 
       - name: Clean up SDK containers
         if: always()

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -162,7 +162,9 @@ jobs:
           echo "::add-mask::${SIMA_CLI_ACCESS_TOKEN_FILE}"
           install -m 700 -d "${HOME}/.sima-cli"
           umask 077
-          printf '%s' "${SIMA_CLI_ACCESS_TOKEN_FILE}" > "${HOME}/.sima-cli/.token.json"
+          printf '%s' "${SIMA_CLI_ACCESS_TOKEN_FILE}" > "${HOME}/.sima-cli/.tokens.json"
+          cp "${HOME}/.sima-cli/.tokens.json" "${HOME}/.sima-cli/.token.json"
+          test -s "${HOME}/.sima-cli/.tokens.json"
           test -s "${HOME}/.sima-cli/.token.json"
 
       - name: Verify Docker is available

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,6 +1,9 @@
 name: Smoke Test
 
 on:
+  push:
+    branches:
+      - feature/devkit-sync
   workflow_run:
     workflows:
       - Build Docker Image
@@ -30,6 +33,7 @@ jobs:
     name: Smoke on ${{ matrix.arch }}
     if: >-
       ${{
+        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -147,6 +147,24 @@ jobs:
           python -m pip install ./sima_cli-2.1.5-py3-none-any.whl
           sima-cli version
 
+      - name: Configure sima-cli access token
+        env:
+          SIMA_CLI_ACCESS_TOKEN_FILE: ${{ secrets.SIMA_CLI_ACCESS_TOKEN_FILE }}
+        run: |
+          set -euo pipefail
+          set +x
+
+          if [[ -z "${SIMA_CLI_ACCESS_TOKEN_FILE}" ]]; then
+            echo "SIMA_CLI_ACCESS_TOKEN_FILE secret is not configured." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::${SIMA_CLI_ACCESS_TOKEN_FILE}"
+          install -m 700 -d "${HOME}/.sima-cli"
+          umask 077
+          printf '%s' "${SIMA_CLI_ACCESS_TOKEN_FILE}" > "${HOME}/.sima-cli/.token.json"
+          test -s "${HOME}/.sima-cli/.token.json"
+
       - name: Verify Docker is available
         run: |
           set -euo pipefail

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,9 +1,6 @@
 name: Smoke Test
 
 on:
-  push:
-    branches:
-      - feature/devkit-sync
   workflow_run:
     workflows:
       - Build Docker Image
@@ -16,13 +13,14 @@ on:
         required: false
         type: string
       image_tag:
-        description: "Image tag to test. Defaults to the current commit SHA."
+        description: "Image tag to test. Defaults to staged-<commit SHA>."
         required: false
         type: string
 
 permissions:
+  actions: read
   contents: read
-  packages: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha }}
@@ -33,7 +31,6 @@ jobs:
     name: Smoke on ${{ matrix.arch }}
     if: >-
       ${{
-        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event.workflow_run.conclusion == 'success' &&
@@ -64,6 +61,15 @@ jobs:
         if: runner.os == 'Linux'
         uses: docker/setup-buildx-action@v4
 
+      - name: Download image metadata
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
       - name: Compute image under test
         id: image
         env:
@@ -75,13 +81,22 @@ jobs:
           set -euo pipefail
 
           owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          tag="${MANUAL_IMAGE_TAG:-${WORKFLOW_RUN_HEAD_SHA:-${GITHUB_SHA}}}"
 
-          if [[ -n "${MANUAL_IMAGE_NAME}" ]]; then
+          metadata_file="$(find .smoke -type f -name image.env -print -quit 2>/dev/null || true)"
+
+          if [[ -n "${metadata_file}" && -z "${MANUAL_IMAGE_NAME}" && -z "${MANUAL_IMAGE_TAG}" ]]; then
+            # shellcheck disable=SC1090
+            source "${metadata_file}"
+            repository="${repository:?}"
+            tag="${staged_tag:?}"
+          elif [[ -n "${MANUAL_IMAGE_NAME}" ]]; then
+            tag="${MANUAL_IMAGE_TAG:-staged-${WORKFLOW_RUN_HEAD_SHA:-${GITHUB_SHA}}}"
             repo="${MANUAL_IMAGE_NAME}"
             repo="${repo#ghcr.io/}"
             repo="${repo#*/}"
+            repository="ghcr.io/${owner}/${repo}"
           else
+            tag="${MANUAL_IMAGE_TAG:-staged-${WORKFLOW_RUN_HEAD_SHA:-${GITHUB_SHA}}}"
             ref_name="${WORKFLOW_RUN_HEAD_BRANCH:-${GITHUB_REF_NAME}}"
             if [[ "${ref_name}" == "main" ]]; then
               repo="sdk"
@@ -93,11 +108,11 @@ jobs:
               fi
               repo="sdk-${branch}"
             fi
+            repository="ghcr.io/${owner}/${repo}"
           fi
 
-          repository="ghcr.io/${owner}/${repo}"
           image_ref="${repository}:${tag}"
-          install_spec="ghcr:${owner}/${repo}:${tag}"
+          install_spec="ghcr:${repository#ghcr.io/}:${tag}"
 
           {
             echo "repository=${repository}"
@@ -230,3 +245,59 @@ jobs:
               docker rm -f "${container_id}"
             fi
           done
+
+  promote:
+    name: Promote staged image
+    needs: smoke
+    if: >-
+      ${{
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request'
+      }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote image
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          promote_args=()
+          if [[ "${promote_latest}" == "true" ]]; then
+            promote_args+=(--tag "${repository}:latest")
+          fi
+          if [[ -n "${release_tag}" ]]; then
+            promote_args+=(--tag "${repository}:${release_tag}")
+          fi
+
+          if [[ "${#promote_args[@]}" -eq 0 ]]; then
+            echo "No promotion tags requested for ${source_ref}."
+            exit 0
+          fi
+
+          docker buildx imagetools inspect "${source_ref}"
+          docker buildx imagetools create \
+            "${promote_args[@]}" \
+            "${source_ref}"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,264 @@
+name: Smoke Test
+
+on:
+  workflow_run:
+    workflows:
+      - Build Docker Image
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_name:
+        description: "GHCR image name without owner, for example sdk-feature-devkit-sync. Defaults to the current ref."
+        required: false
+        type: string
+      image_tag:
+        description: "Image tag to test. Defaults to the current commit SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Smoke on ${{ matrix.arch }}
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event != 'pull_request'
+        )
+      }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-amd64
+            runs_on: ubuntu-24.04
+            docker_arch: amd64
+          - arch: linux-arm64
+            runs_on: ubuntu-24.04-arm
+            docker_arch: arm64
+
+    steps:
+      - name: Set up Docker Buildx
+        if: runner.os == 'Linux'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Compute image under test
+        id: image
+        env:
+          MANUAL_IMAGE_NAME: ${{ github.event.inputs.image_name }}
+          MANUAL_IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          tag="${MANUAL_IMAGE_TAG:-${WORKFLOW_RUN_HEAD_SHA:-${GITHUB_SHA}}}"
+
+          if [[ -n "${MANUAL_IMAGE_NAME}" ]]; then
+            repo="${MANUAL_IMAGE_NAME}"
+            repo="${repo#ghcr.io/}"
+            repo="${repo#*/}"
+          else
+            ref_name="${WORKFLOW_RUN_HEAD_BRANCH:-${GITHUB_REF_NAME}}"
+            if [[ "${ref_name}" == "main" ]]; then
+              repo="sdk"
+            else
+              branch="$(echo "${ref_name}" | tr '[:upper:]' '[:lower:]')"
+              branch="$(echo "${branch}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+              if [[ -z "${branch}" ]]; then
+                branch="branch"
+              fi
+              repo="sdk-${branch}"
+            fi
+          fi
+
+          repository="ghcr.io/${owner}/${repo}"
+          image_ref="${repository}:${tag}"
+          install_spec="ghcr:${owner}/${repo}:${tag}"
+
+          {
+            echo "repository=${repository}"
+            echo "tag=${tag}"
+            echo "image_ref=${image_ref}"
+            echo "install_spec=${install_spec}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Testing ${image_ref}"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for published image
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..12}; do
+            if docker buildx version >/dev/null 2>&1; then
+              inspect_cmd=(docker buildx imagetools inspect "${IMAGE_REF}")
+            else
+              inspect_cmd=(docker manifest inspect "${IMAGE_REF}")
+            fi
+
+            if "${inspect_cmd[@]}" >/dev/null 2>&1; then
+              "${inspect_cmd[@]}"
+              exit 0
+            fi
+            echo "Image manifest not visible yet (${attempt}/12): ${IMAGE_REF}"
+            sleep 10
+          done
+
+          echo "Image manifest was not found: ${IMAGE_REF}" >&2
+          exit 1
+
+      - name: Install sima-cli
+        run: |
+          set -euo pipefail
+
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          curl -fsSL \
+            https://artifacts.sima-neat.com/tools/sima_cli-2.1.5-py3-none-any.whl \
+            -o sima_cli-2.1.5-py3-none-any.whl
+          python -m pip install ./sima_cli-2.1.5-py3-none-any.whl
+          sima-cli version
+
+      - name: Verify Docker is available
+        run: |
+          set -euo pipefail
+
+          docker version
+          docker info
+
+      - name: Install SDK image
+        env:
+          INSTALL_SPEC: ${{ steps.image.outputs.install_spec }}
+        run: |
+          set -euo pipefail
+
+          source .venv/bin/activate
+          sima-cli install "${INSTALL_SPEC}"
+
+      - name: Verify pulled image architecture
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+          EXPECTED_ARCH: ${{ matrix.docker_arch }}
+        run: |
+          set -euo pipefail
+
+          actual_arch="$(docker image inspect "${IMAGE_REF}" --format '{{.Architecture}}')"
+          echo "Pulled image architecture: ${actual_arch}"
+          test "${actual_arch}" = "${EXPECTED_ARCH}"
+
+      - name: Run SDK setup
+        run: |
+          set -euo pipefail
+
+          source .venv/bin/activate
+          sima-cli sdk setup -y -n
+
+      - name: Run neat status check
+        run: |
+          set -euo pipefail
+
+          source .venv/bin/activate
+          python - <<'PY'
+          import os
+          import pty
+          import subprocess
+          import sys
+
+          command = ["sima-cli", "sdk", "neat", "neat --json"]
+          master_fd, slave_fd = pty.openpty()
+          proc = subprocess.Popen(
+              command,
+              stdin=slave_fd,
+              stdout=slave_fd,
+              stderr=slave_fd,
+              close_fds=True,
+          )
+          os.close(slave_fd)
+
+          with open("neat-status.typescript", "wb") as capture:
+              while True:
+                  try:
+                      data = os.read(master_fd, 4096)
+                  except OSError:
+                      break
+                  if not data:
+                      break
+                  capture.write(data)
+                  sys.stdout.buffer.write(data)
+                  sys.stdout.buffer.flush()
+
+          os.close(master_fd)
+          raise SystemExit(proc.wait())
+          PY
+
+          python - <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          text = pathlib.Path("neat-status.typescript").read_text(errors="ignore")
+          text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+          start = text.find("{")
+          end = text.rfind("}")
+          if start < 0 or end < start:
+              print("No JSON object found in neat status output", file=sys.stderr)
+              print(text, file=sys.stderr)
+              sys.exit(1)
+
+          data = json.loads(text[start : end + 1])
+          required_components = {"core", "insight", "pyneat", "runtime"}
+          missing = required_components - set(data.get("components", {}))
+          if missing:
+              raise SystemExit(f"Missing required components: {sorted(missing)}")
+          if data.get("schema") != "sima.neat.status.v1":
+              raise SystemExit(f"Unexpected schema: {data.get('schema')}")
+          if data.get("environment", {}).get("mode") != "elxr-sdk":
+              raise SystemExit(f"Unexpected environment mode: {data.get('environment', {}).get('mode')}")
+
+          print(json.dumps({
+              "schema": data.get("schema"),
+              "mode": data.get("environment", {}).get("mode"),
+              "sdkVersion": data.get("environment", {}).get("sdkVersion"),
+              "components": sorted(required_components),
+          }, indent=2))
+          PY
+
+      - name: Clean up SDK containers
+        if: always()
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image_ref }}
+        run: |
+          set -euo pipefail
+
+          if ! docker info >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          docker ps -aq --filter "ancestor=${IMAGE_REF}" | while read -r container_id; do
+            if [[ -n "${container_id}" ]]; then
+              docker rm -f "${container_id}"
+            fi
+          done

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -41,6 +41,8 @@ jobs:
         )
       }}
     runs-on: ${{ matrix.runs_on }}
+    env:
+      SIMA_CLI_CHECK_FOR_UPDATE: "0"
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +104,7 @@ jobs:
           echo "Testing ${image_ref}"
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update --allow-releaseinfo-change && \
       libssl-dev \
       libgnutls28-dev \
       openssh-client \
+      sshpass \
       python3-dev \
       python3-venv \
       ffmpeg \

--- a/README.md
+++ b/README.md
@@ -6,8 +6,14 @@
 
 [![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
 [![Smoke Test](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml)
+![Ubuntu](https://img.shields.io/badge/Ubuntu-supported-E95420?logo=ubuntu&logoColor=white)
+![Windows 11](https://img.shields.io/badge/Windows%2011-supported-0078D4?logo=windows&logoColor=white)
+![macOS](https://img.shields.io/badge/macOS-supported-000000?logo=apple&logoColor=white)
+![eLxr Platform 2.0.0](https://img.shields.io/badge/eLxr%20Platform-2.0.0%20compatible-2E7D32)
 
 This repository packages the SiMa.ai NEAT SDK as a Docker image for `x86_64` and `arm64` Linux hosts.
+
+The current NEAT SDK image is compatible with the eLxr platform `2.0.0` release.
 
 The main user workflow is:
 
@@ -15,25 +21,6 @@ The main user workflow is:
 2. Install the SDK container image.
 3. Start the SDK workspace.
 4. Optional: pair the SDK container with a DevKit.
-
-## Prerequisites
-
-- Ubuntu Linux host with Docker Engine installed.
-- Access to GitHub Container Registry packages for this repository.
-- `sima-cli` installed in a Python virtual environment.
-- Optional: a SiMa.ai DevKit reachable over SSH when using DevKit workspace sync.
-
-Install `sima-cli`:
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip
-curl -fsSL \
-  https://artifacts.sima-neat.com/tools/sima_cli-2.1.5-py3-none-any.whl \
-  -o sima_cli-2.1.5-py3-none-any.whl
-python -m pip install ./sima_cli-2.1.5-py3-none-any.whl
-```
 
 ## Install The SDK
 
@@ -131,6 +118,7 @@ dk shell
 
 ## Advanced Topics
 
+- [Official Neat SDK installation guide](https://docs.sima-neat.com/getting-started/installation/neat-elxr-sdk)
 - [Build the SDK image locally](docs/building-sdk-image.md)
 - [Manage NEAT Insight in the SDK container](docs/neat-insight.md)
 - [Use the DevKit NFS workspace](docs/devkit-workspace.md)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The main user workflow is:
 
 1. Install `sima-cli`.
 2. Install the SDK container image.
-3. Start the SDK workspace.
-4. Optional: pair the SDK container with a DevKit.
+3. Start the SDK and optionally pair with a Modalix DevKit.
+4. On x86 platforms, during setup optionally install Model SDK extension.
+5. Use VS Code to attach to the running container for an IDE.
 
 ## Install The SDK
 
@@ -40,10 +41,10 @@ The published image contains the toolchain, sysroot, headers, libraries, NEAT ru
 
 ## Start The SDK
 
-Run the SDK setup in non-interactive mode:
+Run the SDK setup:
 
 ```bash
-sima-cli sdk setup -y -n
+sima-cli sdk setup --devkit {devkit ip address}
 ```
 
 Open the SDK shell:
@@ -55,7 +56,7 @@ sima-cli sdk neat
 Check the installed SDK status from inside the SDK shell:
 
 ```bash
-neat --json
+neat
 ```
 
 The SDK workspace is mounted at `/workspace` inside the container.
@@ -93,27 +94,19 @@ The SDK supports an NFS-based shared workspace with a DevKit. The workspace is s
 Start the SDK container with the DevKit IP:
 
 ```bash
-./run.sh --prefer-local --devkit-ip 10.0.0.244
+sima-cli sdk setup --devkit-ip 10.0.0.244
 ```
-
-If the host IP selected for NFS is not reachable from the DevKit, provide the host interface IP explicitly:
-
-```bash
-./run.sh --prefer-local --devkit-ip 10.0.0.244 --hostip 10.0.0.10
-```
-
-Inside the SDK container, source the DevKit helper:
-
-```bash
-source devkit.sh
-```
-
-This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables stale-mount recovery, and sets Git `safe.directory` for the mounted workspace path.
 
 Open a direct SSH shell to the paired DevKit:
 
 ```bash
 dk shell
+```
+
+Run an executable or Python application from the DevKit:
+
+```bash
+dk /workspace/app-binary-or-dot-py-file
 ```
 
 ## Advanced Topics

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # SiMa.ai eLxr Software Development Kit (SDK) Manual
 
 [![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
+[![Smoke Test](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml)
 
 > This is a user guide for the SiMa.ai eLxr Board Support Package (BSP).
 

--- a/README.md
+++ b/README.md
@@ -1,114 +1,89 @@
 <p align="center">
-  <img src="images/simaai_logo.png" alt="SiMa.ai Logo" width="50%">
+  <img src="images/simaai_logo.png" alt="SiMa.ai Logo" width="30%">
 </p>
 
-# SiMa.ai eLxr Software Development Kit (SDK) Manual
+# SiMa.ai NEAT SDK
 
 [![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
 [![Smoke Test](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml)
 
-> This is a user guide for the SiMa.ai eLxr Board Support Package (BSP).
+This repository packages the SiMa.ai NEAT SDK as a Docker image for `x86_64` and `arm64` Linux hosts.
 
-This repository provides a custom build of the Neat SDK for SiMa.ai platforms. It supports both `x86_64` and `arm64` host builds, prepares the sysroot with NEAT-required dependencies during Docker build, installs `sima-cli`, and remains compatible with the official eLxr SDK `2.0` release.
+The main user workflow is:
 
-## About eLxr Project
+1. Install `sima-cli`.
+2. Install the SDK container image.
+3. Start the SDK workspace.
+4. Optional: pair the SDK container with a DevKit.
 
-> The eLxr project is a community-driven effort dedicated to broadening access to cutting-edge technologies for both enthusiasts and enterprise users seeking reliable and innovative solutions that scale from edge to cloud. The project produces and maintains an open source, enterprise-grade Debian-derivative distribution called eLxr that is easy for users to adopt and that fully honors the open source philosophy.
->
-> The eLxr project's mission is centered on accessibility, innovation, and maintaining the integrity of open source software. Making these advancements in an enterprise-grade Debian-derivative ensures that users benefit from a freely available Linux distribution.
->
-> By emphasizing ease of adoption alongside open source principles, eLxr aims to attract a broad range of users and contributors who value both innovation and community-driven development, fostering collaboration and transparency and the spread of new technologies.
->
-> The eLxr project is establishing a robust strategy for building on Debian's ecosystem while also contributing back to it. Because "Debian citizens" contribute eLxr innovations and improvements upstream, they are actively participating in the community's development activities. This approach not only enhances eLxr's own distribution but also strengthens Debian by expanding its feature set and improving its overall quality.
->
-> The ability to release technologies at various stages of Debian's development lifecycle and to introduce innovative new content not yet available in Debian highlights eLxr's agility and responsiveness to emerging needs. Moreover, the commitment to sustainability ensures that contributions made by eLxr members remain accessible and beneficial to the broader Debian community over the long term.[2]
+## Prerequisites
 
-## Terminology
+- Ubuntu Linux host with Docker Engine installed.
+- Access to GitHub Container Registry packages for this repository.
+- `sima-cli` installed in a Python virtual environment.
+- Optional: a SiMa.ai DevKit reachable over SSH when using DevKit workspace sync.
 
-| Term | Meaning |
-| --- | --- |
-| **MLSoC** | Machine Learning System-on-Chip |
-| **SDK** | Software Development Kit |
-| **BSP** | Board Support Package |
-| **Docker** | A Linux container [3] |
-| **Platform** | SiMa.ai MLSoC name, for example `modalix` or `davinci` |
-
-## Assumptions
-
-This manual assumes an `Ubuntu 22.04` host build machine and that the user is familiar with basic Linux commands and environment setup.
-
-This project can run on either `aarch64` or `x86_64` host architectures. The build flow automatically adapts to the host machine type when using the provided build helper.
-
-The examples shown in this manual use the `modalix` platform; however, the instructions can be applied to `davinci` with little or no modification.
-
-At the time of artifacts installation, it is assumed that:
-
-- The user has a SiMa.ai platform booted with an eLxr image and has root access.
-- The platform board is reachable from the Docker container so artifacts can be copied over.
-- The platform is booted with eMMC, enumerated as `mmcblk0` on Linux.
-
-## SiMa.ai eLxr SDK
-
-The eLxr build system is extended to build SiMa.ai Debian packages and images for SiMa.ai MLSoCs.
-
-An SDK, also referred to as a BSP, is provided for customers to build their software and install it on a SiMa.ai MLSoC.
-
-### SDK Docker
-
-Along with this manual, SiMa.ai SDK Dockerfiles, one for each platform, are provided to create the SDK Docker container.
-
-The SDK Docker image contains all toolchains, headers, libraries, and related dependencies needed to build software for the SiMa.ai platform.
-
-CI-built `sdk` images are available for both `aarch64` and `x86_64` machine types.
-
-### Building SDK Docker
-
-#### Prerequisite
-
-- Install the Docker engine on the host build machine.[4]
-- Install `qemu-user-static` only if your workflow needs to execute non-native target binaries during cross-architecture builds. It is not required for the normal SDK image build when the container is built for the host's native architecture and only carries an `arm64` sysroot for cross-compilation.
+Install `sima-cli`:
 
 ```bash
-sudo apt install qemu-user-static
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+curl -fsSL \
+  https://artifacts.sima-neat.com/tools/sima_cli-2.1.5-py3-none-any.whl \
+  -o sima_cli-2.1.5-py3-none-any.whl
+python -m pip install ./sima_cli-2.1.5-py3-none-any.whl
 ```
 
-#### Build Docker Image
+## Install The SDK
 
-- Build the SDK Docker image with the provided `build.sh` helper:
+Install the latest published SDK image:
 
 ```bash
-./build.sh
+sima-cli install ghcr:sima-neat/sdk
 ```
 
-- By default, this builds the `sdk:latest` image.
-- The local build workflow supports both `aarch64` and `x86_64` hosts and automatically selects the matching Docker platform for the current machine.
-- A custom image name and tag can be provided:
+Install a branch-specific image:
 
 ```bash
-./build.sh sdk 2.0.0
+sima-cli install ghcr:sima-neat/sdk-feature-devkit-sync:latest
 ```
 
-> A comma-separated package list can be provided to install additional packages into the sysroot during Docker build. Example:
->
-> `SDK_PKG_LIST=libzix-dev,vxi-dev ./build.sh`
+The published image contains the toolchain, sysroot, headers, libraries, NEAT runtime components, and helper scripts needed to build software for SiMa.ai platforms.
 
-```text
-Building sdk:latest
-Host architecture: arm64
-Docker platform: linux/arm64
+## Start The SDK
+
+Run the SDK setup in non-interactive mode:
+
+```bash
+sima-cli sdk setup -y -n
 ```
 
-### Launching SDK Docker
+Open the SDK shell:
 
-Use the helper script:
+```bash
+sima-cli sdk neat
+```
+
+Check the installed SDK status from inside the SDK shell:
+
+```bash
+neat --json
+```
+
+The SDK workspace is mounted at `/workspace` inside the container.
+
+## Local Repository Helper
+
+If you are working directly from this repository, you can also start the SDK with:
 
 ```bash
 ./run.sh
 ```
 
-This will try to pull `ghcr.io/sima-neat/sdk:<tag>` from GitHub Packages first and fall back to a matching local image if present.
+`run.sh` tries to pull the configured SDK image from GitHub Container Registry first and falls back to a matching local image if present. It mounts the current directory into `/workspace`.
 
-You can also use standard Docker commands directly:
+You can also run Docker directly:
 
 ```bash
 docker pull ghcr.io/sima-neat/sdk:latest
@@ -118,44 +93,17 @@ docker run --rm -it --name sdk --privileged \
   ghcr.io/sima-neat/sdk:latest /bin/bash -l
 ```
 
-> Notes:
->
-> - The sysroot is set up under `/opt/toolchain/aarch64/<platform>`.
-> - `run.sh` mounts the current host directory into `/workspace` inside the container.
-> - Although the build environment is automatically configured when the container launches, it can also be set manually:
->   `source /opt/bin/simaai-init-build-env <platform>`
-
-### NEAT Insight
-
-The SDK image installs `neat-insight` into `/opt/neat-insight/venv` and starts it automatically under `supervisord` when the container starts. By default it listens on port `9900`.
-
-Useful commands inside the running container:
+The build environment is configured automatically when the container starts. To configure it manually:
 
 ```bash
-insight-admin status
-insight-admin logs
-insight-admin restart
-insight-admin stop
+source /opt/bin/simaai-init-build-env modalix
 ```
 
-To temporarily upgrade Insight inside an existing container:
+## Pair With A DevKit
 
-```bash
-insight-admin update main latest
-insight-admin restart
-```
+The SDK supports an NFS-based shared workspace with a DevKit. The workspace is shared bi-directionally between the host and the DevKit.
 
-That change only affects the current container. To make an Insight upgrade permanent, rebuild the SDK image with the desired channel and version:
-
-```bash
-NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh sdk 2.0.0
-```
-
-### DevKit Workspace (NFS)
-
-The workspace sharing flow is now NFS-based.
-
-1. Start SDK container and configure host-side export:
+Start the SDK container with the DevKit IP:
 
 ```bash
 ./run.sh --prefer-local --devkit-ip 10.0.0.244
@@ -167,287 +115,40 @@ If the host IP selected for NFS is not reachable from the DevKit, provide the ho
 ./run.sh --prefer-local --devkit-ip 10.0.0.244 --hostip 10.0.0.10
 ```
 
-2. Inside the container, source the setup helper:
+Inside the SDK container, source the DevKit helper:
 
 ```bash
 source devkit.sh
 ```
 
-This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables a watchdog timer for stale mount recovery, and sets Git `safe.directory` for the mounted workspace path.
+This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables stale-mount recovery, and sets Git `safe.directory` for the mounted workspace path.
 
-During setup, `devkit.sh` also compares the SDK NEAT framework package versions cached under `${SYSROOT:-/opt/toolchain/aarch64/modalix}/neat-install-packages` with the versions installed on the DevKit. If the DevKit is missing NEAT framework packages or has different versions, the SDK copies its cached artifacts to the DevKit and runs the cached installer locally there.
-
-Optional controls:
-
-```bash
-DEVKIT_NEAT_SYNC=OFF          # skip NEAT framework version check/sync
-DEVKIT_NEAT_SYNC_REQUIRED=ON  # fail setup if NEAT framework sync fails
-DEVKIT_NEAT_SYNC_CACHE_DIR=... # override SDK artifact cache directory
-```
-
-To open a direct SSH shell to the paired DevKit from inside the SDK container:
+Open a direct SSH shell to the paired DevKit:
 
 ```bash
 dk shell
 ```
 
-## Build Software
+## Advanced Topics
 
-### Linux Kernel
+- [Build the SDK image locally](docs/building-sdk-image.md)
+- [Manage NEAT Insight in the SDK container](docs/neat-insight.md)
+- [Use the DevKit NFS workspace](docs/devkit-workspace.md)
+- [Build kernel, U-Boot, and device-tree artifacts](docs/building-software.md)
+- [Install BSP artifacts on a board](docs/installing-artifacts.md)
+- [SDK smoke tests](tests/sdk/README.md)
 
-#### Fetching kernel source
+## Supported Platforms
 
-```bash
-git clone https://github.com/SiMa-ai/simaai-linux.git && cd simaai-linux
-```
+The examples use the `modalix` platform. The same flow can be adapted to `davinci` where corresponding platform configuration is available.
 
-#### Configuring kernel
-
-```bash
-make ARCH=arm64 <platform-defconfig>
-```
-
-Supported `platform-defconfig` values:
-
-- `simaai_modalix_defconfig`
-- `simaai_davinci_defconfig`
+The SDK sysroot is located under:
 
 ```text
-root@83a273303643:/data/simaai-linux# make ARCH=arm64 simaai_modalix_defconfig
-...
-...
-#
-# configuration written to .config
-#
-```
-
-#### Building kernel
-
-```bash
-make all -j8 ARCH=arm64 LOCALVERSION="-modalix" DTC_FLAGS=-@
-```
-
-Generated artifacts:
-
-- Kernel image: `arch/arm64/boot/Image`
-- Device trees: `arch/arm64/boot/dts/simaai/*.dtb`
-
-```text
-root@83a273303643:/data/simaai-linux# make all -j8 ARCH=arm64 LOCALVERSION="-modalix" DTC_FLAGS=-@
-...
-...
-NM      System.map
-SORTTAB vmlinux
-OBJCOPY arch/arm64/boot/Image
-GZIP    arch/arm64/boot/Image.gz
-```
-
-### Overlay Device Tree
-
-- Create the device tree overlay file (`.dtso`).
-- Build the overlay device tree blob (`.dtbo`):
-
-```bash
-dtc -@ -I dts -O dtb -o <dtbo-name> <dtso-name>
-```
-
-```text
-root@83a273303643:/data# dtc -@ -I dts -O dtb -o imx415.dtbo imx415.dtso
-```
-
-### U-Boot
-
-#### Fetching U-Boot source
-
-```bash
-git clone https://github.com/SiMa-ai/sima-ai-uboot.git && cd sima-ai-uboot
-```
-
-#### Configuring U-Boot
-
-```bash
-make ARCH=arm64 <platform-defconfig>
-```
-
-Supported `platform-defconfig` values:
-
-- `simaai_modalix_debug_defconfig`
-- `sima_davinci-a65_defconfig`
-
-```text
-root@83a273303643:/data/sima-ai-uboot# make ARCH=arm64 simaai_modalix_debug_defconfig
-...
-...
-#
-# configuration written to .config
-#
-```
-
-#### Building U-Boot
-
-```bash
-make all u-boot-initial-env V=1
-```
-
-Generated artifact:
-
-- U-Boot image: `u-boot.bin`
-
-```text
-root@83a273303643:/data/sima-ai-uboot# make all u-boot-initial-env V=1
-...
-...
-make -f ./scripts/Makefile.build obj=tools ./tools/printinitialenv
-cc -Wp,-MD,tools/.printinitialenv.d -Wall -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu11 -DCONFIG_FIT_SIGNATURE -DCONFIG_FIT_SIGNATURE_MAX_SIZE=0xffffffff -DCONFIG_FIT_CIPHER -include ./include/compiler.h -idirafterinclude -idirafter./arch/arm/include -idirafter./dts/upstream/include -I./scripts/dtc/libfdt -I./tools -DUSE_HOSTCC -D__KERNEL_STRICT_NAMES -D_GNU_SOURCE -o tools/printinitialenv tools/printinitialenv.c
-./tools/printinitialenv | sed -e '/^\s*$/d' | sort -t '=' -k 1,1 -s -o u-boot-initial-env
-```
-
-## Install Artifacts
-
-Artifacts to install:
-
-- U-Boot image
-- Linux kernel image
-- Linux device trees
-- Linux device tree overlays
-- Linux kernel modules
-
-> eMMC has four partitions:
->
-> - `mmcblk0p1`: U-Boot primary
-> - `mmcblk0p2`: U-Boot backup
-> - `mmcblk0p3`: boot partition
-> - `mmcblk0p4`: rootfs partition
->
-> Partition 3 (`mmcblk0p3`) contains two boot directories, `boot-0` and `boot-1`. One is primary and one is backup.
-
-### Copying U-Boot
-
-- Secure-copy U-Boot onto the board from the Docker container.
-
-```text
-root@83a273303643:/data# pwd
-/data
-root@83a273303643:/data# scp sima-ai-uboot/u-boot.bin root@192.168.90.139:/tmp/
-root@192.168.90.139's password:
-u-boot.bin                                                            100% 1024KB      6.9MB/s   00:00
-```
-
-- Identify the U-Boot partition currently in use on the board:
-
-```bash
-parted /dev/mmcblk0 print | grep legacy_boot | cut -f2 -d" "
-```
-
-```text
-root@modalix:~# parted /dev/mmcblk0 print | grep legacy_boot | cut -f2 -d" "
-1
-```
-
-- Flash the new `u-boot.bin` to the currently used U-Boot partition:
-
-```bash
-dd if=/tmp/u-boot.bin of=/dev/mmcblk0p1 status=progress
-sync
-```
-
-```text
-root@modalix:~# dd if=/tmp/u-boot.bin of=/dev/mmcblk0p1 status=progress
-2047+1 records in
-2047+1 records out
-1048560 bytes (1.0 MB, 1.0 MiB) copied, 0.0944332 s, 11.1 MB/s
-root@modalix:~# sync
-```
-
-### Copying Kernel
-
-- Determine the current boot directory on the boot partition:
-
-```bash
-strings /boot/uboot.env | grep boot_path= | cut -f2 -d"="
-```
-
-```text
-root@modalix:~# strings /boot/uboot.env | grep boot_path= | cut -f2 -d"="
-/boot-0/
-```
-
-#### Linux Kernel
-
-- Copy the new kernel image to the boot directory (`/boot/<boot directory>`):
-
-```text
-root@83a273303643:/data# scp simaai-linux/arch/arm64/boot/Image root@192.168.90.139:/boot/boot-0/
-root@192.168.90.139's password:
-Image
-```
-
-#### Device trees
-
-- Copy kernel device trees to the boot directory (`/boot/<boot directory>`):
-
-```text
-root@83a273303643:/data# scp simaai-linux/arch/arm64/boot/dts/simaai/modalix*.dtb root@192.168.90.139:/boot/boot-0/
-root@192.168.90.139's password:
-modalix-dvt.dtb                                                       100%  110KB     1.6MB/s   00:00
-modalix-emulation-bench.dtb                                           100%  107KB   3.1MB/s   00:00
-modalix-hhhl.dtb                                                      100%  110KB   4.1MB/s   00:00
-modalix-som.dtb                                                       100%  108KB   3.2MB/s   00:00
-modalix-vdk.dtb                                                       100%  108KB   3.6MB/s   00:00
-```
-
-#### Device Tree Overlays
-
-- Copy kernel device tree overlays to the boot directory (`/boot/<boot directory>`):
-
-```text
-root@83a273303643:/data# scp imx415.dtbo root@192.168.90.139:/boot/boot-0/
-root@192.168.90.139's password:
-imx415.dtbo                                                        100%  895    41.9KB/s   00:00
-```
-
-#### Kernel Modules
-
-- Copy required kernel modules to the appropriate rootfs partition modules directory, `/lib/modules/<kernel version string>/kernel/...`.
-- Use `uname -a` to determine the kernel version string.
-
-```text
-root@83a273303643:/data# scp simaai-linux/drivers/net/phy/marvell10g.ko root@192.168.90.139:/lib/modules/6.1.22-modalix/kernel/drivers/net/phy/
-root@192.168.90.139's password:
-marvell10g.ko                                                         100%   24KB 722.7KB/s   00:00
-```
-
-### Post Install
-
-```bash
-depmod -a <kernel version string>
-sync
-reboot
-```
-
-```text
-root@modalix:~# depmod -a 6.1.22-modalix
-root@modalix:~# sync
-root@modalix:~# reboot
-```
-
-If new overlays are added:
-
-- Break into the U-Boot prompt.
-- Add the new overlays to the `dtbos` variable and save the environment.
-- Boot the platform.
-
-```text
-Hit any key to stop autoboot:  0
-sima$ env set dtbos $dtbos imx415.dtbo
-sima$ saveenv
-Saving Environment to FAT... OK
-sima$ boot
+/opt/toolchain/aarch64/<platform>
 ```
 
 ## References
 
-- [1] <https://elxr.org/about>
-- [2] <https://www.windriver.com/blog/Introducing-eLxr>
-- [3] <https://www.docker.com/>
-- [4] <https://docs.docker.com/engine/install/ubuntu/>
+- [eLxr project](https://elxr.org/about)
+- [Docker Engine installation](https://docs.docker.com/engine/install/ubuntu/)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="images/simaai_logo.png" alt="SiMa.ai Logo" width="30%">
 </p>
 
-# SiMa.ai NEAT SDK
+# SiMa.ai Neat SDK
 
 [![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
 [![Smoke Test](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml)
@@ -11,9 +11,9 @@
 ![macOS](https://img.shields.io/badge/macOS-supported-000000?logo=apple&logoColor=white)
 ![eLxr Platform 2.0.0](https://img.shields.io/badge/eLxr%20Platform-2.0.0%20compatible-2E7D32)
 
-This repository packages the SiMa.ai NEAT SDK as a Docker image for `x86_64` and `arm64` Linux hosts.
+This repository packages the SiMa.ai Neat SDK as a Docker image for `x86_64` and `arm64` Linux hosts.
 
-The current NEAT SDK image is compatible with the eLxr platform `2.0.0` release.
+The current Neat SDK image is compatible with the eLxr platform `2.0.0` release.
 
 The main user workflow is:
 
@@ -113,7 +113,7 @@ dk /workspace/app-binary-or-dot-py-file
 
 - [Official Neat SDK installation guide](https://docs.sima-neat.com/getting-started/installation/neat-elxr-sdk)
 - [Build the SDK image locally](docs/building-sdk-image.md)
-- [Manage NEAT Insight in the SDK container](docs/neat-insight.md)
+- [Manage Neat Insight in the SDK container](docs/neat-insight.md)
 - [Use the DevKit NFS workspace](docs/devkit-workspace.md)
 - [Build kernel, U-Boot, and device-tree artifacts](docs/building-software.md)
 - [Install BSP artifacts on a board](docs/installing-artifacts.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# SDK Documentation
+
+Start with the repository [README](../README.md) for SDK installation and first-run instructions.
+
+Advanced topics:
+
+- [Build the SDK image locally](building-sdk-image.md)
+- [Manage NEAT Insight in the SDK container](neat-insight.md)
+- [Use the DevKit NFS workspace](devkit-workspace.md)
+- [Build kernel, U-Boot, and device-tree artifacts](building-software.md)
+- [Install BSP artifacts on a board](installing-artifacts.md)

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -1,0 +1,57 @@
+# Build The SDK Image Locally
+
+The CI-published SDK image is the recommended path for most users. Build locally when you need to test Dockerfile changes, add sysroot packages, or create a private development image.
+
+## Prerequisites
+
+- Docker Engine installed on the host build machine.
+- Access to any private package sources required by the build.
+- Optional: `qemu-user-static` if your workflow needs to execute non-native target binaries during cross-architecture builds.
+
+```bash
+sudo apt install qemu-user-static
+```
+
+The normal SDK image build does not require `qemu-user-static` when the container is built for the host's native architecture and only carries an `arm64` sysroot for cross-compilation.
+
+## Build
+
+Build the default local image:
+
+```bash
+./build.sh
+```
+
+By default, this builds `sdk:latest`.
+
+Build with a custom image name and tag:
+
+```bash
+./build.sh sdk 2.0.0
+```
+
+The build helper supports both `aarch64` and `x86_64` hosts and automatically selects the matching Docker platform for the current machine.
+
+Example output:
+
+```text
+Building sdk:latest
+Host architecture: arm64
+Docker platform: linux/arm64
+```
+
+## Add Sysroot Packages
+
+Provide a comma-separated package list with `SDK_PKG_LIST`:
+
+```bash
+SDK_PKG_LIST=libzix-dev,vxi-dev ./build.sh
+```
+
+## NEAT Insight Version
+
+To make an Insight upgrade permanent in the image, rebuild the SDK image with the desired Insight channel and version:
+
+```bash
+NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh sdk 2.0.0
+```

--- a/docs/building-software.md
+++ b/docs/building-software.md
@@ -1,0 +1,121 @@
+# Build BSP Software
+
+These are advanced BSP workflows for building kernel, U-Boot, and device-tree artifacts from inside the SDK container.
+
+The examples use the `modalix` platform. Adapt the defconfig values for other supported platforms.
+
+## Linux Kernel
+
+Fetch the kernel source:
+
+```bash
+git clone https://github.com/SiMa-ai/simaai-linux.git
+cd simaai-linux
+```
+
+Configure the kernel:
+
+```bash
+make ARCH=arm64 <platform-defconfig>
+```
+
+Supported `platform-defconfig` values:
+
+- `simaai_modalix_defconfig`
+- `simaai_davinci_defconfig`
+
+Example:
+
+```text
+root@83a273303643:/data/simaai-linux# make ARCH=arm64 simaai_modalix_defconfig
+...
+#
+# configuration written to .config
+#
+```
+
+Build the kernel:
+
+```bash
+make all -j8 ARCH=arm64 LOCALVERSION="-modalix" DTC_FLAGS=-@
+```
+
+Generated artifacts:
+
+- Kernel image: `arch/arm64/boot/Image`
+- Device trees: `arch/arm64/boot/dts/simaai/*.dtb`
+
+Example:
+
+```text
+root@83a273303643:/data/simaai-linux# make all -j8 ARCH=arm64 LOCALVERSION="-modalix" DTC_FLAGS=-@
+...
+NM      System.map
+SORTTAB vmlinux
+OBJCOPY arch/arm64/boot/Image
+GZIP    arch/arm64/boot/Image.gz
+```
+
+## Overlay Device Tree
+
+Create the device tree overlay file (`.dtso`) and build the overlay device tree blob (`.dtbo`):
+
+```bash
+dtc -@ -I dts -O dtb -o <dtbo-name> <dtso-name>
+```
+
+Example:
+
+```text
+root@83a273303643:/data# dtc -@ -I dts -O dtb -o imx415.dtbo imx415.dtso
+```
+
+## U-Boot
+
+Fetch the U-Boot source:
+
+```bash
+git clone https://github.com/SiMa-ai/sima-ai-uboot.git
+cd sima-ai-uboot
+```
+
+Configure U-Boot:
+
+```bash
+make ARCH=arm64 <platform-defconfig>
+```
+
+Supported `platform-defconfig` values:
+
+- `simaai_modalix_debug_defconfig`
+- `sima_davinci-a65_defconfig`
+
+Example:
+
+```text
+root@83a273303643:/data/sima-ai-uboot# make ARCH=arm64 simaai_modalix_debug_defconfig
+...
+#
+# configuration written to .config
+#
+```
+
+Build U-Boot:
+
+```bash
+make all u-boot-initial-env V=1
+```
+
+Generated artifact:
+
+- U-Boot image: `u-boot.bin`
+
+Example:
+
+```text
+root@83a273303643:/data/sima-ai-uboot# make all u-boot-initial-env V=1
+...
+make -f ./scripts/Makefile.build obj=tools ./tools/printinitialenv
+cc -Wp,-MD,tools/.printinitialenv.d -Wall -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu11 -DCONFIG_FIT_SIGNATURE -DCONFIG_FIT_SIGNATURE_MAX_SIZE=0xffffffff -DCONFIG_FIT_CIPHER -include ./include/compiler.h -idirafterinclude -idirafter./arch/arm/include -idirafter./dts/upstream/include -I./scripts/dtc/libfdt -I./tools -DUSE_HOSTCC -D__KERNEL_STRICT_NAMES -D_GNU_SOURCE -o tools/printinitialenv tools/printinitialenv.c
+./tools/printinitialenv | sed -e '/^\s*$/d' | sort -t '=' -k 1,1 -s -o u-boot-initial-env
+```

--- a/docs/devkit-workspace.md
+++ b/docs/devkit-workspace.md
@@ -1,0 +1,51 @@
+# DevKit Workspace
+
+The DevKit workspace flow uses NFS. The workspace is shared bi-directionally between the host and the DevKit.
+
+## Start The SDK Container
+
+Start the SDK container and configure the host-side NFS export:
+
+```bash
+./run.sh --prefer-local --devkit-ip 10.0.0.244
+```
+
+If the host IP selected for NFS is not reachable from the DevKit, provide the host interface IP explicitly:
+
+```bash
+./run.sh --prefer-local --devkit-ip 10.0.0.244 --hostip 10.0.0.10
+```
+
+## Configure The DevKit Mount
+
+Inside the SDK container, source the setup helper:
+
+```bash
+source devkit.sh
+```
+
+This configures the remote DevKit mount, updates DevKit `/etc/fstab`, enables a watchdog timer for stale mount recovery, and sets Git `safe.directory` for the mounted workspace path.
+
+## NEAT Framework Sync
+
+During setup, `devkit.sh` compares the SDK NEAT framework package versions cached under:
+
+```text
+${SYSROOT:-/opt/toolchain/aarch64/modalix}/neat-install-packages
+```
+
+with the versions installed on the DevKit. If the DevKit is missing NEAT framework packages or has different versions, the SDK copies its cached artifacts to the DevKit and runs the cached installer locally there.
+
+Optional controls:
+
+```bash
+DEVKIT_NEAT_SYNC=OFF           # skip NEAT framework version check/sync
+DEVKIT_NEAT_SYNC_REQUIRED=ON   # fail setup if NEAT framework sync fails
+DEVKIT_NEAT_SYNC_CACHE_DIR=... # override SDK artifact cache directory
+```
+
+## Open A DevKit Shell
+
+```bash
+dk shell
+```

--- a/docs/installing-artifacts.md
+++ b/docs/installing-artifacts.md
@@ -1,0 +1,162 @@
+# Install BSP Artifacts On A Board
+
+These are advanced BSP workflows for manually installing generated artifacts on a SiMa.ai platform.
+
+## Assumptions
+
+- The board is booted with an eLxr image.
+- You have root access to the board.
+- The board is reachable from the SDK container.
+- The board is booted from eMMC, enumerated as `mmcblk0` on Linux.
+
+## Artifacts
+
+Artifacts to install:
+
+- U-Boot image
+- Linux kernel image
+- Linux device trees
+- Linux device tree overlays
+- Linux kernel modules
+
+eMMC has four partitions:
+
+- `mmcblk0p1`: U-Boot primary
+- `mmcblk0p2`: U-Boot backup
+- `mmcblk0p3`: boot partition
+- `mmcblk0p4`: rootfs partition
+
+Partition 3 (`mmcblk0p3`) contains two boot directories, `boot-0` and `boot-1`. One is primary and one is backup.
+
+## Copy U-Boot
+
+Secure-copy U-Boot onto the board from the SDK container:
+
+```text
+root@83a273303643:/data# pwd
+/data
+root@83a273303643:/data# scp sima-ai-uboot/u-boot.bin root@192.168.90.139:/tmp/
+root@192.168.90.139's password:
+u-boot.bin                                                            100% 1024KB      6.9MB/s   00:00
+```
+
+Identify the U-Boot partition currently in use on the board:
+
+```bash
+parted /dev/mmcblk0 print | grep legacy_boot | cut -f2 -d" "
+```
+
+Example:
+
+```text
+root@modalix:~# parted /dev/mmcblk0 print | grep legacy_boot | cut -f2 -d" "
+1
+```
+
+Flash the new `u-boot.bin` to the currently used U-Boot partition:
+
+```bash
+dd if=/tmp/u-boot.bin of=/dev/mmcblk0p1 status=progress
+sync
+```
+
+Example:
+
+```text
+root@modalix:~# dd if=/tmp/u-boot.bin of=/dev/mmcblk0p1 status=progress
+2047+1 records in
+2047+1 records out
+1048560 bytes (1.0 MB, 1.0 MiB) copied, 0.0944332 s, 11.1 MB/s
+root@modalix:~# sync
+```
+
+## Copy Kernel Artifacts
+
+Determine the current boot directory on the boot partition:
+
+```bash
+strings /boot/uboot.env | grep boot_path= | cut -f2 -d"="
+```
+
+Example:
+
+```text
+root@modalix:~# strings /boot/uboot.env | grep boot_path= | cut -f2 -d"="
+/boot-0/
+```
+
+Copy the new kernel image to the boot directory:
+
+```text
+root@83a273303643:/data# scp simaai-linux/arch/arm64/boot/Image root@192.168.90.139:/boot/boot-0/
+root@192.168.90.139's password:
+Image
+```
+
+Copy kernel device trees to the boot directory:
+
+```text
+root@83a273303643:/data# scp simaai-linux/arch/arm64/boot/dts/simaai/modalix*.dtb root@192.168.90.139:/boot/boot-0/
+root@192.168.90.139's password:
+modalix-dvt.dtb                                                       100%  110KB     1.6MB/s   00:00
+modalix-emulation-bench.dtb                                           100%  107KB   3.1MB/s   00:00
+modalix-hhhl.dtb                                                      100%  110KB   4.1MB/s   00:00
+modalix-som.dtb                                                       100%  108KB   3.2MB/s   00:00
+modalix-vdk.dtb                                                       100%  108KB   3.6MB/s   00:00
+```
+
+Copy kernel device tree overlays to the boot directory:
+
+```text
+root@83a273303643:/data# scp imx415.dtbo root@192.168.90.139:/boot/boot-0/
+root@192.168.90.139's password:
+imx415.dtbo                                                        100%  895    41.9KB/s   00:00
+```
+
+## Copy Kernel Modules
+
+Copy required kernel modules to the appropriate rootfs partition modules directory:
+
+```text
+/lib/modules/<kernel version string>/kernel/...
+```
+
+Use `uname -a` to determine the kernel version string.
+
+Example:
+
+```text
+root@83a273303643:/data# scp simaai-linux/drivers/net/phy/marvell10g.ko root@192.168.90.139:/lib/modules/6.1.22-modalix/kernel/drivers/net/phy/
+root@192.168.90.139's password:
+marvell10g.ko                                                         100%   24KB 722.7KB/s   00:00
+```
+
+## Post Install
+
+```bash
+depmod -a <kernel version string>
+sync
+reboot
+```
+
+Example:
+
+```text
+root@modalix:~# depmod -a 6.1.22-modalix
+root@modalix:~# sync
+root@modalix:~# reboot
+```
+
+If new overlays are added:
+
+1. Break into the U-Boot prompt.
+2. Add the new overlays to the `dtbos` variable and save the environment.
+3. Boot the platform.
+
+```text
+Hit any key to stop autoboot:  0
+sima$ env set dtbos $dtbos imx415.dtbo
+sima$ saveenv
+Saving Environment to FAT... OK
+sima$ boot
+```

--- a/docs/neat-insight.md
+++ b/docs/neat-insight.md
@@ -1,0 +1,35 @@
+# NEAT Insight In The SDK Container
+
+The SDK image installs `neat-insight` into `/opt/neat-insight/venv` and starts it automatically under `supervisord` when the container starts.
+
+By default, Insight listens on port `9900`.
+
+## Useful Commands
+
+Run these commands inside the SDK container:
+
+```bash
+insight-admin status
+insight-admin logs
+insight-admin restart
+insight-admin stop
+```
+
+## Temporary Upgrade
+
+To temporarily upgrade Insight inside an existing container:
+
+```bash
+insight-admin update main latest
+insight-admin restart
+```
+
+This only affects the current container.
+
+## Permanent Upgrade
+
+To make an Insight upgrade permanent, rebuild the SDK image with the desired channel and version:
+
+```bash
+NEAT_INSIGHT_BRANCH=main NEAT_INSIGHT_VERSION=latest ./build.sh sdk 2.0.0
+```

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -422,8 +422,13 @@ devkit_sync_noninteractive() {
   esac
 }
 
-devkit_sync_default_sudo_password() {
+devkit_sync_default_password() {
   local user="$1"
+
+  if [[ -n "${DEVKIT_SYNC_PASSWORD:-}" ]]; then
+    printf '%s' "${DEVKIT_SYNC_PASSWORD}"
+    return 0
+  fi
 
   if [[ -n "${DEVKIT_SYNC_SUDO_PASSWORD:-}" ]]; then
     printf '%s' "${DEVKIT_SYNC_SUDO_PASSWORD}"
@@ -484,6 +489,10 @@ if [[ "${_HOST_PLATFORM}" == "darwin" ]]; then
 else
   _NFS_OPTS="vers=4,proto=tcp,soft,timeo=50,retrans=1,_netdev,nofail,x-systemd.automount"
 fi
+_DEFAULT_DEVKIT_PASSWORD=""
+if devkit_sync_default_password "${_DEVKIT_USER}" >/dev/null; then
+  _DEFAULT_DEVKIT_PASSWORD="$(devkit_sync_default_password "${_DEVKIT_USER}")"
+fi
 
 mkdir -p "${HOME}/.ssh"
 chmod 700 "${HOME}/.ssh"
@@ -496,9 +505,21 @@ chmod 600 "${HOME}/.ssh/known_hosts"
 echo "Installing/refreshing SSH key for ${_DEVKIT_USER}@${_DEVKIT_IP}"
 _SSH_COPY_ID_OPTS=(-o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new)
 if devkit_sync_noninteractive; then
-  _SSH_COPY_ID_OPTS+=(-o BatchMode=yes)
+  if [[ -n "${_DEFAULT_DEVKIT_PASSWORD}" ]]; then
+    if ! command -v sshpass >/dev/null 2>&1; then
+      echo "Non-interactive SSH key install requires sshpass when password auth is needed." >&2
+      return 1
+    fi
+    _SSHPASS_ENV=(SSHPASS="${_DEFAULT_DEVKIT_PASSWORD}")
+    _SSH_COPY_ID_CMD=(env "${_SSHPASS_ENV[@]}" sshpass -e ssh-copy-id)
+  else
+    _SSH_COPY_ID_OPTS+=(-o BatchMode=yes)
+    _SSH_COPY_ID_CMD=(ssh-copy-id)
+  fi
+else
+  _SSH_COPY_ID_CMD=(ssh-copy-id)
 fi
-if ! timeout --foreground 120 ssh-copy-id -i "${HOME}/.ssh/id_ed25519.pub" -p "${_DEVKIT_PORT}" "${_SSH_COPY_ID_OPTS[@]}" "${_DEVKIT_USER}@${_DEVKIT_IP}"; then
+if ! timeout --foreground 120 "${_SSH_COPY_ID_CMD[@]}" -i "${HOME}/.ssh/id_ed25519.pub" -p "${_DEVKIT_PORT}" "${_SSH_COPY_ID_OPTS[@]}" "${_DEVKIT_USER}@${_DEVKIT_IP}"; then
   echo "Failed to install SSH key for ${_DEVKIT_USER}@${_DEVKIT_IP}:${_DEVKIT_PORT}." >&2
   echo "Hint: verify the DevKit IP/port, that SSH is running, and that the user is reachable before retrying." >&2
   return 1
@@ -508,17 +529,12 @@ check_devkit_sdk_version_compatibility "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEV
 
 if [[ "${_DEVKIT_USER}" != "root" ]]; then
   if ! check_remote_passwordless_sudo "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"; then
-    _DEFAULT_SUDO_PASSWORD=""
-    if devkit_sync_default_sudo_password "${_DEVKIT_USER}" >/dev/null; then
-      _DEFAULT_SUDO_PASSWORD="$(devkit_sync_default_sudo_password "${_DEVKIT_USER}")"
-    fi
-
     echo ""
     echo "DevKit user '${_DEVKIT_USER}' does not have passwordless sudo."
     echo "This script can apply a one-time sudoers change:"
     echo "  ${_DEVKIT_USER} ALL=(ALL) NOPASSWD:ALL"
     if devkit_sync_noninteractive; then
-      if [[ -n "${_DEFAULT_SUDO_PASSWORD}" ]]; then
+      if [[ -n "${_DEFAULT_DEVKIT_PASSWORD}" ]]; then
         _ALLOW_NOPASSWD="y"
         echo "Non-interactive mode: applying passwordless sudo setup using the default sudo password for '${_DEVKIT_USER}'."
       else
@@ -531,12 +547,12 @@ if [[ "${_DEVKIT_USER}" != "root" ]]; then
     case "${_ALLOW_NOPASSWD,,}" in
       y|yes)
         echo "Applying passwordless sudo setup for ${_DEVKIT_USER}@${_DEVKIT_IP}."
-        _REMOTE_SUDO_PASSWORD="${_DEFAULT_SUDO_PASSWORD}"
+        _REMOTE_SUDO_PASSWORD="${_DEFAULT_DEVKIT_PASSWORD}"
         if ! devkit_sync_noninteractive; then
-          if [[ -n "${_DEFAULT_SUDO_PASSWORD}" ]]; then
+          if [[ -n "${_DEFAULT_DEVKIT_PASSWORD}" ]]; then
             read -r -s -p "Enter sudo password for ${_DEVKIT_USER}@${_DEVKIT_IP} [press Enter for default]: " _REMOTE_SUDO_PASSWORD_INPUT
             echo ""
-            _REMOTE_SUDO_PASSWORD="${_REMOTE_SUDO_PASSWORD_INPUT:-${_DEFAULT_SUDO_PASSWORD}}"
+            _REMOTE_SUDO_PASSWORD="${_REMOTE_SUDO_PASSWORD_INPUT:-${_DEFAULT_DEVKIT_PASSWORD}}"
           else
             read -r -s -p "Enter sudo password for ${_DEVKIT_USER}@${_DEVKIT_IP}: " _REMOTE_SUDO_PASSWORD
             echo ""

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -415,6 +415,29 @@ _HOST_EXPORT_PATH="${DEVKIT_HOST_EXPORT_PATH:-}"
 _HOST_PLATFORM="${DEVKIT_HOST_PLATFORM:-linux}"
 _DEFAULT_MOUNT_PATH="${DEVKIT_SYNC_MOUNT_PATH:-/workspace}"
 
+devkit_sync_noninteractive() {
+  case "${DEVKIT_SYNC_NONINTERACTIVE:-}" in
+    1|true|TRUE|yes|YES|on|ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+devkit_sync_default_sudo_password() {
+  local user="$1"
+
+  if [[ -n "${DEVKIT_SYNC_SUDO_PASSWORD:-}" ]]; then
+    printf '%s' "${DEVKIT_SYNC_SUDO_PASSWORD}"
+    return 0
+  fi
+
+  if [[ "${user}" == "sima" ]]; then
+    printf '%s' "edgeai"
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ -z "${_HOST_IP}" || -z "${_HOST_EXPORT_PATH}" ]]; then
   echo "Missing host export info in environment." >&2
   echo "Expected NFS_SERVER_HOST_IP and DEVKIT_HOST_EXPORT_PATH (set by run.py)." >&2
@@ -445,8 +468,13 @@ printf "DevKit: %s@%s:%s\n" "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"
 printf "Host export: %s:%s\n" "${_HOST_IP}" "${_HOST_EXPORT_PATH}"
 printf "Reminder: NFS workspace is shared bi-directionally.\n\n"
 
-read -r -p "Destination mount path on DevKit [${_DEFAULT_MOUNT_PATH}]: " _MOUNT_POINT
-_MOUNT_POINT="${_MOUNT_POINT:-${_DEFAULT_MOUNT_PATH}}"
+if devkit_sync_noninteractive; then
+  _MOUNT_POINT="${_DEFAULT_MOUNT_PATH}"
+  echo "Non-interactive mode: using default DevKit mount path ${_MOUNT_POINT}"
+else
+  read -r -p "Destination mount path on DevKit [${_DEFAULT_MOUNT_PATH}]: " _MOUNT_POINT
+  _MOUNT_POINT="${_MOUNT_POINT:-${_DEFAULT_MOUNT_PATH}}"
+fi
 if [[ "${_MOUNT_POINT}" != /* ]]; then
   echo "Please provide an absolute path (must start with '/')." >&2
   return 2
@@ -466,7 +494,11 @@ ssh-keyscan -H -p "${_DEVKIT_PORT}" "${_DEVKIT_IP}" >> "${HOME}/.ssh/known_hosts
 chmod 600 "${HOME}/.ssh/known_hosts"
 
 echo "Installing/refreshing SSH key for ${_DEVKIT_USER}@${_DEVKIT_IP}"
-if ! timeout --foreground 120 ssh-copy-id -i "${HOME}/.ssh/id_ed25519.pub" -p "${_DEVKIT_PORT}" -o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new "${_DEVKIT_USER}@${_DEVKIT_IP}"; then
+_SSH_COPY_ID_OPTS=(-o ConnectTimeout=8 -o StrictHostKeyChecking=accept-new)
+if devkit_sync_noninteractive; then
+  _SSH_COPY_ID_OPTS+=(-o BatchMode=yes)
+fi
+if ! timeout --foreground 120 ssh-copy-id -i "${HOME}/.ssh/id_ed25519.pub" -p "${_DEVKIT_PORT}" "${_SSH_COPY_ID_OPTS[@]}" "${_DEVKIT_USER}@${_DEVKIT_IP}"; then
   echo "Failed to install SSH key for ${_DEVKIT_USER}@${_DEVKIT_IP}:${_DEVKIT_PORT}." >&2
   echo "Hint: verify the DevKit IP/port, that SSH is running, and that the user is reachable before retrying." >&2
   return 1
@@ -476,17 +508,40 @@ check_devkit_sdk_version_compatibility "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEV
 
 if [[ "${_DEVKIT_USER}" != "root" ]]; then
   if ! check_remote_passwordless_sudo "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"; then
+    _DEFAULT_SUDO_PASSWORD=""
+    if devkit_sync_default_sudo_password "${_DEVKIT_USER}" >/dev/null; then
+      _DEFAULT_SUDO_PASSWORD="$(devkit_sync_default_sudo_password "${_DEVKIT_USER}")"
+    fi
+
     echo ""
     echo "DevKit user '${_DEVKIT_USER}' does not have passwordless sudo."
     echo "This script can apply a one-time sudoers change:"
     echo "  ${_DEVKIT_USER} ALL=(ALL) NOPASSWD:ALL"
-    read -r -p "Apply this change on ${_DEVKIT_IP}? [y/N]: " _ALLOW_NOPASSWD
+    if devkit_sync_noninteractive; then
+      if [[ -n "${_DEFAULT_SUDO_PASSWORD}" ]]; then
+        _ALLOW_NOPASSWD="y"
+        echo "Non-interactive mode: applying passwordless sudo setup using the default sudo password for '${_DEVKIT_USER}'."
+      else
+        _ALLOW_NOPASSWD="n"
+        echo "Non-interactive mode: accepting default 'no' for passwordless sudo setup."
+      fi
+    else
+      read -r -p "Apply this change on ${_DEVKIT_IP}? [y/N]: " _ALLOW_NOPASSWD
+    fi
     case "${_ALLOW_NOPASSWD,,}" in
       y|yes)
         echo "Applying passwordless sudo setup for ${_DEVKIT_USER}@${_DEVKIT_IP}."
-        _REMOTE_SUDO_PASSWORD=""
-        read -r -s -p "Enter sudo password for ${_DEVKIT_USER}@${_DEVKIT_IP}: " _REMOTE_SUDO_PASSWORD
-        echo ""
+        _REMOTE_SUDO_PASSWORD="${_DEFAULT_SUDO_PASSWORD}"
+        if ! devkit_sync_noninteractive; then
+          if [[ -n "${_DEFAULT_SUDO_PASSWORD}" ]]; then
+            read -r -s -p "Enter sudo password for ${_DEVKIT_USER}@${_DEVKIT_IP} [press Enter for default]: " _REMOTE_SUDO_PASSWORD_INPUT
+            echo ""
+            _REMOTE_SUDO_PASSWORD="${_REMOTE_SUDO_PASSWORD_INPUT:-${_DEFAULT_SUDO_PASSWORD}}"
+          else
+            read -r -s -p "Enter sudo password for ${_DEVKIT_USER}@${_DEVKIT_IP}: " _REMOTE_SUDO_PASSWORD
+            echo ""
+          fi
+        fi
         if [[ -z "${_REMOTE_SUDO_PASSWORD}" ]]; then
           echo "Remote sudo password is required." >&2
           return 1

--- a/tests/sdk/README.md
+++ b/tests/sdk/README.md
@@ -1,0 +1,17 @@
+# SDK Smoke Tests
+
+This directory contains CI smoke tests that validate a published Neat SDK
+container after `sima-cli sdk setup -y -n` starts it.
+
+## Layout
+
+- `run-smoke-tests.sh` runs on the GitHub Actions runner. It finds the running
+  SDK container for `IMAGE_REF`, copies this directory into the container, and
+  invokes `run-in-container.sh`.
+- `run-in-container.sh` runs inside the SDK container and acts as the index for
+  individual SDK smoke tests.
+- `neat-status/` validates the `neat --json` assembly/status contract.
+- `hello-neat/` contains the minimal Hello Neat example from the public docs.
+
+Additional SDK smoke suites should be added as sibling directories and invoked
+from `run-in-container.sh`.

--- a/tests/sdk/hello-neat/CMakeLists.txt
+++ b/tests/sdk/hello-neat/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(sima_neat_hello LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Supports both:
+# - DevKit/native installs (system paths)
+# - Cross builds with SYSROOT exported (SDK sysroot paths)
+if(DEFINED ENV{SYSROOT} AND NOT "$ENV{SYSROOT}" STREQUAL "")
+  list(APPEND CMAKE_PREFIX_PATH
+    "$ENV{SYSROOT}/usr"
+    "$ENV{SYSROOT}/usr/lib"
+    "$ENV{SYSROOT}/usr/lib/aarch64-linux-gnu"
+  )
+endif()
+
+find_package(SimaNeat REQUIRED CONFIG)
+
+add_executable(sima_neat_hello main.cpp)
+target_link_libraries(sima_neat_hello PRIVATE SimaNeat::sima_neat)

--- a/tests/sdk/hello-neat/hello_neat.py
+++ b/tests/sdk/hello-neat/hello_neat.py
@@ -1,0 +1,10 @@
+from pyneat import DeviceType
+
+
+def main():
+    print("Hello from sima-neat")
+    print("DeviceType.CPU =", DeviceType.CPU)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk/hello-neat/main.cpp
+++ b/tests/sdk/hello-neat/main.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+
+#include <pipeline/TensorCore.h>
+
+int main() {
+  auto storage = simaai::neat::make_cpu_owned_storage(64);
+
+  if (!storage) {
+    std::cerr << "Failed to allocate CPU tensor storage\n";
+    return 1;
+  }
+
+  std::cout << "Hello from sima-neat\n";
+  return 0;
+}

--- a/tests/sdk/neat-status/validate_neat_status.py
+++ b/tests/sdk/neat-status/validate_neat_status.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+
+def add_error(errors, message):
+    errors.append(message)
+
+
+def validate_status(data):
+    errors = []
+
+    if data.get("schema") != "sima.neat.status.v1":
+        add_error(errors, f"Unexpected schema: {data.get('schema')}")
+
+    environment = data.get("environment") or {}
+    if environment.get("mode") != "elxr-sdk":
+        add_error(errors, f"Unexpected environment mode: {environment.get('mode')}")
+    if not environment.get("sdkVersion"):
+        add_error(errors, "Missing environment.sdkVersion")
+    if not environment.get("sysroot"):
+        add_error(errors, "Missing environment.sysroot")
+
+    components = data.get("components") or {}
+    required_components = {
+        "core",
+        "gstPlugins",
+        "insight",
+        "modelSdkExtension",
+        "pyneat",
+        "runtime",
+    }
+    for name in sorted(required_components):
+        component = components.get(name)
+        if component is None:
+            add_error(errors, f"Missing component: {name}")
+            continue
+        if not component.get("name"):
+            add_error(errors, f"Missing components.{name}.name")
+
+    for name in ["core", "gstPlugins", "insight", "pyneat", "runtime"]:
+        component = components.get(name) or {}
+        if not component.get("version"):
+            add_error(errors, f"Missing components.{name}.version")
+
+    insight = components.get("insight") or {}
+    if not insight.get("version"):
+        add_error(errors, "Missing components.insight.version")
+    if not insight.get("tag"):
+        add_error(errors, "Missing components.insight.tag")
+    if not insight.get("venv"):
+        add_error(errors, "Missing components.insight.venv")
+    if insight.get("serviceState") not in {"Running", "Starting", "Unknown"}:
+        add_error(
+            errors,
+            f"Unexpected components.insight.serviceState: {insight.get('serviceState')}",
+        )
+
+    model_sdk = components.get("modelSdkExtension") or {}
+    if "installed" not in model_sdk:
+        add_error(errors, "Missing components.modelSdkExtension.installed")
+    if "version" not in model_sdk:
+        add_error(errors, "Missing components.modelSdkExtension.version")
+    elif model_sdk.get("installed") and not model_sdk.get("version"):
+        add_error(errors, "Model SDK Extension is installed but version is empty")
+
+    update_status = data.get("updateCheck", {}).get("status")
+    if update_status not in {"ok", "skipped", "error", None}:
+        add_error(errors, f"Unexpected updateCheck.status: {update_status}")
+
+    return errors
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: validate_neat_status.py <neat-status.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8") as f:
+        data = json.load(f)
+
+    errors = validate_status(data)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("Neat status validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -7,6 +7,20 @@ HELLO_SRC="${ROOT_DIR}/hello-neat"
 HELLO_WORK="${WORK_DIR}/hello-neat"
 STATUS_JSON="${WORK_DIR}/neat-status.json"
 
+setup_sdk_environment() {
+  if [[ -f /opt/bin/simaai-init-build-env ]]; then
+    # shellcheck source=/dev/null
+    source /opt/bin/simaai-init-build-env modalix >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f /etc/profile.d/pkg-config-sysroot.sh ]]; then
+    # shellcheck source=/dev/null
+    source /etc/profile.d/pkg-config-sysroot.sh
+  fi
+
+  export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
+}
+
 run_test() {
   local name="$1"
   shift
@@ -46,6 +60,8 @@ test_hello_neat_cpp() {
 test_hello_neat_python() {
   echo "Skipping Python runtime example; pyneat is validated on the DevKit side."
 }
+
+setup_sdk_environment
 
 rm -rf "${WORK_DIR}"
 mkdir -p "${HELLO_WORK}" "$(dirname "${STATUS_JSON}")"

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK_DIR="${NEAT_SDK_TEST_WORK_DIR:-/tmp/neat-sdk-smoke-work}"
+HELLO_SRC="${ROOT_DIR}/hello-neat"
+HELLO_WORK="${WORK_DIR}/hello-neat"
+STATUS_JSON="${WORK_DIR}/neat-status.json"
+
+run_test() {
+  local name="$1"
+  shift
+
+  printf '\n========== %s ==========\n' "${name}"
+  "$@"
+}
+
+test_neat_status() {
+  echo "::group::Neat status"
+  neat --json | tee "${STATUS_JSON}"
+  python3 "${ROOT_DIR}/neat-status/validate_neat_status.py" "${STATUS_JSON}"
+  echo "::endgroup::"
+}
+
+test_hello_neat_cpp() {
+  cd "${HELLO_WORK}"
+
+  echo "::group::Hello Neat C++ configure"
+  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+  echo "::endgroup::"
+
+  echo "::group::Hello Neat C++ build"
+  cmake --build build -j"$(nproc)"
+  echo "::endgroup::"
+
+  test -x build/sima_neat_hello
+  file build/sima_neat_hello
+
+  if [[ "${NEAT_SDK_SMOKE_RUN_BINARY:-0}" == "1" ]]; then
+    ./build/sima_neat_hello
+  else
+    echo "Skipping C++ binary execution; CI smoke test validates SDK build setup without a paired DevKit."
+  fi
+}
+
+test_hello_neat_python() {
+  echo "Skipping Python runtime example; pyneat is validated on the DevKit side."
+}
+
+rm -rf "${WORK_DIR}"
+mkdir -p "${HELLO_WORK}" "$(dirname "${STATUS_JSON}")"
+cp -a "${HELLO_SRC}/." "${HELLO_WORK}/"
+
+run_test "SDK status: neat --json" test_neat_status
+run_test "Hello Neat C++ build" test_hello_neat_cpp
+run_test "Hello Neat Python runtime" test_hello_neat_python
+
+printf '\nSDK smoke tests passed.\n'

--- a/tests/sdk/run-smoke-tests.sh
+++ b/tests/sdk/run-smoke-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${IMAGE_REF:-}" ]]; then
+  echo "IMAGE_REF is required." >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_ID="$(docker ps -q --filter "ancestor=${IMAGE_REF}" | head -n 1)"
+
+if [[ -z "${CONTAINER_ID}" ]]; then
+  echo "No running SDK container found for image ${IMAGE_REF}." >&2
+  docker ps --format 'table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}' >&2
+  exit 1
+fi
+
+REMOTE_DIR="/tmp/neat-sdk-smoke-tests"
+docker exec "${CONTAINER_ID}" rm -rf "${REMOTE_DIR}"
+docker cp "${SCRIPT_DIR}/." "${CONTAINER_ID}:${REMOTE_DIR}"
+docker exec "${CONTAINER_ID}" chmod +x "${REMOTE_DIR}/run-in-container.sh"
+docker exec "${CONTAINER_ID}" bash "${REMOTE_DIR}/run-in-container.sh"


### PR DESCRIPTION
## Summary

This PR adds an SDK smoke-test gate between publishing a newly built container image and promoting it to user-facing tags. The build workflow now publishes an immutable SHA image and a staged multi-arch tag first, while the smoke workflow validates the staged image on both Ubuntu amd64 and arm64 runners before promotion.

## What changed

- Removed the temporary direct `push` trigger from the `Smoke Test` workflow.
- Kept smoke tests triggered by successful completion of `Build Docker Image`, plus manual dispatch for ad hoc validation.
- Changed the Docker build workflow to publish `staged-<sha>` instead of immediately moving `latest` or release tags.
- Added image promotion metadata as a workflow artifact so smoke reruns can promote the exact staged image that was built.
- Added a promotion job that runs only after the smoke matrix succeeds.
- Promotes branch builds to `latest` only after smoke passes.
- Promotes tag builds such as `v2.0.0` to `2.0.0` only after smoke passes.
- Updated artifact actions to `actions/upload-artifact@v7` and `actions/download-artifact@v7` for Node 24 compatibility.

## Behavior

For a branch build:

1. Build publishes architecture tags, the SHA manifest, and `staged-<sha>`.
2. Smoke tests install and validate `staged-<sha>` on amd64 and arm64.
3. If both smoke jobs pass, the workflow promotes the staged image to `latest` for that image repository.

For a release tag such as `v2.0.0`:

1. Build publishes architecture tags, the SHA manifest, and `staged-<sha>`.
2. It does not publish `2.0.0` during build.
3. Smoke tests validate `staged-<sha>`.
4. If smoke passes, the promotion job publishes `2.0.0`.

Manual smoke-test dispatch remains validation-only and does not promote tags, so arbitrary manual runs cannot accidentally move `latest` or a release tag.

## Validation

- `actionlint .github/workflows/docker-build.yml .github/workflows/smoke-test.yml`
- YAML parse check for both workflow files
