### PR TITLE
Fix Modalix sysroot C++ runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
 ARG NEAT_INSIGHT_BRANCH=main
 ARG NEAT_INSIGHT_VERSION=latest
-ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
+ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libstdc++6 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
 	protobuf-compiler-grpc,\

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -40,11 +40,15 @@ test_modalix_cross_toolchain() {
   local smoke_src="${WORK_DIR}/modalix-cross-smoke.cpp"
   local smoke_bin="${WORK_DIR}/modalix-cross-smoke"
   local compiler="${CXX:-aarch64-linux-gnu-g++}"
+  local sysroot_libdir="${SYSROOT}/usr/lib/aarch64-linux-gnu"
+  local sysroot_gcc_libdir="${SYSROOT}/usr/lib/gcc/aarch64-linux-gnu/12"
 
   test "${SYSROOT}" = "/opt/toolchain/aarch64/modalix"
   command -v "${compiler}"
   test -d "${SYSROOT}/usr/include"
-  test -d "${SYSROOT}/usr/lib/aarch64-linux-gnu"
+  test -d "${sysroot_libdir}"
+  test -e "${sysroot_libdir}/libMLArt.so"
+  test -e "${sysroot_libdir}/libstdc++.so.6"
 
   cat > "${smoke_src}" <<'EOF'
 #include <iostream>
@@ -55,7 +59,18 @@ int main() {
 }
 EOF
 
-  "${compiler}" --sysroot="${SYSROOT}" -o "${smoke_bin}" "${smoke_src}"
+  "${compiler}" \
+    --sysroot="${SYSROOT}" \
+    -L"${sysroot_gcc_libdir}" \
+    -L"${sysroot_libdir}" \
+    -Wl,-rpath-link,"${sysroot_gcc_libdir}" \
+    -Wl,-rpath-link,"${sysroot_libdir}" \
+    -Wl,-rpath-link,"${SYSROOT}/lib/aarch64-linux-gnu" \
+    -o "${smoke_bin}" \
+    "${smoke_src}" \
+    -Wl,--no-as-needed \
+    -lMLArt \
+    -Wl,--as-needed
   file "${smoke_bin}"
   file "${smoke_bin}" | grep -Eq 'aarch64|ARM aarch64|ARM64'
 }


### PR DESCRIPTION
## Summary

Adds the target C++ runtime package to the Modalix SDK sysroot and strengthens the SDK smoke test so it catches MLArt transitive C++ runtime linkage failures.

## Why

Internals failed on a clean arm64 Ubuntu/Vulcan path because `libMLArt.so` declares `DT_NEEDED: libstdc++.so.6`, but the SDK sysroot did not contain `/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu/libstdc++.so.6`. The previous smoke test only compiled a trivial C++ binary and did not link against MLArt, so it missed this.

## Changes

- Add `libstdc++6` to `SDK_SYSROOT_PKG_LIST`, which installs `libstdc++6:arm64` into the Modalix sysroot.
- Update the Modalix cross-toolchain smoke test to require `libMLArt.so` and `libstdc++.so.6`, then link the smoke binary against `-lMLArt`.

## Validation

- `bash -n tests/sdk/run-in-container.sh`
- `git diff --check`
- Clean arm64 Ubuntu machine validation confirmed the SDK/Internals build works with this fix.
