### PR TITLE
Make SDK sysroot setup deterministic

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -161,10 +161,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           python -m pip install --upgrade pip
-          curl -fsSL \
-            https://artifacts.sima-neat.com/tools/sima_cli-2.1.5-py3-none-any.whl \
-            -o sima_cli-2.1.5-py3-none-any.whl
-          python -m pip install ./sima_cli-2.1.5-py3-none-any.whl
+          python -m pip install sima-cli
           sima-cli version
 
       - name: Configure sima-cli access token
@@ -219,7 +216,7 @@ jobs:
           set -euo pipefail
 
           source .venv/bin/activate
-          sima-cli sdk setup -y -n
+          sima-cli sdk setup -y -n --no-model-sdk
 
       - name: Run SDK smoke test suite
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .neat-resources/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
 ARG NEAT_INSIGHT_BRANCH=main
 ARG NEAT_INSIGHT_VERSION=latest
-ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libgfortran5 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev liblapack-dev liblapack3 libopenblas-pthread-dev libopenblas0-pthread libqt5gui5 libsuperlu-dev libsuperlu5"
+ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libssl3 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
 	protobuf-compiler-grpc,\
@@ -19,9 +19,14 @@ ENV SDK_PKG_LIST="\
 ENV NEAT_INSIGHT_VENV_DIR=/opt/neat-insight/venv
 ENV NEAT_INSIGHT_PORT=9900
 ENV NEAT_INSIGHT_SUPERVISED=1
-ENV PATH="${NEAT_INSIGHT_VENV_DIR}/bin:${PATH}"
+ENV RUSTUP_HOME=/opt/toolchain/rust
+ENV CARGO_HOME=/opt/toolchain/rust
+ENV PATH="${NEAT_INSIGHT_VENV_DIR}/bin:${CARGO_HOME}/bin:${PATH}"
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
+COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
 
 RUN dpkg --add-architecture arm64 && \
     dpkg --add-architecture arc && \
@@ -38,34 +43,8 @@ RUN apt-get clean && \
       python3 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -qO - https://mirror.elxr.dev/elxr/public.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/elxr.gpg
-RUN wget -qO - https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /etc/apt/trusted.gpg.d/fluentbit.gpg
-RUN wget --no-check-certificate -O - https://repo.sima.ai/elxr/deb/simaai.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/simaai.gpg
-
-RUN chmod 644 /etc/apt/trusted.gpg.d/elxr.gpg && \
-    chmod 644 /etc/apt/trusted.gpg.d/fluentbit.gpg && \
-    chmod 644 /etc/apt/trusted.gpg.d/simaai.gpg
-
-RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/elxr.gpg] https://mirror.elxr.dev/elxr aria main" > /etc/apt/sources.list.d/elxr.list
-RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/fluentbit.gpg] https://packages.fluentbit.io/debian/bookworm bookworm main" >> /etc/apt/sources.list.d/elxr.list
-RUN echo "deb [trusted=yes] https://repo.sima.ai/elxr/deb/release bookworm non-free  # simaai repo" >> /etc/apt/sources.list.d/elxr.list
-
-RUN echo "Package: *" > /etc/apt/preferences.d/stable.pref
-RUN echo "Pin: origin \"repo.sima.ai/elxr\"" >> /etc/apt/preferences.d/stable.pref
-RUN echo "Pin-Priority: 999" >> /etc/apt/preferences.d/stable.pref
-
-# The SDK setup script also pulls package Build-Depends, many of which are
-# unversioned. Keep SiMa SDK package families on BASE_SDK_VERSION so fresh CI
-# builds do not mix newer sysroot packages into an older SDK image.
-RUN printf '%s\n' \
-      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* cvu-sw* m4-mla-* troot-* libsynopsys atf-* optee-* oot-dtbo-*' \
-      "Pin: version ${BASE_SDK_VERSION}" \
-      'Pin-Priority: 1001' \
-      '' \
-      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* cvu-sw* m4-mla-* troot-* libsynopsys atf-* optee-* oot-dtbo-*' \
-      'Pin: version *' \
-      'Pin-Priority: -1' \
-    > /etc/apt/preferences.d/simaai-sdk-version.pref
+RUN chmod 755 /usr/local/bin/configure-apt-repos.sh && \
+    configure-apt-repos.sh "${BASE_SDK_VERSION}"
 
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \
@@ -73,6 +52,7 @@ RUN apt-get update --allow-releaseinfo-change && \
       vim \
       make \
       cmake \
+      default-jre-headless \
       pkgconf \
       gcc-aarch64-linux-gnu \
       sudo \
@@ -100,225 +80,57 @@ RUN apt-get update --allow-releaseinfo-change && \
       ffmpeg \
       libffi8 \
       libmediainfo0v5 \
+      plantuml \
       supervisor \
-      mkcert \
-      simaai-sdk-tools=${BASE_SDK_VERSION} && \
+      mkcert && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN python3 - <<'PY'
-from pathlib import Path
-
-path = Path("/opt/bin/simaai_setup_sdk.py")
-data = path.read_text()
-new = '''    def get_candidate(pkgname, v):
-        """ Find the package name pkgname with
-            specific version v
-        """
-
-        if pkgname not in cache:
-            return None
-
-        sdk_package_patterns = (
-            'simaai-*',
-            'appcomplex',
-            'a65apps',
-            'evtransforms',
-            'inferencetools',
-            'vdpcli',
-            'mpktools',
-            'vdpspy',
-            'vdp-llm-libs',
-            'swsoc-*',
-            'smifb-*',
-            'cvu-sw*',
-            'm4-mla-*',
-            'troot-*',
-            'libsynopsys',
-            'atf-*',
-            'optee-*',
-            'oot-dtbo-*',
-        )
-        base_pkgname = pkgname.split(':', 1)[0]
-        is_sdk_package = any(fnmatch.fnmatch(base_pkgname, pattern) for pattern in sdk_package_patterns)
-        if is_sdk_package and not v:
-            v = version
-
-        pkg = cache[pkgname]
-        for c in pkg.versions:
-            if fnmatch.fnmatch(c.version, v):
-                return c
-        if is_sdk_package:
-            return None
-        #if no matching version found, return the default candidate
-        return pkg.candidate
-'''
-start = data.index("    def get_candidate(pkgname, v):")
-end = data.index("    def collect_rdeps(candidate, recursive):", start)
-data = data[:start] + new + "\n" + data[end:]
-new = '''    def download(uri, dlname):
-        """ Downloads the package
-        """
-
-        cmd = ["wget", uri, "-O", dlname]
-        ret = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        if ret.returncode != 0:
-            print(f"Error while downloading OSS package {dlname}:\\n{ret.stderr}")
-            return
-
-        sdk_package_patterns = (
-            'simaai-*',
-            'appcomplex',
-            'a65apps',
-            'evtransforms',
-            'inferencetools',
-            'vdpcli',
-            'mpktools',
-            'vdpspy',
-            'vdp-llm-libs',
-            'swsoc-*',
-            'smifb-*',
-            'cvu-sw*',
-            'm4-mla-*',
-            'troot-*',
-            'libsynopsys',
-            'atf-*',
-            'optee-*',
-            'oot-dtbo-*',
-        )
-        pkg = subprocess.check_output(["dpkg-deb", "-f", dlname, "Package"], text=True).strip()
-        ver = subprocess.check_output(["dpkg-deb", "-f", dlname, "Version"], text=True).strip()
-        if any(fnmatch.fnmatch(pkg, pattern) for pattern in sdk_package_patterns) and ver != version:
-            raise RuntimeError(f"Unexpected {pkg} version {ver}; expected {version}")
-
-'''
-start = data.index("    def download(uri, dlname):")
-end = data.index("    def collect_bdeps(candidate, name):", start)
-path.write_text(data[:start] + new + "\n" + data[end:])
-PY
+COPY scripts/simaai-init-build-env /opt/bin/simaai-init-build-env
+COPY scripts/simaai_setup_sdk.py /opt/bin/simaai_setup_sdk.py
+COPY scripts/install-rustup.sh /usr/local/bin/install-rustup.sh
+COPY scripts/install-sima-cli.sh /usr/local/bin/install-sima-cli.sh
+COPY scripts/setup-sdk-sysroot.sh /usr/local/bin/setup-sdk-sysroot.sh
+COPY scripts/validate-sysroot-package-versions.sh /usr/local/bin/validate-sysroot-package-versions.sh
+RUN chmod 755 /opt/bin/simaai-init-build-env \
+              /opt/bin/simaai_setup_sdk.py \
+              /usr/local/bin/install-rustup.sh \
+              /usr/local/bin/install-sima-cli.sh \
+              /usr/local/bin/setup-sdk-sysroot.sh \
+              /usr/local/bin/validate-sysroot-package-versions.sh
 
 # Ensure images expose a docker group so downstream setup scripts can
 # reliably add users with `usermod -a -G docker <user>`.
 RUN getent group docker >/dev/null || groupadd --system docker
 
-RUN if [ "${MINIMAL_IMAGE}" != "1" ]; then \
-      export RUSTUP_HOME=/opt/toolchain/rust && \
-      export CARGO_HOME=/opt/toolchain/rust && \
-      mkdir -p "${RUSTUP_HOME}" && \
-      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh && \
-      chmod 755 /tmp/rustup.sh && \
-      /tmp/rustup.sh -y --profile minimal && \
-      echo "export RUSTUP_HOME=${RUSTUP_HOME}" >> "${CARGO_HOME}/env" && \
-      echo "export CARGO_HOME=${CARGO_HOME}" >> "${CARGO_HOME}/env" && \
-      . "${CARGO_HOME}/env" && \
-      rm /tmp/rustup.sh; \
-    else \
-      echo "Skipping rustup install for minimal image build"; \
-    fi
+RUN install-rustup.sh
 
-ENV RUSTUP_HOME=/opt/toolchain/rust
-ENV CARGO_HOME=/opt/toolchain/rust
-ENV PATH=/opt/toolchain/rust/bin:${PATH}
-
-RUN if [ "${MINIMAL_IMAGE}" != "1" ]; then \
-      python3 /opt/bin/simaai_setup_sdk.py modalix "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}"; \
-      find /tmp/modalix -type f -name '*.deb' -exec sh -c ' \
-        expected="$1"; \
-        shift; \
-        for deb do \
-          pkg="$(dpkg-deb -f "${deb}" Package)"; \
-          ver="$(dpkg-deb -f "${deb}" Version)"; \
-          case "${pkg}" in \
-            simaai-*|appcomplex|a65apps|evtransforms|inferencetools|vdpcli|mpktools|vdpspy|vdp-llm-libs|swsoc-*|smifb-*|cvu-sw*|m4-mla-*|troot-*|libsynopsys|atf-*|optee-*|oot-dtbo-*) \
-              if [ "${ver}" != "${expected}" ]; then \
-                echo "Unexpected ${pkg} version ${ver}; expected ${expected}" >&2; \
-                exit 1; \
-              fi; \
-              ;; \
-          esac; \
-        done' sh "${BASE_SDK_VERSION}" {} +; \
-    else \
-      mkdir -p /opt/toolchain/aarch64/modalix/usr/include \
-               /opt/toolchain/aarch64/modalix/usr/lib \
-               /opt/toolchain/aarch64/modalix/usr/lib/pkgconfig \
-               /opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu \
-               /opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/pkgconfig \
-               /opt/toolchain/aarch64/modalix/usr/share/pkgconfig; \
-    fi && \
-    curl -fsSL https://docs.sima.ai/_static/tools/sima-cli-installer.sh | bash && \
-    test -x /root/.sima-cli/.venv/bin/sima-cli && \
-    ln -sf /root/.sima-cli/.venv/bin/sima-cli /usr/local/bin/sima-cli && \
-    /usr/local/bin/sima-cli --help >/dev/null 2>&1 && \
+RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
+    install-sima-cli.sh && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/*
 
 COPY scripts/install-sysroot-overlay.sh /usr/local/bin/install-sysroot-overlay.sh
+COPY scripts/install-sdk-sysroot-overlay.sh /usr/local/bin/install-sdk-sysroot-overlay.sh
 COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
+    chmod 755 /usr/local/bin/install-sdk-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
-    if [ "${MINIMAL_IMAGE}" != "1" ]; then \
-      /bin/bash -lc 'set -euo pipefail; \
-        overlay_pkgs=(); \
-        for pkg in ${SDK_SYSROOT_PKG_LIST}; do \
-          overlay_pkgs+=("${pkg}:arm64"); \
-        done; \
-        /usr/local/bin/install-sysroot-overlay.sh /opt/toolchain/aarch64/modalix "${overlay_pkgs[@]}"'; \
-      chmod -R a+rX /opt/toolchain/aarch64/modalix/usr/include; \
-    else \
-      echo "Skipping sysroot overlay for minimal image build"; \
-    fi
+    install-sdk-sysroot-overlay.sh
 
 RUN /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH}" "${NEAT_INSIGHT_VERSION}" && \
     chmod -R a+rwX "${NEAT_INSIGHT_VENV_DIR}"
 
-RUN cat > /etc/profile.d/neat-sdk-prompt.sh <<'EOF'
-#!/usr/bin/env bash
-if [[ $- == *i* ]]; then
-  export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-version}"
-  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-${SDK_IMAGE_TAG}}"
-  _sdk_rewrite_prompt_hostname() {
-    local prompt="${1-}"
-    prompt="${prompt//\\h/${SDK_PROMPT_HOSTNAME}}"
-    prompt="${prompt//\\H/${SDK_PROMPT_HOSTNAME}}"
-    printf '%s' "${prompt}"
-  }
-  if [[ -n "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
-    DEVKIT_SYNC_ORIG_PS1="$(_sdk_rewrite_prompt_hostname "${DEVKIT_SYNC_ORIG_PS1}")"
-    export DEVKIT_SYNC_ORIG_PS1
-  fi
-  if [[ -n "${PS1:-}" ]]; then
-    PS1="$(_sdk_rewrite_prompt_hostname "${PS1}")"
-    export PS1
-  fi
-  if declare -F __devkit_apply_prompt >/dev/null 2>&1; then
-    __devkit_apply_prompt
-  fi
-fi
-EOF
-RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh
-
-RUN cat > /etc/profile.d/pkg-config-sysroot.sh <<'EOF'
-#!/usr/bin/env bash
-export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
-if [[ -z "${PKG_CONFIG:-}" || ! -x "${PKG_CONFIG}" ]]; then
-  export PKG_CONFIG="/usr/bin/pkg-config"
-fi
-if [[ -z "${PKG_CONFIG_EXECUTABLE:-}" || ! -x "${PKG_CONFIG_EXECUTABLE}" ]]; then
-  export PKG_CONFIG_EXECUTABLE="${PKG_CONFIG}"
-fi
-export PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:-$SYSROOT}"
-export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:-$SYSROOT/usr/lib/aarch64-linux-gnu/pkgconfig:$SYSROOT/usr/lib/pkgconfig:$SYSROOT/usr/share/pkgconfig}"
-unset PKG_CONFIG_PATH || true
-export LDFLAGS="--sysroot=$SYSROOT -L$SYSROOT/usr/lib/aarch64-linux-gnu -L$SYSROOT/lib/aarch64-linux-gnu ${LDFLAGS:-}"
-EOF
-RUN chmod 755 /etc/profile.d/pkg-config-sysroot.sh
+COPY config/profile.d/*.sh /etc/profile.d/
+RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
+              /etc/profile.d/pkg-config-sysroot.sh
 
 RUN printf 'SDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
     "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
@@ -328,22 +140,10 @@ RUN printf 'SDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_n
 WORKDIR /workspace
 
 # Preinstall Neat Framework and resources
+COPY scripts/install-neat-resources.sh /usr/local/bin/install-neat-resources.sh
+RUN chmod 755 /usr/local/bin/install-neat-resources.sh
 RUN --mount=type=secret,id=neat_github_pat \
-    mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src && \
-    wget -O /tmp/install-neat.sh https://tools.sima-neat.com/install-neat.sh && \
-    cd /neat-resources/core-extra && \
-    bash /tmp/install-neat.sh --minimum "${NEAT_BRANCH}" "${NEAT_VERSION}" && \
-    rm -f /tmp/install-neat.sh && \
-    find /neat-resources/core-extra -type f \
-      \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.whl' \) -delete && \
-    if [ -f /run/secrets/neat_github_pat ] && [ -s /run/secrets/neat_github_pat ]; then \
-      NEAT_GITHUB_PAT="$(cat /run/secrets/neat_github_pat)" && \
-      git clone --depth 1 "https://${NEAT_GITHUB_PAT}@github.com/sima-neat/core.git" /neat-resources/core-src && \
-      git -C /neat-resources/core-src remote set-url origin https://github.com/sima-neat/core.git; \
-    else \
-      echo "Skipping sima-neat/core clone; neat_github_pat build secret not provided"; \
-    fi && \
-    git clone --depth 1 https://github.com/sima-neat/apps.git /neat-resources/apps-src
+    install-neat-resources.sh
 
 # Expose required ports
 EXPOSE 9900 9000-9079 9100-9179 8081 8554

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,17 @@ RUN echo "Package: *" > /etc/apt/preferences.d/stable.pref
 RUN echo "Pin: origin \"repo.sima.ai/elxr\"" >> /etc/apt/preferences.d/stable.pref
 RUN echo "Pin-Priority: 999" >> /etc/apt/preferences.d/stable.pref
 
-# The SiMa palette package has loose dependencies. Keep SDK-versioned packages
-# on BASE_SDK_VERSION so fresh CI builds do not mix newer sysroot packages into
-# an older SDK image when repo.sima.ai publishes a later release.
+# The SDK setup script also pulls package Build-Depends, many of which are
+# unversioned. Keep SiMa SDK package families on BASE_SDK_VERSION so fresh CI
+# builds do not mix newer sysroot packages into an older SDK image.
 RUN printf '%s\n' \
-      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* libcamera libcamera-tools' \
+      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* cvu-sw* m4-mla-* troot-* libsynopsys atf-* optee-* oot-dtbo-*' \
       "Pin: version ${BASE_SDK_VERSION}" \
       'Pin-Priority: 1001' \
+      '' \
+      'Package: simaai-* appcomplex a65apps evtransforms inferencetools vdpcli mpktools vdpspy vdp-llm-libs swsoc-* smifb-* cvu-sw* m4-mla-* troot-* libsynopsys atf-* optee-* oot-dtbo-*' \
+      'Pin: version *' \
+      'Pin-Priority: -1' \
     > /etc/apt/preferences.d/simaai-sdk-version.pref
 
 RUN apt-get update --allow-releaseinfo-change && \
@@ -102,6 +106,97 @@ RUN apt-get update --allow-releaseinfo-change && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN python3 - <<'PY'
+from pathlib import Path
+
+path = Path("/opt/bin/simaai_setup_sdk.py")
+data = path.read_text()
+new = '''    def get_candidate(pkgname, v):
+        """ Find the package name pkgname with
+            specific version v
+        """
+
+        if pkgname not in cache:
+            return None
+
+        sdk_package_patterns = (
+            'simaai-*',
+            'appcomplex',
+            'a65apps',
+            'evtransforms',
+            'inferencetools',
+            'vdpcli',
+            'mpktools',
+            'vdpspy',
+            'vdp-llm-libs',
+            'swsoc-*',
+            'smifb-*',
+            'cvu-sw*',
+            'm4-mla-*',
+            'troot-*',
+            'libsynopsys',
+            'atf-*',
+            'optee-*',
+            'oot-dtbo-*',
+        )
+        base_pkgname = pkgname.split(':', 1)[0]
+        is_sdk_package = any(fnmatch.fnmatch(base_pkgname, pattern) for pattern in sdk_package_patterns)
+        if is_sdk_package and not v:
+            v = version
+
+        pkg = cache[pkgname]
+        for c in pkg.versions:
+            if fnmatch.fnmatch(c.version, v):
+                return c
+        if is_sdk_package:
+            return None
+        #if no matching version found, return the default candidate
+        return pkg.candidate
+'''
+start = data.index("    def get_candidate(pkgname, v):")
+end = data.index("    def collect_rdeps(candidate, recursive):", start)
+data = data[:start] + new + "\n" + data[end:]
+new = '''    def download(uri, dlname):
+        """ Downloads the package
+        """
+
+        cmd = ["wget", uri, "-O", dlname]
+        ret = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        if ret.returncode != 0:
+            print(f"Error while downloading OSS package {dlname}:\\n{ret.stderr}")
+            return
+
+        sdk_package_patterns = (
+            'simaai-*',
+            'appcomplex',
+            'a65apps',
+            'evtransforms',
+            'inferencetools',
+            'vdpcli',
+            'mpktools',
+            'vdpspy',
+            'vdp-llm-libs',
+            'swsoc-*',
+            'smifb-*',
+            'cvu-sw*',
+            'm4-mla-*',
+            'troot-*',
+            'libsynopsys',
+            'atf-*',
+            'optee-*',
+            'oot-dtbo-*',
+        )
+        pkg = subprocess.check_output(["dpkg-deb", "-f", dlname, "Package"], text=True).strip()
+        ver = subprocess.check_output(["dpkg-deb", "-f", dlname, "Version"], text=True).strip()
+        if any(fnmatch.fnmatch(pkg, pattern) for pattern in sdk_package_patterns) and ver != version:
+            raise RuntimeError(f"Unexpected {pkg} version {ver}; expected {version}")
+
+'''
+start = data.index("    def download(uri, dlname):")
+end = data.index("    def collect_bdeps(candidate, name):", start)
+path.write_text(data[:start] + new + "\n" + data[end:])
+PY
+
 # Ensure images expose a docker group so downstream setup scripts can
 # reliably add users with `usermod -a -G docker <user>`.
 RUN getent group docker >/dev/null || groupadd --system docker
@@ -127,6 +222,21 @@ ENV PATH=/opt/toolchain/rust/bin:${PATH}
 
 RUN if [ "${MINIMAL_IMAGE}" != "1" ]; then \
       python3 /opt/bin/simaai_setup_sdk.py modalix "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}"; \
+      find /tmp/modalix -type f -name '*.deb' -exec sh -c ' \
+        expected="$1"; \
+        shift; \
+        for deb do \
+          pkg="$(dpkg-deb -f "${deb}" Package)"; \
+          ver="$(dpkg-deb -f "${deb}" Version)"; \
+          case "${pkg}" in \
+            simaai-*|appcomplex|a65apps|evtransforms|inferencetools|vdpcli|mpktools|vdpspy|vdp-llm-libs|swsoc-*|smifb-*|cvu-sw*|m4-mla-*|troot-*|libsynopsys|atf-*|optee-*|oot-dtbo-*) \
+              if [ "${ver}" != "${expected}" ]; then \
+                echo "Unexpected ${pkg} version ${ver}; expected ${expected}" >&2; \
+                exit 1; \
+              fi; \
+              ;; \
+          esac; \
+        done' sh "${BASE_SDK_VERSION}" {} +; \
     else \
       mkdir -p /opt/toolchain/aarch64/modalix/usr/include \
                /opt/toolchain/aarch64/modalix/usr/lib \

--- a/config/platform-package-patterns.txt
+++ b/config/platform-package-patterns.txt
@@ -1,0 +1,19 @@
+# SiMa platform-owned packages that must match BASE_SDK_VERSION.
+simaai-*
+appcomplex
+a65apps
+evtransforms
+inferencetools
+vdpcli
+mpktools
+vdpspy
+vdp-llm-libs
+swsoc-*
+smifb-*
+cvu-sw*
+m4-mla-*
+troot-*
+libsynopsys
+atf-*
+optee-*
+oot-dtbo-*

--- a/config/profile.d/neat-sdk-prompt.sh
+++ b/config/profile.d/neat-sdk-prompt.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+if [[ $- == *i* ]]; then
+  export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-version}"
+  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-${SDK_IMAGE_TAG}}"
+  _sdk_rewrite_prompt_hostname() {
+    local prompt="${1-}"
+    prompt="${prompt//\\h/${SDK_PROMPT_HOSTNAME}}"
+    prompt="${prompt//\\H/${SDK_PROMPT_HOSTNAME}}"
+    printf '%s' "${prompt}"
+  }
+  if [[ -n "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
+    DEVKIT_SYNC_ORIG_PS1="$(_sdk_rewrite_prompt_hostname "${DEVKIT_SYNC_ORIG_PS1}")"
+    export DEVKIT_SYNC_ORIG_PS1
+  fi
+  if [[ -n "${PS1:-}" ]]; then
+    PS1="$(_sdk_rewrite_prompt_hostname "${PS1}")"
+    export PS1
+  fi
+  if declare -F __devkit_apply_prompt >/dev/null 2>&1; then
+    __devkit_apply_prompt
+  fi
+fi

--- a/config/profile.d/pkg-config-sysroot.sh
+++ b/config/profile.d/pkg-config-sysroot.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
+if [[ -z "${PKG_CONFIG:-}" || ! -x "${PKG_CONFIG}" ]]; then
+  export PKG_CONFIG="/usr/bin/pkg-config"
+fi
+if [[ -z "${PKG_CONFIG_EXECUTABLE:-}" || ! -x "${PKG_CONFIG_EXECUTABLE}" ]]; then
+  export PKG_CONFIG_EXECUTABLE="${PKG_CONFIG}"
+fi
+export PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:-$SYSROOT}"
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:-$SYSROOT/usr/lib/aarch64-linux-gnu/pkgconfig:$SYSROOT/usr/lib/pkgconfig:$SYSROOT/usr/share/pkgconfig}"
+unset PKG_CONFIG_PATH || true
+export LDFLAGS="--sysroot=$SYSROOT -L$SYSROOT/usr/lib/aarch64-linux-gnu -L$SYSROOT/lib/aarch64-linux-gnu ${LDFLAGS:-}"

--- a/scripts/configure-apt-repos.sh
+++ b/scripts/configure-apt-repos.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_sdk_version="${1:?Usage: configure-apt-repos.sh BASE_SDK_VERSION [PATTERNS_FILE]}"
+patterns_file="${2:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
+
+if [[ ! -f "${patterns_file}" ]]; then
+  echo "Platform package patterns file not found: ${patterns_file}" >&2
+  exit 1
+fi
+
+wget -qO - https://mirror.elxr.dev/elxr/public.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/elxr.gpg
+wget -qO - https://packages.fluentbit.io/fluentbit.key | gpg --dearmor > /etc/apt/trusted.gpg.d/fluentbit.gpg
+wget --no-check-certificate -O - https://repo.sima.ai/elxr/deb/simaai.gpg | gpg --dearmor > /etc/apt/trusted.gpg.d/simaai.gpg
+
+chmod 644 /etc/apt/trusted.gpg.d/elxr.gpg \
+          /etc/apt/trusted.gpg.d/fluentbit.gpg \
+          /etc/apt/trusted.gpg.d/simaai.gpg
+
+cat > /etc/apt/sources.list.d/elxr.list <<'EOF'
+deb [signed-by=/etc/apt/trusted.gpg.d/elxr.gpg] https://mirror.elxr.dev/elxr aria main
+deb [signed-by=/etc/apt/trusted.gpg.d/fluentbit.gpg] https://packages.fluentbit.io/debian/bookworm bookworm main
+deb [trusted=yes] https://repo.sima.ai/elxr/deb/release bookworm non-free  # simaai repo
+EOF
+
+cat > /etc/apt/preferences.d/stable.pref <<'EOF'
+Package: *
+Pin: origin "repo.sima.ai/elxr"
+Pin-Priority: 999
+EOF
+
+platform_packages="$(
+  sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${patterns_file}" |
+    tr '\n' ' ' |
+    sed 's/[[:space:]]*$//'
+)"
+
+cat > /etc/apt/preferences.d/simaai-sdk-version.pref <<EOF
+Package: ${platform_packages}
+Pin: version ${base_sdk_version}
+Pin-Priority: 1001
+
+Package: ${platform_packages}
+Pin: version *
+Pin-Priority: -1
+EOF

--- a/scripts/install-neat-resources.sh
+++ b/scripts/install-neat-resources.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src
+
+wget -O /tmp/install-neat.sh https://tools.sima-neat.com/install-neat.sh
+(
+  cd /neat-resources/core-extra
+  bash /tmp/install-neat.sh --minimum "${NEAT_BRANCH:-main}" "${NEAT_VERSION:-latest}"
+)
+rm -f /tmp/install-neat.sh
+
+find /neat-resources/core-extra -type f \
+  \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.whl' \) -delete
+
+if [[ -f /run/secrets/neat_github_pat && -s /run/secrets/neat_github_pat ]]; then
+  NEAT_GITHUB_PAT="$(cat /run/secrets/neat_github_pat)"
+  git clone --depth 1 "https://${NEAT_GITHUB_PAT}@github.com/sima-neat/core.git" /neat-resources/core-src
+  git -C /neat-resources/core-src remote set-url origin https://github.com/sima-neat/core.git
+else
+  echo "Skipping sima-neat/core clone; neat_github_pat build secret not provided"
+fi
+
+git clone --depth 1 https://github.com/sima-neat/apps.git /neat-resources/apps-src
+
+chown -R root:root /neat-resources
+chmod -R go-w /neat-resources

--- a/scripts/install-rustup.sh
+++ b/scripts/install-rustup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
+  echo "Skipping rustup install for minimal image build"
+  exit 0
+fi
+
+export RUSTUP_HOME=/opt/toolchain/rust
+export CARGO_HOME=/opt/toolchain/rust
+
+mkdir -p "${RUSTUP_HOME}"
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh
+chmod 755 /tmp/rustup.sh
+/tmp/rustup.sh -y --profile minimal
+. "${CARGO_HOME}/env"
+rustup target add aarch64-unknown-linux-gnu
+{
+  echo "export RUSTUP_HOME=${RUSTUP_HOME}"
+  echo "export CARGO_HOME=${CARGO_HOME}"
+} >> "${CARGO_HOME}/env"
+rm /tmp/rustup.sh

--- a/scripts/install-sdk-sysroot-overlay.sh
+++ b/scripts/install-sdk-sysroot-overlay.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
+  echo "Skipping sysroot overlay for minimal image build"
+  exit 0
+fi
+
+overlay_pkgs=()
+for pkg in ${SDK_SYSROOT_PKG_LIST:-}; do
+  overlay_pkgs+=("${pkg}:arm64")
+done
+
+/usr/local/bin/install-sysroot-overlay.sh /opt/toolchain/aarch64/modalix "${overlay_pkgs[@]}"
+chmod -R a+rX /opt/toolchain/aarch64/modalix/usr/include

--- a/scripts/install-sima-cli.sh
+++ b/scripts/install-sima-cli.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+curl -fsSL https://docs.sima.ai/_static/tools/sima-cli-installer.sh | bash
+test -x /root/.sima-cli/.venv/bin/sima-cli
+ln -sf /root/.sima-cli/.venv/bin/sima-cli /usr/local/bin/sima-cli
+/usr/local/bin/sima-cli --help >/dev/null 2>&1

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -104,6 +104,7 @@ fi
 
 apt-get update --allow-releaseinfo-change
 apt-get install -y --download-only --no-install-recommends \
+  --reinstall \
   -o Dir::Cache::archives="${workdir}/archives" \
   "${PACKAGES[@]}"
 
@@ -166,6 +167,20 @@ fi
 if [[ -e "${LIBDIR}/libopenblas.so.0" && ! -e "${LIBDIR}/libopenblas.so" ]]; then
   ln -sfn libopenblas.so.0 "${LIBDIR}/libopenblas.so"
 fi
+
+find "${SYSROOT}" -type l -print0 \
+  | while IFS= read -r -d '' link; do
+      target="$(readlink "${link}")"
+      case "${target}" in
+        /usr/*|/lib/*)
+          sysroot_target="${SYSROOT}${target}"
+          if [[ -e "${sysroot_target}" ]]; then
+            rel_target="$(realpath --relative-to="$(dirname "${link}")" "${sysroot_target}")"
+            ln -sfn "${rel_target}" "${link}"
+          fi
+          ;;
+      esac
+    done
 
 if [[ -d "${SYSROOT}/usr/include" ]]; then
   chmod -R a+rX "${SYSROOT}/usr/include"

--- a/scripts/setup-sdk-sysroot.sh
+++ b/scripts/setup-sdk-sysroot.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_sdk_version="${1:?Usage: setup-sdk-sysroot.sh BASE_SDK_VERSION SDK_PKG_LIST}"
+sdk_pkg_list="${2:-}"
+
+if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
+  mkdir -p /opt/toolchain/aarch64/modalix/usr/include \
+           /opt/toolchain/aarch64/modalix/usr/lib \
+           /opt/toolchain/aarch64/modalix/usr/lib/pkgconfig \
+           /opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu \
+           /opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/pkgconfig \
+           /opt/toolchain/aarch64/modalix/usr/share/pkgconfig
+  exit 0
+fi
+
+python3 /opt/bin/simaai_setup_sdk.py modalix "${base_sdk_version}" "${sdk_pkg_list}"
+validate-sysroot-package-versions.sh "${base_sdk_version}" /tmp/modalix /opt/toolchain/aarch64/modalix

--- a/scripts/simaai-init-build-env
+++ b/scripts/simaai-init-build-env
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# SiMa.ai Application Build Environment Setup Script
+# Copyright (c) 2025 SiMa Techonlofies, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+BOARD=$1
+
+    if [ "${BOARD}" = "davinci" ]; then
+	echo "Setting up build environment for davinci..."
+
+	export CFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/davinci"
+	export CXXFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/davinci"
+	export CPPFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/davinci"
+	export SYSROOT="/opt/toolchain/aarch64/davinci"
+elif [ "${BOARD}" = "modalix" ]; then
+	echo "Setting up build environment for modalix..."
+	export CFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/modalix"
+	export CXXFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/modalix"
+	export CPPFLAGS="-mcpu=cortex-a65 -march=armv8.2-a+crypto -mbranch-protection=standard -mabi=lp64 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -O2 -pipe --sysroot=/opt/toolchain/aarch64/modalix"
+	export SYSROOT="/opt/toolchain/aarch64/modalix"
+else
+	echo "Usage: source simaai-init-build-env <modalix|davinci>"
+fi
+
+export CROSS_COMPILE="aarch64-linux-gnu-"
+export CC="${CROSS_COMPILE}gcc"
+export CXX="${CROSS_COMPILE}g++"
+export LD="${CROSS_COMPILE}ld"
+export STRIP="${CROSS_COMPILE}strip"
+export OBJDUMP="${CROSS_COMPILE}objdump"
+export OBJCOPY="${CROSS_COMPILE}objcopy"
+export AR="${CROSS_COMPILE}ar"
+export LDFLAGS="--sysroot=${SYSROOT} -L${SYSROOT}/usr/lib/aarch64-linux-gnu -L${SYSROOT}/lib/aarch64-linux-gnu -L${SYSROOT}/usr/lib/aarch64-linux-gnu/blas -L${SYSROOT}/usr/lib/aarch64-linux-gnu/lapack -L${SYSROOT}/usr/lib/aarch64-linux-gnu/openblas-pthread -Wl,-rpath-link,${SYSROOT}/usr/lib/aarch64-linux-gnu -Wl,-rpath-link,${SYSROOT}/lib/aarch64-linux-gnu -Wl,-rpath-link,${SYSROOT}/usr/lib/aarch64-linux-gnu/blas -Wl,-rpath-link,${SYSROOT}/usr/lib/aarch64-linux-gnu/lapack -Wl,-rpath-link,${SYSROOT}/usr/lib/aarch64-linux-gnu/openblas-pthread -Wl,--allow-shlib-undefined"
+export PKG_CONFIG_LIBDIR="${SYSROOT}/usr/lib/aarch64-linux-gnu/pkgconfig:${SYSROOT}/usr/lib/pkgconfig:${SYSROOT}/usr/share/pkgconfig"
+unset PKG_CONFIG_PATH
+export CFLAGS="${CFLAGS} -I${SYSROOT}/usr/include -I${SYSROOT}/usr/include/simaai"
+export CXXFLAGS="${CXXFLAGS} -I${SYSROOT}/usr/include -I${SYSROOT}/usr/include/simaai"
+export CPPFLAGS="${CPPFLAGS} -I${SYSROOT}/usr/include -I${SYSROOT}/usr/include/simaai"
+export CMAKE_LIBRARY_PATH="${SYSROOT}/usr/lib:${SYSROOT}/usr/lib/aarch64-linux-gnu:${SYSROOT}/usr/lib/aarch64-linux-gnu/blas:${SYSROOT}/usr/lib/aarch64-linux-gnu/lapack"
+export OpenCV_DIR="${SYSROOT}/usr/lib/aarch64-linux-gnu/cmake/opencv4"
+export CODEC_INCLUDE_DIRS="${SYSROOT}/usr/include/simaai/codec"
+export RUSTUP_HOME=/opt/toolchain/rust
+export CARGO_HOME=/opt/toolchain/rust
+export PATH=/opt/toolchain/rust/bin:${PATH}

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -1,0 +1,443 @@
+"""
+Copyright (c) 2025 SiMa Technologies, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+
+Vendored from simaai-sdk-tools 2.0.0.
+
+Local SDK image changes:
+- Resolve platform-owned packages to the requested platform version when a
+  dependency is unversioned.
+- Never fall back to the newest candidate for platform-owned packages.
+- Validate downloaded platform-owned packages before extraction.
+- Keep extraction deterministic and extract platform-owned packages after
+  generic build dependencies.
+- Skip libdlpack-dev because the SiMa TVM package owns the compatible
+  dlpack/dlpack.h header in this sysroot.
+"""
+
+import apt
+import fnmatch
+import glob
+import os
+import shutil
+import subprocess
+import sys
+
+
+DEFAULT_PLATFORM_PACKAGE_PATTERNS = (
+    "simaai-*",
+    "appcomplex",
+    "a65apps",
+    "evtransforms",
+    "inferencetools",
+    "vdpcli",
+    "mpktools",
+    "vdpspy",
+    "vdp-llm-libs",
+    "swsoc-*",
+    "smifb-*",
+    "cvu-sw*",
+    "m4-mla-*",
+    "troot-*",
+    "libsynopsys",
+    "atf-*",
+    "optee-*",
+    "oot-dtbo-*",
+)
+
+# TVM is SDK-owned, but its package version is not the platform version
+# (for example, Modalix 2.0 uses tvm 1.4.0). Extract it after generic build
+# dependencies so its bundled dlpack header remains paired with TVM headers.
+SDK_OWNED_NON_PLATFORM_PACKAGES = {
+    "tvm",
+    "python3-tvm",
+}
+
+SKIP_PACKAGES = {
+    "libdlpack-dev",
+}
+
+
+def load_platform_package_patterns():
+    patterns_file = os.environ.get(
+        "PLATFORM_PACKAGE_PATTERNS_FILE",
+        "/usr/local/share/sima-sdk/platform-package-patterns.txt",
+    )
+    if not os.path.exists(patterns_file):
+        return DEFAULT_PLATFORM_PACKAGE_PATTERNS
+
+    patterns = []
+    with open(patterns_file, "rt", encoding="utf-8") as rf:
+        for line in rf:
+            item = line.split("#", 1)[0].strip()
+            if item:
+                patterns.append(item)
+
+    return tuple(patterns) or DEFAULT_PLATFORM_PACKAGE_PATTERNS
+
+
+PLATFORM_PACKAGE_PATTERNS = load_platform_package_patterns()
+
+
+def usage():
+    print("Usage: python3 simaai_setup_sdk.py <platform> <palette-version> <libc-version> <whitelist>")
+    print("where:")
+    print("\tplatform        = SiMa.ai platform name e.g. modalix")
+    print("\tpalette-version = SiMa.ai palette package version string e.g. 2.0.0*")
+    print("\tlibc-version    = Version string of libc headers e.g. 6.1.22-modalix-485")
+    print("\twhitelist       = Comma separated list of additional packages e.g. libgrpc-dev,protobuf-compiler-grpc")
+
+
+def base_package_name(pkgname):
+    return pkgname.split(":", 1)[0]
+
+
+def is_platform_package(pkgname):
+    base = base_package_name(pkgname)
+    return any(fnmatch.fnmatch(base, pattern) for pattern in PLATFORM_PACKAGE_PATTERNS)
+
+
+def normalize_arm64_name(pkgname):
+    if ":" in pkgname:
+        return pkgname
+    return f"{pkgname}:arm64"
+
+
+def package_field(deb_path, field):
+    return subprocess.check_output(["dpkg-deb", "-f", deb_path, field], text=True).strip()
+
+
+def main(pkg_name, version, libc_ver, dldir, installdir):
+    # packages that are to be ignored
+    blacklist = {
+        "m4-mla-modalix:armhf": "",
+        "m4-mla-davinci:armhf": "",
+        "c++-compiler:arm64": "",
+        "cvu-sw:arc": "",
+        "binutils:arm64": "",
+        "g++:arm64": "",
+        "gcc:arm64": "",
+        "smifb3-modalix": "",
+        "smifb3-davinci": "",
+        "simaai-pcie-drv-modalix": "",
+        "simaai-pcie-drv-davinci": "",
+        "lttng-modules-modalix": "",
+        "lttng-modules-davinci": "",
+    }
+
+    def get_build_depends_list(deb_file_path):
+        """Extract the package names from the Build-Depends tag."""
+
+        result = subprocess.run(
+            ["dpkg-deb", "-I", deb_file_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"dpkg-deb failed: {result.stderr}")
+
+        formatted_line = ""
+
+        for line in result.stdout.splitlines():
+            if line.startswith(" "):
+                formatted_line += "#" + line.strip()
+            elif line.startswith("\t"):
+                formatted_line += " " + line.strip()
+
+        _, _, val = formatted_line.partition("#Build-Depends:")
+        if val:
+            dep_str = val.strip().split("#")[0]
+            return [d.strip() for d in dep_str.split(",")]
+
+        return []
+
+    def get_candidate(pkgname, requested_version):
+        """Find a package candidate, enforcing platform-version determinism."""
+
+        base = base_package_name(pkgname)
+        if base in SKIP_PACKAGES:
+            print(f"Skipping {pkgname}; SDK-owned package provides the required files")
+            return None
+
+        if pkgname not in cache:
+            return None
+
+        if is_platform_package(pkgname) and not requested_version:
+            requested_version = version
+
+        pkg = cache[pkgname]
+        if requested_version:
+            for candidate in pkg.versions:
+                if fnmatch.fnmatch(candidate.version, requested_version):
+                    return candidate
+            if is_platform_package(pkgname):
+                print(f"Skipping {pkgname}; no candidate matches platform version {version}")
+                return None
+            return None
+
+        return pkg.candidate
+
+    def collect_rdeps(candidate, recursive):
+        """Collect the runtime dependencies of the package."""
+
+        if candidate is None:
+            return
+
+        for dep_list in candidate.get_dependencies("Depends"):
+            for dep in dep_list:
+                name = normalize_arm64_name(dep.name)
+
+                dep_str = str(dep)
+                if "=" in dep_str:
+                    ver = dep_str.split("=")[1].strip()
+                else:
+                    ver = ""
+
+                if name in blacklist:
+                    continue
+
+                if name in graph:
+                    continue
+
+                graph[name] = ver
+                if recursive:
+                    collect_rdeps(get_candidate(name, ver), recursive)
+
+    def download(uri, dlname):
+        """Download a package and validate platform-owned versions."""
+
+        cmd = ["wget", uri, "-O", dlname]
+        ret = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        if ret.returncode != 0:
+            print(f"Error while downloading OSS package {dlname}:\n{ret.stderr}")
+            return
+
+        pkg = package_field(dlname, "Package")
+        ver = package_field(dlname, "Version")
+        if is_platform_package(pkg) and ver != version:
+            raise RuntimeError(f"Unexpected {pkg} version {ver}; expected {version}")
+
+    def collect_bdeps(candidate, name):
+        """Collect the build-time dependencies."""
+
+        if candidate is None:
+            return
+
+        dlname = dldir + "/" + name + ".deb"
+        # Need to download the package first to run dpkg-deb and find build
+        # dependencies.
+        download(candidate.uri, dlname)
+
+        bdep_list = get_build_depends_list(dlname)
+
+        if bdep_list:
+            for bdep in bdep_list:
+                if not bdep:
+                    continue
+                if bdep in graph or bdep in shadow or bdep in blacklist:
+                    continue
+                ver = ""
+                shadow[bdep] = ver
+                collect_bdeps(get_candidate(bdep, ver), bdep)
+
+    def extract(filename):
+        """Extract a package into the sysroot."""
+
+        deb_path = dldir + "/" + filename
+        dpkg = subprocess.Popen(
+            ["dpkg-deb", "--fsys-tarfile", deb_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+        )
+        tar = subprocess.run(
+            [
+                "tar",
+                "-x",
+                "-C",
+                installdir,
+                "--exclude=./usr/share/doc/*",
+                "--exclude=./usr/share/man/*",
+                "--exclude=./usr/share/lintian/*",
+                "--exclude=./usr/share/locale/*",
+            ],
+            stdin=dpkg.stdout,
+            capture_output=True,
+            text=True,
+        )
+        if dpkg.stdout is not None:
+            dpkg.stdout.close()
+        dpkg_stderr = dpkg.stderr.read() if dpkg.stderr is not None else b""
+        dpkg_returncode = dpkg.wait()
+
+        if dpkg_returncode != 0 or tar.returncode != 0:
+            stderr = ""
+            if dpkg_stderr:
+                stderr += dpkg_stderr.decode("utf-8", errors="replace")
+            stderr += tar.stderr
+            raise RuntimeError(
+                f"Error while extracting OSS package {filename}:\n{stderr}"
+            )
+
+    def tweak_conf(files, old, new):
+        for f in glob.glob(files):
+            if os.path.islink(f):
+                target = os.readlink(f)
+                if target.startswith("/usr"):
+                    sysroot_target = installdir + target
+                    if os.path.exists(sysroot_target):
+                        os.unlink(f)
+                        os.symlink(sysroot_target, f)
+
+            if not os.path.exists(f):
+                print(f"Skipping stale config symlink {f}")
+                continue
+
+            with open(f, "rt", encoding="utf-8") as rf:
+                data = rf.read()
+                data = data.replace(old, new)
+            with open(f, "wt", encoding="utf-8") as wf:
+                wf.write(data)
+
+    def process_whitelist():
+        for item in whitelist:
+            if not item or item == ":arm64":
+                continue
+            if item in graph:
+                continue
+
+            graph[item] = ""
+            c = get_candidate(item, "")
+            if c is not None:
+                collect_rdeps(c, True)
+
+    def extraction_sort_key(filename):
+        deb_path = os.path.join(dldir, filename)
+        pkg = package_field(deb_path, "Package")
+        if base_package_name(pkg) in SDK_OWNED_NON_PLATFORM_PACKAGES:
+            priority = 2
+        elif is_platform_package(pkg):
+            priority = 1
+        else:
+            priority = 0
+        return (priority, pkg, filename)
+
+    def validate_tvm_dlpack_header():
+        header = os.path.join(installdir, "usr/include/dlpack/dlpack.h")
+        if not os.path.exists(header):
+            return
+        with open(header, "rt", encoding="utf-8") as rf:
+            data = rf.read()
+        missing = [
+            name
+            for name in ("kDLOneAPI", "kDLWebGPU", "kDLHexagon")
+            if name not in data
+        ]
+        if missing:
+            raise RuntimeError(
+                f"{header} is incompatible with TVM headers; missing {', '.join(missing)}"
+            )
+
+    print("Updating cache...")
+    cache = apt.Cache()
+    cache.update()
+    cache.open(None)
+
+    if pkg_name not in cache:
+        print(f"Package {pkg_name} not found!")
+        return
+
+    c_palette = get_candidate(pkg_name, version)
+    if c_palette is None:
+        raise RuntimeError(f"No {pkg_name} candidate matches platform version {version}")
+    print(f"Using {pkg_name} = {c_palette.version}")
+
+    graph = {}
+    # first get all rdeps of palette only
+    collect_rdeps(c_palette, False)
+
+    # need a shadow copy to iterate over
+    shadow = graph.copy()
+
+    print("Collecting runtime dependencies...")
+    for name, ver in shadow.items():
+        collect_rdeps(get_candidate(name, ver), True)
+
+    process_whitelist()
+    # fix linux-libc-dev version
+    graph["linux-libc-dev:arm64"] = libc_ver
+
+    shadow.clear()
+    shutil.rmtree(dldir, ignore_errors=True)
+    os.makedirs(dldir, exist_ok=True)
+
+    print("Collecting buildtime dependencies...")
+    for name, ver in graph.items():
+        collect_bdeps(get_candidate(name, ver), name)
+
+    full = graph.copy()
+    full.update(shadow)
+    graph.clear()
+
+    for name, ver in shadow.items():
+        collect_rdeps(get_candidate(name, ver), True)
+
+    full.update(graph)
+
+    for name, ver in graph.items():
+        c = get_candidate(name, ver)
+        if c is not None:
+            download(c.uri, dldir + "/" + name + ".deb")
+
+    os.makedirs(installdir, exist_ok=True)
+
+    print("Setting up sysroot...")
+    deb_files = [
+        filename
+        for filename in os.listdir(dldir)
+        if os.path.isfile(os.path.join(dldir, filename)) and filename.endswith(".deb")
+    ]
+    for filename in sorted(deb_files, key=extraction_sort_key):
+        extract(filename)
+
+    validate_tvm_dlpack_header()
+
+    pcpath = "usr/lib/aarch64-linux-gnu/pkgconfig/"
+    tweak_conf(installdir + "/" + pcpath + "*.pc", "=/usr", "=" + installdir + "/usr")
+
+    cmakeconfpath = "usr/lib/aarch64-linux-gnu/cmake/"
+    tweak_conf(installdir + "/" + cmakeconfpath + "*/*.cmake", "/usr", installdir + "/usr")
+
+    print("SDK deployment completed!")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        usage()
+        sys.exit(1)
+
+    platform = sys.argv[1]
+    palette_ver = sys.argv[2]
+    libc_ver = sys.argv[3]
+
+    if platform != "modalix" and platform != "davinci":
+        usage()
+        sys.exit(1)
+
+    if len(sys.argv) > 4:
+        whitelist = [
+            f"{item.strip()}:arm64"
+            for item in sys.argv[4].split(",")
+            if item.strip()
+        ]
+    else:
+        whitelist = []
+
+    pkg_name = f"simaai-palette-{platform}:arm64"
+    installdir = f"/opt/toolchain/aarch64/{platform}"
+    dldir = f"/tmp/{platform}"
+
+    main(pkg_name, palette_ver, libc_ver, dldir, installdir)

--- a/scripts/validate-sysroot-package-versions.sh
+++ b/scripts/validate-sysroot-package-versions.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") EXPECTED_VERSION DEB_DIR [SYSROOT]" >&2
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
+  exit 2
+fi
+
+expected_version="$1"
+deb_dir="$2"
+sysroot="${3:-}"
+patterns_file="${PLATFORM_PACKAGE_PATTERNS_FILE:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
+
+if [[ ! -d "${deb_dir}" ]]; then
+  echo "Package download directory not found: ${deb_dir}" >&2
+  exit 1
+fi
+
+platform_package_patterns=(
+  simaai-*
+  appcomplex
+  a65apps
+  evtransforms
+  inferencetools
+  vdpcli
+  mpktools
+  vdpspy
+  vdp-llm-libs
+  swsoc-*
+  smifb-*
+  cvu-sw*
+  m4-mla-*
+  troot-*
+  libsynopsys
+  atf-*
+  optee-*
+  oot-dtbo-*
+)
+
+if [[ -f "${patterns_file}" ]]; then
+  platform_package_patterns=()
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    if [[ -n "${line}" ]]; then
+      platform_package_patterns+=("${line}")
+    fi
+  done < "${patterns_file}"
+fi
+
+is_platform_package() {
+  local base="${1%%:*}"
+  local pattern
+  for pattern in "${platform_package_patterns[@]}"; do
+    if [[ "${base}" == ${pattern} ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+errors=0
+deb_count=0
+
+while IFS= read -r -d '' deb; do
+  deb_count=$((deb_count + 1))
+  pkg="$(dpkg-deb -f "${deb}" Package)"
+  ver="$(dpkg-deb -f "${deb}" Version)"
+
+  if is_platform_package "${pkg}" && [[ "${ver}" != "${expected_version}" ]]; then
+    echo "Unexpected ${pkg} version ${ver}; expected ${expected_version} (${deb})" >&2
+    errors=$((errors + 1))
+  fi
+done < <(find "${deb_dir}" -type f -name '*.deb' -print0 | sort -z)
+
+if [[ "${deb_count}" -eq 0 ]]; then
+  echo "No .deb files found in ${deb_dir}" >&2
+  errors=$((errors + 1))
+fi
+
+if [[ -n "${sysroot}" ]]; then
+  dlpack_header="${sysroot}/usr/include/dlpack/dlpack.h"
+  if [[ -f "${dlpack_header}" ]]; then
+    for symbol in kDLOneAPI kDLWebGPU kDLHexagon; do
+      if ! grep -q "${symbol}" "${dlpack_header}"; then
+        echo "${dlpack_header} is missing ${symbol}; TVM/DLPack headers are mismatched" >&2
+        errors=$((errors + 1))
+      fi
+    done
+  fi
+fi
+
+if [[ "${errors}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Validated ${deb_count} downloaded sysroot packages for platform version ${expected_version}"


### PR DESCRIPTION
## Summary

This PR makes the SDK image setup deterministic for a selected `BASE_SDK_VERSION` and extracts the SDK setup logic out of the Dockerfile into maintained scripts/config files.

Key changes:

- Vendor and patch `simaai_setup_sdk.py` so SDK sysroot package resolution is deterministic.
- Add explicit validation that SiMa/platform-owned packages match the requested base SDK version.
- Add sysroot overlay handling for Debian packages needed by cross builds.
- Move Dockerfile inline setup logic into focused scripts under `scripts/` and package matching rules under `config/`.
- Install `sima-cli` from PyPI and verify it during smoke setup.
- Skip Model SDK installation in smoke tests with `--no-model-sdk` to avoid unnecessary space usage.
- Add Rust cross-compilation setup for `aarch64-unknown-linux-gnu`.
- Keep `/neat-resources` as root-owned/read-only reference material for agents, not as a build input.
- Add profile/env setup for pkg-config/sysroot behavior and SDK prompt configuration.

## Why this is needed

The previous SDK setup relied on the upstream SDK setup script and apt candidate selection behavior. In practice, that allowed a `BASE_SDK_VERSION=2.0.0` image to silently pull some `2.1.0` packages when dependencies resolved to newer candidates. That led to inconsistent sysroots and hard-to-debug build failures, including ABI/header mismatches in TVM/DLPack-related headers and package sets that differed across rebuilds.

For this SDK image, the platform version needs to be strict:

- a 2.0 SDK image must pull 2.0 platform-owned packages only;
- a 2.1 SDK image must pull 2.1 platform-owned packages only;
- if the repo serves a mixed package graph, the Docker build should fail early with a clear package/version error instead of producing a subtly inconsistent sysroot.

The vendored setup script also lets us maintain local fixes that are specific to this SDK image, including package filtering, extraction ordering, sysroot validation, and handling packages that should come from the SDK-owned package set instead of generic Debian candidates.

The Dockerfile had also accumulated too much inline setup logic. Moving that behavior into scripts makes each part easier to review, test, and patch independently.

## Validation

Tested manually by Jim on both supported SDK host platforms:

- ARM64 SDK platform: internals build confirmed working.
- x86 SDK platform: internals build confirmed working.
- Core build confirmed working on ARM64 and x86 platforms with the matching internals artifacts.

Additional local validation performed on this branch:

- `bash -n scripts/*.sh config/profile.d/*.sh`
- `python3 -m py_compile scripts/simaai_setup_sdk.py`
- `git diff --check`
- `docker buildx build --check -f Dockerfile .`
