### PR TITLE
Pin SiMa SDK sysroot package versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,15 @@ RUN echo "Package: *" > /etc/apt/preferences.d/stable.pref
 RUN echo "Pin: origin \"repo.sima.ai/elxr\"" >> /etc/apt/preferences.d/stable.pref
 RUN echo "Pin-Priority: 999" >> /etc/apt/preferences.d/stable.pref
 
+# The SiMa palette package has loose dependencies. Keep SDK-versioned packages
+# on BASE_SDK_VERSION so fresh CI builds do not mix newer sysroot packages into
+# an older SDK image when repo.sima.ai publishes a later release.
+RUN printf '%s\n' \
+      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* libcamera libcamera-tools' \
+      "Pin: version ${BASE_SDK_VERSION}" \
+      'Pin-Priority: 1001' \
+    > /etc/apt/preferences.d/simaai-sdk-version.pref
+
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \
       python3-apt-ostree \


### PR DESCRIPTION
## Summary

Pins SDK-versioned SiMa package candidates to `BASE_SDK_VERSION` during Docker image builds.

## Why

The SiMa `simaai-palette-modalix` package for `2.0.0` declares loose dependencies. After `2.1.0` packages appeared in `repo.sima.ai`, fresh CI builds could resolve dependencies such as `simaai-mlart-modalix`, `simaai-gst-plugins`, and `simaai-common` to `2.1.0` while still labeling the image as SDK `2.0.0`.

That mixed sysroot introduced the April `gst-api.h` header, which includes C++ STL headers before `extern "C"` and breaks C compilation paths.

## Change

Adds an apt preferences file that gives SDK-versioned SiMa packages at `${BASE_SDK_VERSION}` priority `1001`, so newer candidates do not get mixed into an older SDK sysroot. Packages without a matching SDK version can still resolve normally.

## Validation

- Verified the remote image currently resolves the affected packages to `2.1.0` without the pin.
- Verified the same package set resolves to `2.0.0` with the new pin.
- Confirmed `simaai-mlart-modalix_2.1.0_arm64.deb` contains the C++ `gst-api.h` while `2.0.0` does not.
- Ran `docker buildx build --check -f Dockerfile .` successfully.
