### PR TITLE
[codex] Wait for Insight readiness in SDK smoke

### DIFF
--- a/tests/sdk/neat-status/validate_neat_status.py
+++ b/tests/sdk/neat-status/validate_neat_status.py
@@ -50,7 +50,7 @@ def validate_status(data):
         add_error(errors, "Missing components.insight.tag")
     if not insight.get("venv"):
         add_error(errors, "Missing components.insight.venv")
-    if insight.get("serviceState") not in {"Running", "Starting", "Unknown"}:
+    if insight.get("serviceState") != "Running":
         add_error(
             errors,
             f"Unexpected components.insight.serviceState: {insight.get('serviceState')}",

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -8,6 +8,7 @@ HELLO_WORK="${WORK_DIR}/hello-neat"
 REPRESENTATIVE_SRC="${ROOT_DIR}/representative-builds"
 REPRESENTATIVE_WORK="${WORK_DIR}/representative-builds"
 STATUS_JSON="${WORK_DIR}/neat-status.json"
+INSIGHT_WAIT_SECONDS="${NEAT_SDK_INSIGHT_WAIT_SECONDS:-30}"
 
 setup_sdk_environment() {
   if [[ -f /opt/bin/simaai-init-build-env ]]; then
@@ -32,8 +33,41 @@ run_test() {
 }
 
 test_neat_status() {
+  local deadline
+  local insight_state
+
   echo "::group::Neat status"
-  neat --json | tee "${STATUS_JSON}"
+  deadline=$((SECONDS + INSIGHT_WAIT_SECONDS))
+  while true; do
+    neat --json | tee "${STATUS_JSON}"
+    insight_state="$(
+      python3 - "${STATUS_JSON}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+print((data.get("components", {}).get("insight", {}) or {}).get("serviceState", ""))
+PY
+    )"
+
+    if [[ "${insight_state}" == "Running" ]] || (( SECONDS >= deadline )); then
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ "${insight_state}" != "Running" ]] && command -v insight-admin >/dev/null 2>&1; then
+    echo "Insight did not report Running within ${INSIGHT_WAIT_SECONDS}s; collecting supervisor diagnostics."
+    insight-admin status || true
+    insight-admin logs 120 || true
+  fi
+
+  if [[ "${insight_state}" != "Running" ]]; then
+    echo "Unexpected Insight service state after ${INSIGHT_WAIT_SECONDS}s: ${insight_state:-unknown}" >&2
+    return 1
+  fi
+
   python3 "${ROOT_DIR}/neat-status/validate_neat_status.py" "${STATUS_JSON}"
   echo "::endgroup::"
 }


### PR DESCRIPTION
## Summary

Update the SDK smoke test so Insight readiness handles startup timing differences without weakening the test.

## Root Cause

The smoke test queried `neat --json` immediately after SDK container setup. On slower arm64 runners, Supervisor may not have finished starting `neat-insight` yet, so the first status sample can report a non-running state even though Insight starts successfully shortly afterward.

## Changes

- Poll `neat --json` for up to 30 seconds waiting for Insight to report `Running`.
- Collect `insight-admin status` and recent Insight logs if readiness does not happen in time.
- Keep the final status validation strict: `components.insight.serviceState` must be `Running`.

## Validation

- `bash -n tests/sdk/run-in-container.sh`
- Ran the status JSON validator against a representative passing sample.
