### PR TITLE
Fix x86 sysroot overlay apt resolution

### DIFF
--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -68,6 +68,7 @@ if [[ " ${TARGET_ARCHES[*]} " == *" arm64 "* && -z "${LINUX_LIBC_DEV_ARM64_VERSI
   exit 1
 fi
 
+APT_TARGET_ARCH="${TARGET_ARCHES[0]}"
 export DEBIAN_FRONTEND=noninteractive
 
 workdir="$(mktemp -d)"
@@ -77,6 +78,7 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "${SYSROOT}" "${LIBDIR}" "${workdir}/archives/partial" "${workdir}/linux-libc-dev"
+touch "${workdir}/status"
 
 # apt downloads as the sandbox user _apt. mktemp creates a 0700 root-owned
 # directory, so make only the download staging paths accessible to avoid
@@ -89,32 +91,26 @@ fi
 echo "Downloading sysroot overlay packages into ${SYSROOT}"
 printf '  %s\n' "${PACKAGES[@]}"
 
-# In cross builds, apt treats some packages as Multi-Arch: same and requires
-# the host and target architecture versions to match. Download the target
-# linux-libc-dev version that matches the installed host package here, then
-# replace the sysroot headers with the SDK-pinned version below.
-native_arch="$(dpkg --print-architecture)"
-if [[ " ${TARGET_ARCHES[*]} " != *" ${native_arch} "* ]] &&
-   dpkg-query -W -f='${Status}' linux-libc-dev 2>/dev/null | grep -q "install ok installed"; then
-  native_linux_libc_version="$(dpkg-query -W -f='${Version}' linux-libc-dev)"
-  for arch in "${TARGET_ARCHES[@]}"; do
-    PACKAGES+=("linux-libc-dev:${arch}=${native_linux_libc_version}")
-  done
-fi
-
 apt-get update --allow-releaseinfo-change
 apt-get install -y --download-only --no-install-recommends \
   --reinstall \
+  -o APT::Architecture="${APT_TARGET_ARCH}" \
   -o Dir::Cache::archives="${workdir}/archives" \
+  -o Dir::State::status="${workdir}/status" \
   "${PACKAGES[@]}"
 
 find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
   | while IFS= read -r -d '' deb; do
       deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
+      deb_pkg="$(dpkg-deb -f "${deb}" Package)"
       # Apt may download host-arch helper packages while solving target deps.
       # Only target-arch and arch-independent payloads belong in this sysroot.
       if [[ "${deb_arch}" != "all" && " ${TARGET_ARCHES[*]} " != *" ${deb_arch} "* ]]; then
         echo "Skipping $(basename "${deb}") for architecture ${deb_arch}"
+        continue
+      fi
+      if [[ "${deb_pkg}" == "linux-libc-dev" && "${deb_arch}" == "arm64" ]]; then
+        echo "Skipping $(basename "${deb}"); extracting SDK-pinned arm64 headers separately"
         continue
       fi
       echo "Extracting $(basename "${deb}")"
@@ -122,8 +118,8 @@ find "${workdir}/archives" -maxdepth 1 -type f -name '*.deb' -print0 \
     done
 
 # The official Modalix 2.0 SDK sysroot uses SiMa's 6.1.22 arm64 UAPI headers.
-# Download this .deb directly so apt's multiarch resolver cannot reject it for
-# differing from the native amd64 linux-libc-dev package installed in the image.
+# Download this .deb directly so sysroot headers do not depend on the native
+# linux-libc-dev version installed in the image.
 for arch in "${TARGET_ARCHES[@]}"; do
   if [[ "${arch}" != "arm64" ]]; then
     continue


### PR DESCRIPTION
## Summary

Fixes the SDK 2.0 sysroot overlay installer when building llima from an x86 SDK container.

The previous script tried to satisfy apt's multiarch resolver by appending the native `linux-libc-dev` version for each target architecture. On x86 SDK containers this produced requests like:

```text
linux-libc-dev:arm64=6.1.172-1
```

That exact arm64 package version is not available in the configured target repositories, so llima builds failed before the script could extract the SDK-pinned Modalix UAPI headers.

## Root Cause

On x86:

- native architecture is `amd64`
- sysroot target architecture is `arm64`
- native `linux-libc-dev` can be a Debian host version such as `6.1.172-1`
- target arm64 repositories do not provide that exact `linux-libc-dev:arm64` version

On Mac/aarch64 this did not reproduce because native and target architecture both resolve as arm64, so the native-version injection path was skipped.

## Changes

- Use a temporary apt status file for sysroot overlay downloads.
- Set `APT::Architecture` to the target architecture during the download step.
- Remove the native `linux-libc-dev` version injection.
- Continue extracting the SDK-pinned Modalix arm64 headers separately:
  `linux-libc-dev:arm64=6.1.22-modalix-827`.
- Skip any `linux-libc-dev:arm64` package that appears through dependency resolution so the final headers remain deterministic.

## Validation

- `bash -n sdk/scripts/install-sysroot-overlay.sh`
- `git diff --check`
- On `ll2`, copied the patched script into the running `ghcr.io/sima-neat/sdk:latest` container and ran it against temporary sysroots.
- Verified a small representative overlay package set.
- Verified the full llima overlay package set:
  `libopencv-flann406`, `libopencv-dnn406`, `libopencv-features2d406`, `libopencv-objdetect406`, `libopencv-video406`, `libssl-dev`, `libfmt9`, `libspdlog1.10`, `libcpp-httplib0.11`, and `libpgm-dev` for `arm64`.
- Confirmed the patched path no longer asks apt for `linux-libc-dev:arm64=6.1.172-1` and still extracts `linux-libc-dev:arm64=6.1.22-modalix-827`.

Fixes #20.
