### PR TITLE
Prepare SDK 2.1.1 host/toolchain update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
 
 COPY scripts/install-sysroot-overlay.sh /usr/local/bin/install-sysroot-overlay.sh
 COPY scripts/install-sdk-sysroot-overlay.sh /usr/local/bin/install-sdk-sysroot-overlay.sh
+COPY scripts/sysroot.sh /usr/local/bin/sysroot
 COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
@@ -119,6 +120,7 @@ COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/install-sdk-sysroot-overlay.sh && \
+    chmod 755 /usr/local/bin/sysroot && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,9 @@ RUN aarch64-linux-gnu-gcc --version && \
     aarch64-linux-gnu-ld --version && \
     printf 'int main(void) { return 0; }\n' > /tmp/cross-smoke.c && \
     aarch64-linux-gnu-gcc -c -o /tmp/cross-smoke.o /tmp/cross-smoke.c && \
-    rm -f /tmp/cross-smoke.o /tmp/cross-smoke.c
+    printf '#include <iostream>\nint main() { std::cout << "ok\\\\n"; return 0; }\n' > /tmp/cross-smoke.cpp && \
+    aarch64-linux-gnu-g++ -o /tmp/cross-smoke-cxx /tmp/cross-smoke.cpp && \
+    rm -f /tmp/cross-smoke.o /tmp/cross-smoke.c /tmp/cross-smoke.cpp /tmp/cross-smoke-cxx
 
 COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
 COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
@@ -150,6 +152,9 @@ RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
     aarch64-linux-gnu-gcc --version && \
     aarch64-linux-gnu-g++ --version && \
     aarch64-linux-gnu-ld --version && \
+    printf '#include <iostream>\nint main() { std::cout << "ok\\\\n"; return 0; }\n' > /tmp/cross-smoke.cpp && \
+    aarch64-linux-gnu-g++ -o /tmp/cross-smoke-cxx /tmp/cross-smoke.cpp && \
+    rm -f /tmp/cross-smoke.cpp /tmp/cross-smoke-cxx && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 # syntax=docker/dockerfile:1.7
 # Generated Dockerfile for modalix.
-FROM debian:bookworm
+ARG SDK_BASE_IMAGE=ubuntu:24.04
+ARG SDK_CROSS_TOOLCHAIN_IMAGE=debian:bookworm
+FROM ${SDK_CROSS_TOOLCHAIN_IMAGE} AS cross-toolchain
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY scripts/install-cross-toolchain.sh /usr/local/bin/install-cross-toolchain.sh
+RUN chmod 755 /usr/local/bin/install-cross-toolchain.sh && \
+    install-cross-toolchain.sh
+
+FROM ${SDK_BASE_IMAGE}
 
 ARG SDK_PKG_LIST
 ARG SDK_GIT_BRANCH=unknown
@@ -11,7 +21,7 @@ ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
 ARG NEAT_INSIGHT_BRANCH=main
 ARG NEAT_INSIGHT_VERSION=latest
-ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libssl3 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
+ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
 	protobuf-compiler-grpc,\
@@ -25,8 +35,9 @@ ENV PATH="${NEAT_INSIGHT_VENV_DIR}/bin:${CARGO_HOME}/bin:${PATH}"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
-COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
+RUN if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      sed -i "/^Types: deb/a Architectures: $(dpkg --print-architecture)" /etc/apt/sources.list.d/ubuntu.sources; \
+    fi
 
 RUN dpkg --add-architecture arm64 && \
     dpkg --add-architecture arc && \
@@ -36,27 +47,24 @@ RUN apt-get clean && \
     apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \
       wget \
-      curl \
       gnupg \
       ca-certificates \
       iputils-ping \
-      python3 && \
+      python3 \
+      python3-apt && \
     rm -rf /var/lib/apt/lists/*
 
-RUN chmod 755 /usr/local/bin/configure-apt-repos.sh && \
-    configure-apt-repos.sh "${BASE_SDK_VERSION}"
+RUN python3 -c 'import apt'
 
 RUN apt-get update --allow-releaseinfo-change && \
     apt-get install -y --no-install-recommends \
-      python3-apt-ostree \
       vim \
       make \
       cmake \
+      debian-archive-keyring \
       default-jre-headless \
       pkgconf \
-      gcc-aarch64-linux-gnu \
       sudo \
-      g++-aarch64-linux-gnu \
       device-tree-compiler \
       bison \
       flex \
@@ -71,8 +79,14 @@ RUN apt-get update --allow-releaseinfo-change && \
       curl \
       htop \
       file \
+      libgmp10 \
+      libisl23 \
+      libjansson4 \
+      libmpc3 \
+      libmpfr6 \
       libssl-dev \
       libgnutls28-dev \
+      libzstd1 \
       openssh-client \
       sshpass \
       python3-dev \
@@ -85,6 +99,31 @@ RUN apt-get update --allow-releaseinfo-change && \
       mkcert && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=cross-toolchain /opt/cross-toolchain/ /
+COPY --from=cross-toolchain /opt/cross-toolchain/ /opt/bookworm-cross-toolchain/
+
+RUN aarch64-linux-gnu-gcc --version && \
+    aarch64-linux-gnu-g++ --version && \
+    aarch64-linux-gnu-ld --version && \
+    printf 'int main(void) { return 0; }\n' > /tmp/cross-smoke.c && \
+    aarch64-linux-gnu-gcc -c -o /tmp/cross-smoke.o /tmp/cross-smoke.c && \
+    rm -f /tmp/cross-smoke.o /tmp/cross-smoke.c
+
+COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
+COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
+
+RUN chmod 755 /usr/local/bin/configure-apt-repos.sh && \
+    configure-apt-repos.sh "${BASE_SDK_VERSION}"
+
+RUN mkdir -p /tmp/supervisor /var/log/supervisor && \
+    chmod 1777 /tmp/supervisor && \
+    chmod -R a+rwX /var/log/supervisor && \
+    sed -i \
+      -e 's#file=/var/run/supervisor.sock#file=/tmp/supervisor/supervisor.sock#' \
+      -e 's#pidfile=/var/run/supervisord.pid#pidfile=/tmp/supervisor/supervisord.pid#' \
+      -e 's#serverurl=unix:///var/run/supervisor.sock#serverurl=unix:///tmp/supervisor/supervisor.sock#' \
+      /etc/supervisor/supervisord.conf
 
 COPY scripts/simaai-init-build-env /opt/bin/simaai-init-build-env
 COPY scripts/simaai_setup_sdk.py /opt/bin/simaai_setup_sdk.py
@@ -107,6 +146,10 @@ RUN install-rustup.sh
 
 RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
     install-sima-cli.sh && \
+    cp -a /opt/bookworm-cross-toolchain/. / && \
+    aarch64-linux-gnu-gcc --version && \
+    aarch64-linux-gnu-g++ --version && \
+    aarch64-linux-gnu-ld --version && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/*
 

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,9 @@ CONTEXT_DIR="${CONTEXT_DIR:-${SCRIPT_DIR}}"
 IMAGE_NAME="${IMAGE_NAME:-sdk}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 MINIMAL_IMAGE="${MINIMAL_IMAGE:-0}"
+SDK_BASE_IMAGE="${SDK_BASE_IMAGE:-ubuntu:24.04}"
+SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE:-debian:bookworm}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
 BASE_SDK_VERSION="${BASE_SDK_VERSION:-2.1.1}"
 NEAT_BRANCH="${NEAT_BRANCH:-main}"
 NEAT_VERSION="${NEAT_VERSION:-latest}"
@@ -27,6 +30,9 @@ Environment overrides:
   IMAGE_NAME   Docker image name (default: ${IMAGE_NAME})
   IMAGE_TAG    Docker image tag (default: ${IMAGE_TAG})
   MINIMAL_IMAGE  If set to 1, skip rustup/setup-sdk/sysroot-overlay and install sima-cli only for /neat-resources baking (default: ${MINIMAL_IMAGE})
+  DOCKER_PLATFORM  Docker platform to build, e.g. linux/amd64 or linux/arm64 (default: current host)
+  SDK_BASE_IMAGE  Base Docker image for the SDK host/container userspace (default: ${SDK_BASE_IMAGE})
+  SDK_CROSS_TOOLCHAIN_IMAGE  Base image used only to source the pinned aarch64 cross compiler (default: ${SDK_CROSS_TOOLCHAIN_IMAGE})
   BASE_SDK_VERSION  Base eLxr/SiMa SDK package version to install (default: ${BASE_SDK_VERSION})
   NEAT_BRANCH  NEAT Framework branch to bake into /neat-resources (default: ${NEAT_BRANCH})
   NEAT_VERSION  NEAT Framework version/tag to bake into /neat-resources (default: ${NEAT_VERSION})
@@ -85,18 +91,22 @@ git_branch="${git_branch//\//_}"
 
 host_arch="$(uname -m)"
 
-case "${host_arch}" in
-  x86_64|amd64)
-    docker_platform="linux/amd64"
-    ;;
-  aarch64|arm64)
-    docker_platform="linux/arm64"
-    ;;
-  *)
-    echo "Unsupported host architecture: ${host_arch}" >&2
-    exit 1
-    ;;
-esac
+if [[ -n "${DOCKER_PLATFORM}" ]]; then
+  docker_platform="${DOCKER_PLATFORM}"
+else
+  case "${host_arch}" in
+    x86_64|amd64)
+      docker_platform="linux/amd64"
+      ;;
+    aarch64|arm64)
+      docker_platform="linux/arm64"
+      ;;
+    *)
+      echo "Unsupported host architecture: ${host_arch}" >&2
+      exit 1
+      ;;
+  esac
+fi
 
 image_ref="${IMAGE_NAME}:${IMAGE_TAG}"
 
@@ -106,6 +116,8 @@ echo "Docker platform: ${docker_platform}"
 echo "Git branch: ${git_branch}"
 echo "Git hash: ${git_hash}"
 echo "Base SDK version: ${BASE_SDK_VERSION}"
+echo "SDK base image: ${SDK_BASE_IMAGE}"
+echo "SDK cross toolchain image: ${SDK_CROSS_TOOLCHAIN_IMAGE}"
 echo "Minimal image mode: ${MINIMAL_IMAGE}"
 if [[ "${MINIMAL_IMAGE}" == "1" ]]; then
   echo "Minimal mode note: full setup-sdk is skipped; sima-cli is installed via the official installer for baked /neat-resources."
@@ -121,6 +133,8 @@ if docker buildx version >/dev/null 2>&1; then
     --load
     --platform "${docker_platform}"
     --build-arg MINIMAL_IMAGE="${MINIMAL_IMAGE}"
+    --build-arg SDK_BASE_IMAGE="${SDK_BASE_IMAGE}"
+    --build-arg SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE}"
     --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
     --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
     --build-arg NEAT_VERSION="${NEAT_VERSION}"
@@ -142,6 +156,8 @@ build_cmd=(
   docker build
   --platform "${docker_platform}"
   --build-arg MINIMAL_IMAGE="${MINIMAL_IMAGE}"
+  --build-arg SDK_BASE_IMAGE="${SDK_BASE_IMAGE}"
+  --build-arg SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE}"
   --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
   --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
   --build-arg NEAT_VERSION="${NEAT_VERSION}"

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -42,10 +42,29 @@ Docker platform: linux/arm64
 
 ## Add Sysroot Packages
 
-Provide a comma-separated package list with `SDK_PKG_LIST`:
+Inside a running SDK container, install additional ARM64 Debian packages into the sysroot with `sysroot`:
 
 ```bash
-SDK_PKG_LIST=libzix-dev,vxi-dev ./build.sh
+sudo sysroot install libzix-dev vxi-dev
+```
+
+The command installs into `/opt/toolchain/aarch64/modalix` by default and appends `:arm64` to unqualified package names. You can also pass explicit package qualifiers:
+
+```bash
+sudo sysroot install libopencv-dnn406:arm64 libfoo-dev=1.2.3
+```
+
+For OpenCV CMake component names, `sysroot` can resolve names such as `opencv_dnn` to the matching Debian package when apt metadata contains a single match:
+
+```bash
+sudo sysroot install opencv_dnn
+```
+
+Packages installed through `sysroot install` are tracked in lightweight manifests, so they can be listed or removed later:
+
+```bash
+sysroot list
+sudo sysroot remove libzix-dev
 ```
 
 ## NEAT Insight Version

--- a/scripts/configure-apt-repos.sh
+++ b/scripts/configure-apt-repos.sh
@@ -18,17 +18,50 @@ chmod 644 /etc/apt/trusted.gpg.d/elxr.gpg \
           /etc/apt/trusted.gpg.d/fluentbit.gpg \
           /etc/apt/trusted.gpg.d/simaai.gpg
 
+host_id=""
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  host_id="${ID:-}"
+fi
+
 cat > /etc/apt/sources.list.d/elxr.list <<'EOF'
 deb [signed-by=/etc/apt/trusted.gpg.d/elxr.gpg] https://mirror.elxr.dev/elxr aria main
 deb [signed-by=/etc/apt/trusted.gpg.d/fluentbit.gpg] https://packages.fluentbit.io/debian/bookworm bookworm main
 deb [trusted=yes] https://repo.sima.ai/elxr/deb/release bookworm non-free  # simaai repo
 EOF
 
-cat > /etc/apt/preferences.d/stable.pref <<'EOF'
+if [[ "${host_id}" == "ubuntu" ]]; then
+  cat > /etc/apt/sources.list.d/debian-target.list <<'EOF'
+deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm main
+deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-updates main
+deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian-security bookworm-security main
+EOF
+
+  cat > /etc/apt/preferences.d/stable.pref <<'EOF'
+Package: *
+Pin: origin "repo.sima.ai/elxr"
+Pin-Priority: 100
+
+Package: *
+Pin: origin "mirror.elxr.dev"
+Pin-Priority: 100
+
+Package: *
+Pin: origin "deb.debian.org"
+Pin-Priority: 100
+
+Package: *
+Pin: origin "packages.fluentbit.io"
+Pin-Priority: 100
+EOF
+else
+  cat > /etc/apt/preferences.d/stable.pref <<'EOF'
 Package: *
 Pin: origin "repo.sima.ai/elxr"
 Pin-Priority: 999
 EOF
+fi
 
 platform_packages="$(
   sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${patterns_file}" |

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -21,7 +21,7 @@ unset PKG_CONFIG_PATH || true
 export LDFLAGS="--sysroot=$SYSROOT -L$SYSROOT/usr/lib/aarch64-linux-gnu -L$SYSROOT/lib/aarch64-linux-gnu ${LDFLAGS:-}"
 
 if [[ "${NEAT_INSIGHT_SUPERVISED:-1}" != "0" ]] && command -v supervisord >/dev/null 2>&1; then
-  mkdir -p /var/log/supervisor
+  mkdir -p /tmp/supervisor /var/log/supervisor
   if ! supervisorctl status >/dev/null 2>&1; then
     supervisord -c /etc/supervisor/supervisord.conf
   fi

--- a/scripts/install-cross-toolchain.sh
+++ b/scripts/install-cross-toolchain.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+apt-get update --allow-releaseinfo-change
+
+host_arch="$(dpkg --print-architecture)"
+case "${host_arch}" in
+  amd64)
+    toolchain_packages=(gcc-aarch64-linux-gnu g++-aarch64-linux-gnu)
+    multiarch=x86_64-linux-gnu
+    ;;
+  arm64)
+    toolchain_packages=(gcc g++ binutils)
+    multiarch=aarch64-linux-gnu
+    ;;
+  *)
+    echo "Unsupported SDK host architecture for aarch64 toolchain: ${host_arch}" >&2
+    exit 1
+    ;;
+esac
+
+apt-get install -y --no-install-recommends "${toolchain_packages[@]}"
+
+mkdir -p /opt/cross-toolchain/usr/bin \
+         /opt/cross-toolchain/usr/lib \
+         "/opt/cross-toolchain/usr/lib/${multiarch}"
+
+cp -a /usr/bin/aarch64-linux-gnu-* /opt/cross-toolchain/usr/bin/
+
+if [[ -d /usr/lib/gcc-cross/aarch64-linux-gnu ]]; then
+  mkdir -p /opt/cross-toolchain/usr/lib/gcc-cross
+  cp -a /usr/lib/gcc-cross/aarch64-linux-gnu /opt/cross-toolchain/usr/lib/gcc-cross/
+fi
+
+if [[ -d /usr/lib/gcc/aarch64-linux-gnu ]]; then
+  mkdir -p /opt/cross-toolchain/usr/lib/gcc
+  cp -a /usr/lib/gcc/aarch64-linux-gnu /opt/cross-toolchain/usr/lib/gcc/
+fi
+
+if [[ -d /usr/aarch64-linux-gnu ]]; then
+  cp -a /usr/aarch64-linux-gnu /opt/cross-toolchain/usr/
+fi
+
+if [[ "${host_arch}" == "arm64" ]]; then
+  cp -a /usr/bin/gcc /usr/bin/gcc-* \
+        /usr/bin/g++ /usr/bin/g++-* \
+        /usr/bin/cpp /usr/bin/cpp-* \
+        /opt/cross-toolchain/usr/bin/
+  ln -sf gcc /opt/cross-toolchain/usr/bin/aarch64-linux-gnu-gcc
+  ln -sf g++ /opt/cross-toolchain/usr/bin/aarch64-linux-gnu-g++
+  ln -sf cpp /opt/cross-toolchain/usr/bin/aarch64-linux-gnu-cpp
+  ln -sf aarch64-linux-gnu-as /opt/cross-toolchain/usr/bin/as
+  ln -sf aarch64-linux-gnu-ld /opt/cross-toolchain/usr/bin/ld
+fi
+
+for lib in \
+  "/usr/lib/${multiarch}"/libbfd*.so* \
+  "/usr/lib/${multiarch}"/libctf*.so* \
+  "/usr/lib/${multiarch}"/libopcodes*.so* \
+  "/usr/lib/${multiarch}"/libsframe*.so*; do
+  if [[ -e "${lib}" ]]; then
+    cp -a "${lib}" "/opt/cross-toolchain/usr/lib/${multiarch}/"
+  fi
+done
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/scripts/install-cross-toolchain.sh
+++ b/scripts/install-cross-toolchain.sh
@@ -43,6 +43,15 @@ if [[ -d /usr/aarch64-linux-gnu ]]; then
 fi
 
 if [[ "${host_arch}" == "arm64" ]]; then
+  mkdir -p /opt/cross-toolchain/usr/include \
+           /opt/cross-toolchain/usr/include/aarch64-linux-gnu
+  if [[ -d /usr/include/c++ ]]; then
+    cp -a /usr/include/c++ /opt/cross-toolchain/usr/include/
+  fi
+  if [[ -d /usr/include/aarch64-linux-gnu/c++ ]]; then
+    cp -a /usr/include/aarch64-linux-gnu/c++ /opt/cross-toolchain/usr/include/aarch64-linux-gnu/
+  fi
+
   cp -a /usr/bin/gcc /usr/bin/gcc-* \
         /usr/bin/g++ /usr/bin/g++-* \
         /usr/bin/cpp /usr/bin/cpp-* \

--- a/scripts/install-sima-cli.sh
+++ b/scripts/install-sima-cli.sh
@@ -2,7 +2,30 @@
 
 set -euo pipefail
 
-curl -fsSL https://docs.sima.ai/_static/tools/sima-cli-installer.sh | bash
-test -x /root/.sima-cli/.venv/bin/sima-cli
-ln -sf /root/.sima-cli/.venv/bin/sima-cli /usr/local/bin/sima-cli
+root_venv=/root/.sima-cli/.venv
+install_venv=/opt/sima-cli/venv
+
+if ! curl -fsSL https://docs.sima.ai/_static/tools/sima-cli-installer.sh | bash; then
+  test -x "${root_venv}/bin/sima-cli"
+fi
+test -x "${root_venv}/bin/sima-cli"
+rm -rf /opt/sima-cli
+mkdir -p /opt/sima-cli
+cp -a "${root_venv}" "${install_venv}"
+while IFS= read -r -d '' launcher; do
+  sed -i '1 s#/root/.sima-cli/.venv#/opt/sima-cli/venv#' "${launcher}"
+done < <(grep -IlZ '^#!.*/root/.sima-cli/.venv' "${install_venv}"/bin/* 2>/dev/null || true)
+chmod -R a+rX /opt/sima-cli
+cat >/usr/local/bin/sima-cli <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${HOME:-}" || ! -d "${HOME}" || ! -w "${HOME}" ]]; then
+  export HOME="/tmp/sima-cli-home-$(id -u)"
+  mkdir -p "${HOME}"
+fi
+
+exec /opt/sima-cli/venv/bin/sima-cli "$@"
+EOF
+chmod 755 /usr/local/bin/sima-cli
 /usr/local/bin/sima-cli --help >/dev/null 2>&1

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -77,6 +77,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
+touch "${workdir}/status"
 
 # apt downloads as the sandbox user _apt. mktemp creates a 0700 root-owned
 # directory, so make only the download staging paths accessible to avoid
@@ -89,41 +90,34 @@ fi
 echo "Downloading sysroot overlay packages into ${SYSROOT}"
 printf '  %s\n' "${PACKAGES[@]}"
 
-# In cross builds, apt treats some packages as Multi-Arch: same and requires
-# the host and target architecture versions to match. Download the target
-# linux-libc-dev version that matches the installed host package here, then
-# replace the sysroot headers with the SDK-pinned version below.
-native_arch="$(dpkg --print-architecture)"
-if [[ " ${TARGET_ARCHES[*]} " != *" ${native_arch} "* ]] &&
-   dpkg-query -W -f='${Status}' linux-libc-dev 2>/dev/null | grep -q "install ok installed"; then
-  native_linux_libc_version="$(dpkg-query -W -f='${Version}' linux-libc-dev)"
-  for arch in "${TARGET_ARCHES[@]}"; do
-    PACKAGES+=("linux-libc-dev:${arch}=${native_linux_libc_version}")
-  done
-fi
-
 apt-get update --allow-releaseinfo-change
 apt-get install -y --download-only --no-install-recommends \
   --reinstall \
   -o Dir::Cache::archives="${workdir}/archives" \
+  -o Dir::State::status="${workdir}/status" \
   "${PACKAGES[@]}"
 
 find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
   | while IFS= read -r -d '' deb; do
       deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
+      deb_pkg="$(dpkg-deb -f "${deb}" Package)"
       # Apt may download host-arch helper packages while solving target deps.
       # Only target-arch and arch-independent payloads belong in this sysroot.
       if [[ "${deb_arch}" != "all" && " ${TARGET_ARCHES[*]} " != *" ${deb_arch} "* ]]; then
         echo "Skipping $(basename "${deb}") for architecture ${deb_arch}"
         continue
       fi
+      if [[ "${deb_pkg}" == "linux-libc-dev" && "${deb_arch}" == "arm64" ]]; then
+        echo "Skipping $(basename "${deb}"); extracting SDK-pinned arm64 headers separately"
+        continue
+      fi
       echo "Extracting $(basename "${deb}")"
       dpkg-deb -x "${deb}" "${SYSROOT}"
     done
 
-# The official Modalix 2.0 SDK sysroot uses SiMa's 6.1.22 arm64 UAPI headers.
-# Download this .deb directly so apt's multiarch resolver cannot reject it for
-# differing from the native amd64 linux-libc-dev package installed in the image.
+# The official Modalix 2.0 SDK sysroot uses SiMa's pinned arm64 UAPI headers.
+# Download this .deb directly so sysroot headers do not depend on the native
+# linux-libc-dev version installed in the image.
 for arch in "${TARGET_ARCHES[@]}"; do
   if [[ "${arch}" != "arm64" ]]; then
     continue

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -68,13 +68,40 @@ if [[ " ${TARGET_ARCHES[*]} " == *" arm64 "* && -z "${LINUX_LIBC_DEV_ARM64_VERSI
   exit 1
 fi
 
+APT_TARGET_ARCH="${TARGET_ARCHES[0]}"
 export DEBIAN_FRONTEND=noninteractive
 
 workdir="$(mktemp -d)"
+sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
 cleanup() {
   rm -rf "${workdir}"
+  rm -f "${sysroot_pref}"
 }
 trap cleanup EXIT
+
+if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
+  cat >"${sysroot_pref}" <<'EOF'
+Package: *
+Pin: origin "repo.sima.ai/elxr"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "mirror.elxr.dev"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "deb.debian.org"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "packages.fluentbit.io"
+Pin-Priority: 990
+
+Package: *
+Pin: release o=Ubuntu
+Pin-Priority: 100
+EOF
+fi
 
 mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
 touch "${workdir}/status"
@@ -93,6 +120,7 @@ printf '  %s\n' "${PACKAGES[@]}"
 apt-get update --allow-releaseinfo-change
 apt-get install -y --download-only --no-install-recommends \
   --reinstall \
+  -o APT::Architecture="${APT_TARGET_ARCH}" \
   -o Dir::Cache::archives="${workdir}/archives" \
   -o Dir::State::status="${workdir}/status" \
   "${PACKAGES[@]}"
@@ -175,6 +203,19 @@ find "${SYSROOT}" -type l -print0 \
           ;;
       esac
     done
+
+while IFS= read -r referenced; do
+  if [[ "${referenced}" != "${SYSROOT}"/* ]]; then
+    continue
+  fi
+  if [[ ! -e "${referenced}" ]]; then
+    echo "Broken CMake package reference: ${referenced}" >&2
+    exit 1
+  fi
+done < <(
+  grep -RhoE "\"${SYSROOT}\"/[^\" ]+" "${SYSROOT}/usr/lib/aarch64-linux-gnu/cmake" 2>/dev/null |
+    sed 's/^"//'
+)
 
 if [[ -d "${SYSROOT}/usr/include" ]]; then
   chmod -R a+rX "${SYSROOT}/usr/include"

--- a/scripts/setup-sdk-sysroot.sh
+++ b/scripts/setup-sdk-sysroot.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 
 base_sdk_version="${1:?Usage: setup-sdk-sysroot.sh BASE_SDK_VERSION SDK_PKG_LIST}"
 sdk_pkg_list="${2:-}"
+sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
+
+cleanup_sysroot_pref() {
+  rm -f "${sysroot_pref}"
+}
 
 if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
   mkdir -p /opt/toolchain/aarch64/modalix/usr/include \
@@ -13,6 +18,31 @@ if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
            /opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/pkgconfig \
            /opt/toolchain/aarch64/modalix/usr/share/pkgconfig
   exit 0
+fi
+
+if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
+  cat >"${sysroot_pref}" <<'EOF'
+Package: *
+Pin: origin "repo.sima.ai/elxr"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "mirror.elxr.dev"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "deb.debian.org"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "packages.fluentbit.io"
+Pin-Priority: 990
+
+Package: *
+Pin: release o=Ubuntu
+Pin-Priority: 100
+EOF
+  trap cleanup_sysroot_pref EXIT
 fi
 
 python3 /opt/bin/simaai_setup_sdk.py modalix "${base_sdk_version}" "${sdk_pkg_list}"

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -292,6 +292,7 @@ download_for_manifest() {
   shift 2
 
   mkdir -p "${outdir}/archives/partial"
+  touch "${outdir}/status"
   chmod 755 "${outdir}" "${outdir}/archives" "${outdir}/archives/partial"
   if id _apt >/dev/null 2>&1; then
     chown _apt "${outdir}/archives" "${outdir}/archives/partial"
@@ -300,6 +301,7 @@ download_for_manifest() {
   apt-get update --allow-releaseinfo-change
   apt-get install -y --download-only --no-install-recommends --reinstall \
     -o Dir::Cache::archives="${outdir}/archives" \
+    -o Dir::State::status="${outdir}/status" \
     "$@"
 }
 
@@ -321,6 +323,9 @@ record_manifests() {
 
       deb_pkg="$(dpkg-deb -f "${deb}" Package)"
       deb_version="$(dpkg-deb -f "${deb}" Version)"
+      if [[ "${deb_pkg}" == "linux-libc-dev" && "${deb_arch}" == "arm64" ]]; then
+        continue
+      fi
       manifest="$(manifest_path "${sysroot}" "${deb_pkg}" "${deb_arch}")"
       tmp_manifest="${manifest}.tmp"
 

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+program_name="$(basename "$0")"
+DEFAULT_SYSROOT="/opt/toolchain/aarch64/modalix"
+DEFAULT_ARCH="arm64"
+INSTALLER="${SYSROOT_INSTALLER:-/usr/local/bin/install-sysroot-overlay.sh}"
+
+usage() {
+  cat <<EOF
+Usage:
+  ${program_name} install [options] package [package ...]
+  ${program_name} remove  [options] package [package ...]
+  ${program_name} list    [options]
+  ${program_name} help
+
+Manages Debian package payloads in the SDK sysroot. Install downloads packages
+with apt and extracts them into the sysroot. Remove deletes files recorded by
+this command's install manifests; it cannot remove packages installed before
+manifest tracking existed.
+
+Options:
+  --sysroot PATH  Sysroot to operate on (default: \${SYSROOT:-${DEFAULT_SYSROOT}})
+  --arch ARCH     Target architecture for unqualified packages (default: ${DEFAULT_ARCH})
+  --dry-run       Print actions without changing the sysroot
+  -h, --help      Show this help
+
+Examples:
+  sudo ${program_name} install libpgm-dev
+  sudo ${program_name} install opencv_dnn
+  ${program_name} list
+  sudo ${program_name} remove libpgm-dev
+EOF
+}
+
+die() {
+  echo "${program_name}: $*" >&2
+  exit 2
+}
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+    return
+  fi
+
+  echo "${program_name}: this operation requires root privileges, and sudo is not available." >&2
+  return 1
+}
+
+has_dry_run_arg() {
+  local arg
+  for arg in "$@"; do
+    if [[ "${arg}" == "--dry-run" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+reexec_as_root_if_needed() {
+  local command="$1"
+  shift
+
+  if [[ "$(id -u)" -eq 0 ]] || has_dry_run_arg "$@"; then
+    return
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo_cmd=(sudo env)
+    if [[ -n "${SYSROOT:-}" ]]; then
+      sudo_cmd+=("SYSROOT=${SYSROOT}")
+    fi
+    if [[ -n "${SYSROOT_ARCH:-}" ]]; then
+      sudo_cmd+=("SYSROOT_ARCH=${SYSROOT_ARCH}")
+    fi
+    if [[ -n "${SYSROOT_INSTALLER:-}" ]]; then
+      sudo_cmd+=("SYSROOT_INSTALLER=${SYSROOT_INSTALLER}")
+    fi
+    sudo_cmd+=("${BASH_SOURCE[0]}" "${command}" "$@")
+    exec "${sudo_cmd[@]}"
+  fi
+
+  echo "${program_name}: ${command} requires root privileges, and sudo is not available." >&2
+  exit 1
+}
+
+validate_arch() {
+  local arch="$1"
+  if [[ -z "${arch}" || "${arch}" == *[!A-Za-z0-9._-]* ]]; then
+    die "invalid architecture: ${arch}"
+  fi
+}
+
+validate_sysroot() {
+  local sysroot="$1"
+  if [[ -z "${sysroot}" || "${sysroot}" != /* ]]; then
+    die "sysroot must be an absolute path: ${sysroot}"
+  fi
+}
+
+normalize_package() {
+  local pkg="$1"
+  local arch="$2"
+  local name version name_part explicit_arch
+
+  if [[ -z "${pkg}" ]]; then
+    die "empty package name"
+  fi
+  if [[ "${pkg}" == -* ]]; then
+    die "unsupported package option: ${pkg}"
+  fi
+  if [[ "${pkg}" == */* ]]; then
+    die "package paths are not supported: ${pkg}"
+  fi
+
+  name="${pkg}"
+  version=""
+  if [[ "${name}" == *=* ]]; then
+    version="${name#*=}"
+    name="${name%%=*}"
+    if [[ -z "${version}" ]]; then
+      die "missing version after '=' in ${pkg}"
+    fi
+  fi
+
+  explicit_arch=""
+  name_part="${name}"
+  if [[ "${name}" == *:* ]]; then
+    name_part="${name%%:*}"
+    explicit_arch="${name##*:}"
+    if [[ -z "${name_part}" || -z "${explicit_arch}" ]]; then
+      die "invalid package architecture qualifier: ${pkg}"
+    fi
+    validate_arch "${explicit_arch}"
+  fi
+
+  if [[ -z "${name_part}" || "${name_part}" == *[!A-Za-z0-9.+_-]* ]]; then
+    die "invalid package name: ${pkg}"
+  fi
+
+  if [[ -z "${explicit_arch}" ]]; then
+    name="${name}:${arch}"
+  fi
+
+  if [[ -n "${version}" ]]; then
+    printf '%s=%s\n' "${name}" "${version}"
+  else
+    printf '%s\n' "${name}"
+  fi
+}
+
+package_base() {
+  local pkg="${1%%=*}"
+  pkg="${pkg%%:*}"
+  printf '%s\n' "${pkg}"
+}
+
+package_arch() {
+  local pkg="${1%%=*}"
+  if [[ "${pkg}" == *:* ]]; then
+    printf '%s\n' "${pkg##*:}"
+  else
+    printf '%s\n' "${DEFAULT_ARCH}"
+  fi
+}
+
+manifest_root() {
+  printf '%s/var/lib/sima-sdk/sysroot-packages\n' "$1"
+}
+
+manifest_path() {
+  local sysroot="$1"
+  local pkg="$2"
+  local arch="$3"
+  printf '%s/%s_%s.manifest\n' "$(manifest_root "${sysroot}")" "${pkg}" "${arch}"
+}
+
+apt_package_exists() {
+  local pkg="$1"
+  local arch="$2"
+
+  command -v apt-cache >/dev/null 2>&1 || return 1
+  apt-cache policy "${pkg}:${arch}" 2>/dev/null | grep -q 'Candidate: [^(]'
+}
+
+resolve_component_name() {
+  local pkg="$1"
+  local arch="$2"
+  local base version component candidates
+
+  base="${pkg%%=*}"
+  version=""
+  if [[ "${pkg}" == *=* ]]; then
+    version="${pkg#*=}"
+  fi
+
+  if [[ "${base}" == *:* ]] || apt_package_exists "${base}" "${arch}"; then
+    printf '%s\n' "${pkg}"
+    return
+  fi
+
+  case "${base}" in
+    opencv_*)
+      component="${base#opencv_}"
+      component="${component//_/-}"
+      if command -v apt-cache >/dev/null 2>&1; then
+        mapfile -t candidates < <(
+          {
+            apt-cache search "^libopencv-${component}[0-9]+$" 2>/dev/null | awk '{print $1}'
+            apt-cache search "^libopencv-${component}-dev$" 2>/dev/null | awk '{print $1}'
+          } | awk '!seen[$0]++'
+        )
+        if [[ ${#candidates[@]} -eq 1 ]]; then
+          if [[ -n "${version}" ]]; then
+            printf '%s=%s\n' "${candidates[0]}" "${version}"
+          else
+            printf '%s\n' "${candidates[0]}"
+          fi
+          return
+        fi
+      fi
+      ;;
+  esac
+
+  printf '%s\n' "${pkg}"
+}
+
+parse_common_options() {
+  sysroot="${SYSROOT:-${DEFAULT_SYSROOT}}"
+  arch="${SYSROOT_ARCH:-${DEFAULT_ARCH}}"
+  dry_run=0
+  args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --sysroot)
+        [[ $# -ge 2 ]] || die "--sysroot requires a value"
+        sysroot="$2"
+        shift 2
+        ;;
+      --sysroot=*)
+        sysroot="${1#*=}"
+        shift
+        ;;
+      --arch)
+        [[ $# -ge 2 ]] || die "--arch requires a value"
+        arch="$2"
+        shift 2
+        ;;
+      --arch=*)
+        arch="${1#*=}"
+        shift
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --)
+        shift
+        while [[ $# -gt 0 ]]; do
+          args+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        die "unsupported option: $1"
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  validate_sysroot "${sysroot}"
+  validate_arch "${arch}"
+}
+
+download_for_manifest() {
+  local arch="$1"
+  local outdir="$2"
+  shift 2
+
+  mkdir -p "${outdir}/archives/partial"
+  chmod 755 "${outdir}" "${outdir}/archives" "${outdir}/archives/partial"
+  if id _apt >/dev/null 2>&1; then
+    chown _apt "${outdir}/archives" "${outdir}/archives/partial"
+  fi
+
+  apt-get update --allow-releaseinfo-change
+  apt-get install -y --download-only --no-install-recommends --reinstall \
+    -o Dir::Cache::archives="${outdir}/archives" \
+    "$@"
+}
+
+record_manifests() {
+  local sysroot="$1"
+  local arch="$2"
+  local debdir="$3"
+  local root
+
+  root="$(manifest_root "${sysroot}")"
+  mkdir -p "${root}"
+
+  find "${debdir}" -maxdepth 1 -type f -name '*.deb' -print0 |
+    while IFS= read -r -d '' deb; do
+      deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
+      if [[ "${deb_arch}" != "all" && "${deb_arch}" != "${arch}" ]]; then
+        continue
+      fi
+
+      deb_pkg="$(dpkg-deb -f "${deb}" Package)"
+      deb_version="$(dpkg-deb -f "${deb}" Version)"
+      manifest="$(manifest_path "${sysroot}" "${deb_pkg}" "${deb_arch}")"
+      tmp_manifest="${manifest}.tmp"
+
+      {
+        printf 'Package: %s\n' "${deb_pkg}"
+        printf 'Architecture: %s\n' "${deb_arch}"
+        printf 'Version: %s\n' "${deb_version}"
+        printf '\n'
+        dpkg-deb -c "${deb}" |
+          awk '
+            {
+              path = $6
+              sub(/^\.\//, "", path)
+              if (path != "" && path !~ /\/$/) {
+                print path
+              }
+            }
+          ' | sort -u
+      } > "${tmp_manifest}"
+
+      mv "${tmp_manifest}" "${manifest}"
+      echo "Recorded ${deb_pkg}:${deb_arch} ${deb_version}"
+    done
+}
+
+cmd_install() {
+  parse_common_options "$@"
+  if [[ ${#args[@]} -eq 0 ]]; then
+    die "install requires at least one package"
+  fi
+  if [[ "${dry_run}" != "1" && ! -x "${INSTALLER}" ]]; then
+    echo "${program_name}: sysroot installer not found or not executable: ${INSTALLER}" >&2
+    exit 1
+  fi
+
+  resolved=()
+  normalized=()
+  for pkg in "${args[@]}"; do
+    resolved_pkg="$(resolve_component_name "${pkg}" "${arch}")"
+    resolved+=("${resolved_pkg}")
+    normalized+=("$(normalize_package "${resolved_pkg}" "${arch}")")
+  done
+
+  echo "Installing into sysroot: ${sysroot}"
+  printf '  %s\n' "${normalized[@]}"
+  for i in "${!args[@]}"; do
+    if [[ "${args[$i]}" != "${resolved[$i]}" ]]; then
+      echo "Resolved ${args[$i]} -> ${resolved[$i]}"
+    fi
+  done
+
+  if [[ "${dry_run}" == "1" ]]; then
+    printf 'Dry run install:'
+    printf ' %q' "${INSTALLER}" "${sysroot}" "${normalized[@]}"
+    printf '\n'
+    exit 0
+  fi
+
+  run_as_root "${INSTALLER}" "${sysroot}" "${normalized[@]}"
+
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "${workdir}"' EXIT
+  download_for_manifest "${arch}" "${workdir}" "${normalized[@]}"
+  record_manifests "${sysroot}" "${arch}" "${workdir}/archives"
+}
+
+file_owned_elsewhere() {
+  local root="$1"
+  local current_manifest="$2"
+  local rel="$3"
+  local other
+
+  while IFS= read -r -d '' other; do
+    if [[ "${other}" == "${current_manifest}" ]]; then
+      continue
+    fi
+    if awk -v needle="${rel}" 'BEGIN{found=1} $0 == needle {found=0; exit} END{exit found}' "${other}"; then
+      return 0
+    fi
+  done < <(find "${root}" -type f -name '*.manifest' -print0 2>/dev/null)
+
+  return 1
+}
+
+remove_empty_parents() {
+  local sysroot="$1"
+  local rel="$2"
+  local dir
+
+  dir="$(dirname "${sysroot}/${rel}")"
+  while [[ "${dir}" != "${sysroot}" && "${dir}" == "${sysroot}"/* ]]; do
+    rmdir "${dir}" 2>/dev/null || break
+    dir="$(dirname "${dir}")"
+  done
+}
+
+cmd_remove() {
+  parse_common_options "$@"
+  if [[ ${#args[@]} -eq 0 ]]; then
+    die "remove requires at least one package"
+  fi
+
+  root="$(manifest_root "${sysroot}")"
+  if [[ ! -d "${root}" ]]; then
+    echo "No sysroot package manifests found in ${root}" >&2
+    exit 1
+  fi
+
+  manifests=()
+  for pkg in "${args[@]}"; do
+    normalized="$(normalize_package "${pkg}" "${arch}")"
+    base="$(package_base "${normalized}")"
+    pkg_arch="$(package_arch "${normalized}")"
+    manifest="$(manifest_path "${sysroot}" "${base}" "${pkg_arch}")"
+    if [[ ! -f "${manifest}" && "${pkg_arch}" != "all" ]]; then
+      all_manifest="$(manifest_path "${sysroot}" "${base}" "all")"
+      if [[ -f "${all_manifest}" ]]; then
+        manifest="${all_manifest}"
+      fi
+    fi
+    if [[ ! -f "${manifest}" ]]; then
+      echo "${program_name}: ${base}:${pkg_arch} is not tracked in ${root}" >&2
+      exit 1
+    fi
+    manifests+=("${manifest}")
+  done
+
+  for manifest in "${manifests[@]}"; do
+    pkg="$(awk -F': ' '$1 == "Package" {print $2; exit}' "${manifest}")"
+    pkg_arch="$(awk -F': ' '$1 == "Architecture" {print $2; exit}' "${manifest}")"
+    echo "Removing ${pkg}:${pkg_arch} from ${sysroot}"
+
+    awk 'seen_blank {print} /^$/ {seen_blank=1}' "${manifest}" | sort -r |
+      while IFS= read -r rel; do
+        [[ -n "${rel}" ]] || continue
+        target="${sysroot}/${rel}"
+        if file_owned_elsewhere "${root}" "${manifest}" "${rel}"; then
+          continue
+        fi
+        if [[ "${dry_run}" == "1" ]]; then
+          if [[ -e "${target}" || -L "${target}" ]]; then
+            echo "Would remove ${target}"
+          fi
+          continue
+        fi
+        if [[ -e "${target}" || -L "${target}" ]]; then
+          rm -f "${target}"
+          remove_empty_parents "${sysroot}" "${rel}"
+        fi
+      done
+
+    if [[ "${dry_run}" == "1" ]]; then
+      echo "Would remove manifest ${manifest}"
+    else
+      rm -f "${manifest}"
+    fi
+  done
+}
+
+cmd_list() {
+  parse_common_options "$@"
+  if [[ ${#args[@]} -ne 0 ]]; then
+    die "list does not accept package arguments"
+  fi
+
+  root="$(manifest_root "${sysroot}")"
+  if [[ ! -d "${root}" ]]; then
+    echo "No tracked sysroot packages."
+    return
+  fi
+
+  shopt -s nullglob
+  manifests=("${root}"/*.manifest)
+  shopt -u nullglob
+  if [[ ${#manifests[@]} -eq 0 ]]; then
+    echo "No tracked sysroot packages."
+    return
+  fi
+
+  printf '%s\0' "${manifests[@]}" |
+    sort -z |
+    while IFS= read -r -d '' manifest; do
+      pkg="$(awk -F': ' '$1 == "Package" {print $2; exit}' "${manifest}")"
+      pkg_arch="$(awk -F': ' '$1 == "Architecture" {print $2; exit}' "${manifest}")"
+      version="$(awk -F': ' '$1 == "Version" {print $2; exit}' "${manifest}")"
+      printf '%s:%s %s\n' "${pkg}" "${pkg_arch}" "${version}"
+    done
+}
+
+command="${1:-}"
+case "${command}" in
+  ""|-h|--help|help)
+    usage
+    ;;
+  install)
+    shift
+    reexec_as_root_if_needed install "$@"
+    cmd_install "$@"
+    ;;
+  remove)
+    shift
+    reexec_as_root_if_needed remove "$@"
+    cmd_remove "$@"
+    ;;
+  list)
+    shift
+    cmd_list "$@"
+    ;;
+  *)
+    echo "${program_name}: unsupported command: ${command}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -289,6 +289,7 @@ parse_common_options() {
 download_for_manifest() {
   local arch="$1"
   local outdir="$2"
+  local sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
   shift 2
 
   mkdir -p "${outdir}/archives/partial"
@@ -298,8 +299,33 @@ download_for_manifest() {
     chown _apt "${outdir}/archives" "${outdir}/archives/partial"
   fi
 
+  if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
+    cat >"${sysroot_pref}" <<'EOF'
+Package: *
+Pin: origin "repo.sima.ai/elxr"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "mirror.elxr.dev"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "deb.debian.org"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "packages.fluentbit.io"
+Pin-Priority: 990
+
+Package: *
+Pin: release o=Ubuntu
+Pin-Priority: 100
+EOF
+  fi
+
   apt-get update --allow-releaseinfo-change
   apt-get install -y --download-only --no-install-recommends --reinstall \
+    -o APT::Architecture="${arch}" \
     -o Dir::Cache::archives="${outdir}/archives" \
     -o Dir::State::status="${outdir}/status" \
     "$@"
@@ -387,7 +413,7 @@ cmd_install() {
   run_as_root "${INSTALLER}" "${sysroot}" "${normalized[@]}"
 
   workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"' EXIT
+  trap 'rm -rf "${workdir}"; rm -f /etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref' EXIT
   download_for_manifest "${arch}" "${workdir}" "${normalized[@]}"
   record_manifests "${sysroot}" "${arch}" "${workdir}/archives"
 }

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -36,6 +36,30 @@ test_neat_status() {
   echo "::endgroup::"
 }
 
+test_modalix_cross_toolchain() {
+  local smoke_src="${WORK_DIR}/modalix-cross-smoke.cpp"
+  local smoke_bin="${WORK_DIR}/modalix-cross-smoke"
+  local compiler="${CXX:-aarch64-linux-gnu-g++}"
+
+  test "${SYSROOT}" = "/opt/toolchain/aarch64/modalix"
+  command -v "${compiler}"
+  test -d "${SYSROOT}/usr/include"
+  test -d "${SYSROOT}/usr/lib/aarch64-linux-gnu"
+
+  cat > "${smoke_src}" <<'EOF'
+#include <iostream>
+
+int main() {
+  std::cout << "modalix cross toolchain ok\n";
+  return 0;
+}
+EOF
+
+  "${compiler}" --sysroot="${SYSROOT}" -o "${smoke_bin}" "${smoke_src}"
+  file "${smoke_bin}"
+  file "${smoke_bin}" | grep -Eq 'aarch64|ARM aarch64|ARM64'
+}
+
 test_hello_neat_cpp() {
   cd "${HELLO_WORK}"
 
@@ -68,6 +92,7 @@ mkdir -p "${HELLO_WORK}" "$(dirname "${STATUS_JSON}")"
 cp -a "${HELLO_SRC}/." "${HELLO_WORK}/"
 
 run_test "SDK status: neat --json" test_neat_status
+run_test "Modalix cross toolchain" test_modalix_cross_toolchain
 run_test "Hello Neat C++ build" test_hello_neat_cpp
 run_test "Hello Neat Python runtime" test_hello_neat_python
 


### PR DESCRIPTION
## Summary
This PR prepares the Neat SDK image for the 2.1.1 line by moving the host SDK environment to Ubuntu 24.04/Noble and tightening how the target sysroot is managed.

The main changes are:
- Update the SDK Docker build so the host environment can use the newer Ubuntu 24.04 toolchain required by Model SDK extension 2.1.1.
- Keep Modalix/aarch64 cross compilation isolated to the platform sysroot/runtime line instead of letting the host toolchain change leak into target builds.
- Add a `sysroot` package management command so missing target packages can be installed into the SDK sysroot without rebuilding the whole image.
- Isolate sysroot overlay apt resolution from the host SDK apt state.
- Snapshot/fix the arm64 SDK C++ cross-toolchain path used by SDK smoke tests and downstream builds.
- Extend SDK smoke coverage so it exercises the Modalix cross-compilation path, not only host/container startup.

## Why
Model SDK extension 2.1.1 is built with a newer toolchain than the previous Neat SDK host image provided. Installing that extension into the old SDK image fails because the host environment is too old for the extension's build/runtime expectations.

To support Model SDK extension 2.1.1, the Neat SDK host container needs to move to Ubuntu 24.04/Noble. At the same time, cross compilation for Modalix/devkit must continue to target the platform sysroot and runtime ABI. This PR separates those two concerns: newer host tooling for SDK extension compatibility, stable target sysroot behavior for devkit builds.

## Compatibility Strategy
The SDK image now has two distinct compatibility surfaces:

- Host SDK environment: Ubuntu 24.04/Noble, used for SDK-side tooling, package installation, and Model SDK extension compatibility.
- Target cross-compilation environment: Modalix/aarch64 sysroot, kept on the platform software line so binaries continue to target the devkit runtime ABI.

This avoids treating the SDK host upgrade as a target runtime/toolchain upgrade.

## Developer Impact
Developers should be able to install the Model SDK extension 2.1.1 inside the Neat SDK container without the previous toolchain mismatch failures.

Downstream projects should continue using the Modalix cross-compilation path for target builds. If a target dependency is missing from the sysroot, the new `sysroot` command provides a way to install it into the sysroot without rebuilding the SDK image.

## Validation
- Branch is clean and pushed to `origin/2.1.1-prep`.
- Compared against `origin/develop`; changes are limited to SDK Docker/build scripts, sysroot tooling, docs, and smoke test coverage.
- SDK smoke coverage was updated to include the Modalix cross-compilation path.
