### PR TITLE
Port SDK release process to develop and harden DevKit compatibility checks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: Build SDK Docker Image
 
 on:
   push:
@@ -130,9 +130,16 @@ jobs:
           mkdir -p image-metadata
 
           release_tag=""
+          release_latest_tag=""
           promote_latest=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            release_tag="${GITHUB_REF_NAME#v}"
+            release_tag="${GITHUB_REF_NAME}"
+            if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+$ ]]; then
+              release_latest_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-latest"
+            else
+              echo "Release tags must use vX.Y.Z format: ${GITHUB_REF_NAME}" >&2
+              exit 1
+            fi
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             promote_latest=true
           fi
@@ -143,6 +150,7 @@ jobs:
             echo "staged_tag=staged-${GITHUB_SHA}"
             echo "commit_sha=${GITHUB_SHA}"
             echo "release_tag=${release_tag}"
+            echo "release_latest_tag=${release_latest_tag}"
             echo "promote_latest=${promote_latest}"
           } > image-metadata/image.env
         env:
@@ -248,7 +256,7 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install sima-cli
-          sima-cli version
+          sima-cli --version
 
       - name: Configure sima-cli access token
         env:
@@ -359,14 +367,20 @@ jobs:
           # shellcheck disable=SC1090
           source "${metadata_file}"
 
-          if [[ "${promote_latest}" != "true" && -z "${release_tag}" ]]; then
+          if [[ "${promote_latest}" != "true" && -z "${release_tag}" && -z "${release_latest_tag:-}" ]]; then
             echo "Promotion skipped: no release tag or latest promotion requested."
             exit 0
           fi
 
-          tags=(--tag "${repository}:latest")
+          tags=()
+          if [[ "${promote_latest}" == "true" ]]; then
+            tags+=(--tag "${repository}:latest")
+          fi
           if [[ -n "${release_tag}" ]]; then
-            tags=(--tag "${repository}:${release_tag}" --tag "${repository}:latest")
+            tags+=(--tag "${repository}:${release_tag}")
+          fi
+          if [[ -n "${release_latest_tag:-}" ]]; then
+            tags+=(--tag "${repository}:${release_latest_tag}")
           fi
 
           docker buildx imagetools create \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+run-name: Release ${{ inputs.tag }} from ${{ inputs.source_branch }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_line:
+        description: Minor release line, for example 2.1. Creates or reuses release-2.1.
+        required: true
+        type: string
+      tag:
+        description: Patch release version without v prefix, for example 2.1.2.
+        required: true
+        type: string
+      source_branch:
+        description: Source branch for creating a new release branch.
+        required: true
+        type: string
+        default: develop
+      branch_exists_behavior:
+        description: Behavior when release-{release_line} already exists.
+        required: true
+        type: choice
+        default: reuse
+        options:
+          - reuse
+          - fail
+          - update_from_source
+      tag_exists_behavior:
+        description: Behavior when v{tag} already exists.
+        required: true
+        type: choice
+        default: fail
+        options:
+          - fail
+          - move
+      release_notes_mode:
+        description: Release notes source for the draft GitHub release.
+        required: true
+        type: choice
+        default: generated
+        options:
+          - generated
+          - empty
+          - from_file
+      release_notes_file:
+        description: Release notes file path when release_notes_mode is from_file.
+        required: false
+        type: string
+        default: ""
+      prerelease:
+        description: Mark the draft release as a prerelease.
+        required: false
+        type: boolean
+        default: false
+      latest:
+        description: Mark the release as latest when published.
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: Resolve and print actions without pushing branches, tags, or releases.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: sima-neat/.github/.github/workflows/vulcan-release.yml@main
+    with:
+      release_line: ${{ inputs.release_line }}
+      tag: ${{ inputs.tag }}
+      source_branch: ${{ inputs.source_branch }}
+      branch_exists_behavior: ${{ inputs.branch_exists_behavior }}
+      tag_exists_behavior: ${{ inputs.tag_exists_behavior }}
+      release_notes_mode: ${{ inputs.release_notes_mode }}
+      release_notes_file: ${{ inputs.release_notes_file }}
+      prerelease: ${{ inputs.prerelease }}
+      latest: ${{ inputs.latest }}
+      dry_run: ${{ inputs.dry_run }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,14 @@ FROM ${SDK_BASE_IMAGE}
 ARG SDK_PKG_LIST
 ARG SDK_GIT_BRANCH=unknown
 ARG SDK_GIT_HASH=nogit
+ARG SDK_RELEASE_REF=unknown-nogit
 ARG BASE_SDK_VERSION=2.1.2
 ARG MINIMAL_IMAGE=0
 ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
-ARG NEAT_INSIGHT_BRANCH=main
-ARG NEAT_INSIGHT_VERSION=latest
+ARG NEAT_CORE_TARGET=
+ARG NEAT_INSIGHT_BRANCH=
+ARG NEAT_INSIGHT_VERSION=
 ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libstdc++6 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
@@ -32,8 +34,10 @@ ENV NEAT_INSIGHT_SUPERVISED=1
 ENV RUSTUP_HOME=/opt/toolchain/rust
 ENV CARGO_HOME=/opt/toolchain/rust
 ENV SDK_GIT_BRANCH="${SDK_GIT_BRANCH}"
+ENV SDK_RELEASE_REF="${SDK_RELEASE_REF}"
 ENV SDK_IMAGE_BRANCH="${SDK_GIT_BRANCH}"
-ENV SDK_IMAGE_TAG=latest
+ENV SDK_IMAGE_TAG="${SDK_RELEASE_REF}"
+ENV SDK_PROMPT_HOSTNAME="neat-sdk-${SDK_RELEASE_REF}"
 ENV PATH="${NEAT_INSIGHT_VENV_DIR}/bin:${CARGO_HOME}/bin:${PATH}"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -116,6 +120,7 @@ RUN aarch64-linux-gnu-gcc --version && \
     rm -f /tmp/cross-smoke.o /tmp/cross-smoke.c /tmp/cross-smoke.cpp /tmp/cross-smoke-cxx
 
 COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
+COPY deps/manifest.json /usr/local/share/sima-sdk/deps/manifest.json
 COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
 
 RUN chmod 755 /usr/local/bin/configure-apt-repos.sh && \
@@ -134,12 +139,14 @@ COPY scripts/simaai-init-build-env /opt/bin/simaai-init-build-env
 COPY scripts/simaai_setup_sdk.py /opt/bin/simaai_setup_sdk.py
 COPY scripts/install-rustup.sh /usr/local/bin/install-rustup.sh
 COPY scripts/install-sima-cli.sh /usr/local/bin/install-sima-cli.sh
+COPY scripts/neat-deps.sh /usr/local/bin/neat-deps.sh
 COPY scripts/setup-sdk-sysroot.sh /usr/local/bin/setup-sdk-sysroot.sh
 COPY scripts/validate-sysroot-package-versions.sh /usr/local/bin/validate-sysroot-package-versions.sh
 RUN chmod 755 /opt/bin/simaai-init-build-env \
               /opt/bin/simaai_setup_sdk.py \
               /usr/local/bin/install-rustup.sh \
               /usr/local/bin/install-sima-cli.sh \
+              /usr/local/bin/neat-deps.sh \
               /usr/local/bin/setup-sdk-sysroot.sh \
               /usr/local/bin/validate-sysroot-package-versions.sh
 
@@ -178,14 +185,19 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/devkit.sh && \
     install-sdk-sysroot-overlay.sh
 
-RUN /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH}" "${NEAT_INSIGHT_VERSION}" && \
+RUN if [ -n "${NEAT_INSIGHT_BRANCH}${NEAT_INSIGHT_VERSION}" ]; then \
+      /usr/local/bin/insight-admin update "${NEAT_INSIGHT_BRANCH:-main}" "${NEAT_INSIGHT_VERSION:-latest}"; \
+    else \
+      /usr/local/bin/insight-admin update; \
+    fi && \
     chmod -R a+rwX "${NEAT_INSIGHT_VENV_DIR}"
 
 COPY config/profile.d/*.sh /etc/profile.d/
 RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
               /etc/profile.d/pkg-config-sysroot.sh
 
-RUN printf 'SDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
+RUN printf 'SDK Release = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
+    "${SDK_RELEASE_REF}" \
     "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
     "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
     > /etc/sdk-release

--- a/build.sh
+++ b/build.sh
@@ -14,8 +14,9 @@ DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
 BASE_SDK_VERSION="${BASE_SDK_VERSION:-2.1.2}"
 NEAT_BRANCH="${NEAT_BRANCH:-main}"
 NEAT_VERSION="${NEAT_VERSION:-latest}"
-NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH:-main}"
-NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION:-latest}"
+NEAT_CORE_TARGET="${NEAT_CORE_TARGET:-}"
+NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH:-}"
+NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION:-}"
 NEAT_GITHUB_PAT="${NEAT_GITHUB_PAT:-${GITHUB_PAT:-}}"
 
 usage() {
@@ -36,8 +37,9 @@ Environment overrides:
   BASE_SDK_VERSION  Base eLxr/SiMa SDK package version to install (default: ${BASE_SDK_VERSION})
   NEAT_BRANCH  NEAT Framework branch to bake into /neat-resources (default: ${NEAT_BRANCH})
   NEAT_VERSION  NEAT Framework version/tag to bake into /neat-resources (default: ${NEAT_VERSION})
-  NEAT_INSIGHT_BRANCH  neat-insight branch/release channel to install (default: ${NEAT_INSIGHT_BRANCH})
-  NEAT_INSIGHT_VERSION  neat-insight version/tag to install, or latest (default: ${NEAT_INSIGHT_VERSION})
+  NEAT_CORE_TARGET  Override the Neat Core Vulcan package target from deps/manifest.json
+  NEAT_INSIGHT_BRANCH  Override the Insight branch/release channel from deps/manifest.json
+  NEAT_INSIGHT_VERSION  Override the Insight version/tag from deps/manifest.json
   NEAT_GITHUB_PAT  Secret token for cloning sima-neat/core during image build (default: from GITHUB_PAT or unset)
 EOF
 }
@@ -78,9 +80,19 @@ fi
 
 git_branch="$(git -C "${SCRIPT_DIR}" branch --show-current 2>/dev/null || true)"
 git_hash="$(git -C "${SCRIPT_DIR}" rev-parse --short HEAD 2>/dev/null || true)"
+git_tag=""
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  git_tag="${GITHUB_REF_NAME}"
+elif [[ -z "${GITHUB_REF_TYPE:-}" ]]; then
+  git_tag="$(git -C "${SCRIPT_DIR}" describe --tags --exact-match HEAD 2>/dev/null || true)"
+fi
 
 if [[ -z "${git_branch}" ]]; then
-  git_branch="unknown"
+  if [[ "${GITHUB_REF_TYPE:-}" == "branch" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    git_branch="${GITHUB_REF_NAME}"
+  else
+    git_branch="unknown"
+  fi
 fi
 
 if [[ -z "${git_hash}" ]]; then
@@ -88,6 +100,12 @@ if [[ -z "${git_hash}" ]]; then
 fi
 
 git_branch="${git_branch//\//_}"
+
+if [[ -n "${git_tag}" ]]; then
+  sdk_release_ref="${git_tag}"
+else
+  sdk_release_ref="${git_branch}-${git_hash}"
+fi
 
 host_arch="$(uname -m)"
 
@@ -115,6 +133,7 @@ echo "Host architecture: ${host_arch}"
 echo "Docker platform: ${docker_platform}"
 echo "Git branch: ${git_branch}"
 echo "Git hash: ${git_hash}"
+echo "SDK release ref: ${sdk_release_ref}"
 echo "Base SDK version: ${BASE_SDK_VERSION}"
 echo "SDK base image: ${SDK_BASE_IMAGE}"
 echo "SDK cross toolchain image: ${SDK_CROSS_TOOLCHAIN_IMAGE}"
@@ -124,8 +143,9 @@ if [[ "${MINIMAL_IMAGE}" == "1" ]]; then
 fi
 echo "NEAT branch: ${NEAT_BRANCH}"
 echo "NEAT version: ${NEAT_VERSION}"
-echo "NEAT Insight branch: ${NEAT_INSIGHT_BRANCH}"
-echo "NEAT Insight version: ${NEAT_INSIGHT_VERSION}"
+echo "NEAT Core target override: ${NEAT_CORE_TARGET:-<deps/manifest.json>}"
+echo "NEAT Insight branch override: ${NEAT_INSIGHT_BRANCH:-<deps/manifest.json>}"
+echo "NEAT Insight version override: ${NEAT_INSIGHT_VERSION:-<deps/manifest.json>}"
 
 if docker buildx version >/dev/null 2>&1; then
   buildx_cmd=(
@@ -138,10 +158,12 @@ if docker buildx version >/dev/null 2>&1; then
     --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
     --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
     --build-arg NEAT_VERSION="${NEAT_VERSION}"
+    --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"
     --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
     --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
     --build-arg SDK_GIT_BRANCH="${git_branch}"
     --build-arg SDK_GIT_HASH="${git_hash}"
+    --build-arg SDK_RELEASE_REF="${sdk_release_ref}"
     -f "${DOCKERFILE}"
     -t "${image_ref}"
   )
@@ -161,10 +183,12 @@ build_cmd=(
   --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
   --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
   --build-arg NEAT_VERSION="${NEAT_VERSION}"
+  --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"
   --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
   --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
   --build-arg SDK_GIT_BRANCH="${git_branch}"
   --build-arg SDK_GIT_HASH="${git_hash}"
+  --build-arg SDK_RELEASE_REF="${sdk_release_ref}"
   -f "${DOCKERFILE}"
   -t "${image_ref}"
 )

--- a/config/profile.d/neat-sdk-prompt.sh
+++ b/config/profile.d/neat-sdk-prompt.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 if [[ $- == *i* ]]; then
   export SDK_IMAGE_BRANCH="${SDK_IMAGE_BRANCH:-${SDK_GIT_BRANCH:-main}}"
-  export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-latest}"
+  export SDK_PROMPT_REF="${SDK_RELEASE_REF:-${SDK_IMAGE_TAG:-latest}}"
+  export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-${SDK_PROMPT_REF}}"
   _sdk_prompt_slug() {
     local value="${1-}"
     value="${value//\//-}"
@@ -10,7 +11,7 @@ if [[ $- == *i* ]]; then
     value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-|-$//g')"
     printf '%s' "${value:-unknown}"
   }
-  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-$(_sdk_prompt_slug "${SDK_IMAGE_BRANCH}")-$(_sdk_prompt_slug "${SDK_IMAGE_TAG}")}"
+  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-$(_sdk_prompt_slug "${SDK_PROMPT_REF}")}"
   _sdk_rewrite_prompt_hostname() {
     local prompt="${1-}"
     prompt="${prompt//\\h/${SDK_PROMPT_HOSTNAME}}"

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,0 +1,9 @@
+{
+  "core": {
+    "ref": "develop:latest"
+  },
+  "insight": {
+    "ref": "main:latest"
+  },
+  "platform-version": "2.1.2"
+}

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -35,9 +35,9 @@ check_devkit_sdk_version_compatibility() {
   echo "Checking DevKit/SDK version compatibility..."
 
   if [[ ! -r "${sdk_release}" ]]; then
-    printf "%bWARNING:%b SDK release file not found or unreadable: %s\n" "${c_warn}" "${c_reset}" "${sdk_release}" >&2
-    printf "Please use an SDK image that includes /etc/sdk-release before connecting a DevKit.\n" >&2
-    return 0
+    printf "%bERROR:%b SDK release file not found or unreadable: %s\n" "${c_warn}" "${c_reset}" "${sdk_release}" >&2
+    printf "Use an SDK image that includes /etc/sdk-release before connecting a DevKit.\n" >&2
+    return 1
   fi
 
   devkit_distro_version="$(
@@ -56,9 +56,9 @@ EOS
   )"
 
   if [[ -z "${devkit_distro_version}" ]]; then
-    printf "%bWARNING:%b Could not read DISTRO_VERSION from DevKit /etc/buildinfo.\n" "${c_warn}" "${c_reset}" >&2
-    printf "Please update your DevKit to a build that exposes /etc/buildinfo with DISTRO_VERSION.\n" >&2
-    return 0
+    printf "%bERROR:%b Could not read DISTRO_VERSION from DevKit /etc/buildinfo.\n" "${c_warn}" "${c_reset}" >&2
+    printf "Update your DevKit to a build that exposes /etc/buildinfo with DISTRO_VERSION, then reconnect.\n" >&2
+    return 1
   fi
 
   if grep -Fq "${devkit_distro_version}" "${sdk_release}"; then
@@ -79,7 +79,7 @@ EOS
   fi
 
   {
-    printf "%bWARNING: DevKit/SDK version mismatch.\n" "${c_warn}"
+    printf "%bERROR: DevKit/SDK version mismatch.\n" "${c_warn}"
     printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}"
     printf "  SDK release file     : %s\n" "${sdk_release}"
     sed 's/^/    /' "${sdk_release}"
@@ -89,7 +89,7 @@ EOS
       printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.%b\n" "${sdk_release}" "${c_reset}"
     fi
   } >&2
-  return 0
+  return 1
 }
 
 sync_neat_framework_to_devkit() {
@@ -526,6 +526,10 @@ if ! timeout --foreground 120 "${_SSH_COPY_ID_CMD[@]}" -i "${HOME}/.ssh/id_ed255
 fi
 
 check_devkit_sdk_version_compatibility "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"
+_DEVKIT_COMPAT_STATUS=$?
+if (( _DEVKIT_COMPAT_STATUS != 0 )); then
+  return "${_DEVKIT_COMPAT_STATUS}"
+fi
 
 if [[ "${_DEVKIT_USER}" != "root" ]]; then
   if ! check_remote_passwordless_sudo "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_PORT}"; then

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -751,7 +751,8 @@ export DEVKIT_SYNC_MOUNT_POINT="${_MOUNT_POINT}"
 export DEVKIT_SYNC_DEVKIT_USER="${_DEVKIT_USER}"
 export DEVKIT_SYNC_DEVKIT_PORT="${_DEVKIT_PORT}"
 export SDK_IMAGE_BRANCH="${SDK_IMAGE_BRANCH:-${SDK_GIT_BRANCH:-main}}"
-export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-latest}"
+export SDK_PROMPT_REF="${SDK_RELEASE_REF:-${SDK_IMAGE_TAG:-latest}}"
+export SDK_IMAGE_TAG="${SDK_IMAGE_TAG:-${SDK_PROMPT_REF}}"
 __devkit_prompt_slug() {
   local value="${1-}"
   value="${value//\//-}"
@@ -760,7 +761,7 @@ __devkit_prompt_slug() {
   value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-|-$//g')"
   printf '%s' "${value:-unknown}"
 }
-export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-$(__devkit_prompt_slug "${SDK_IMAGE_BRANCH}")-$(__devkit_prompt_slug "${SDK_IMAGE_TAG}")}"
+export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-$(__devkit_prompt_slug "${SDK_PROMPT_REF}")}"
 
 __devkit_rewrite_prompt_hostname() {
   local prompt="${1-}"
@@ -1101,6 +1102,8 @@ _persist_file="${HOME}/.devkit-sync.rc"
   echo "export DEVKIT_SYNC_MOUNT_POINT='${DEVKIT_SYNC_MOUNT_POINT}'"
   echo "export DEVKIT_SYNC_DEVKIT_USER='${DEVKIT_SYNC_DEVKIT_USER}'"
   echo "export DEVKIT_SYNC_DEVKIT_PORT='${DEVKIT_SYNC_DEVKIT_PORT}'"
+  echo "export SDK_RELEASE_REF='${SDK_RELEASE_REF:-}'"
+  echo "export SDK_PROMPT_REF='${SDK_PROMPT_REF}'"
   echo "export SDK_IMAGE_BRANCH='${SDK_IMAGE_BRANCH}'"
   echo "export SDK_IMAGE_TAG='${SDK_IMAGE_TAG}'"
   echo "export SDK_PROMPT_HOSTNAME='${SDK_PROMPT_HOSTNAME}'"

--- a/scripts/insight-admin.sh
+++ b/scripts/insight-admin.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/neat-deps.sh"
+
 program_name="$(basename "$0")"
 command="${1:-}"
 
@@ -14,8 +17,8 @@ Usage:
   ${program_name} logs [lines]
 
 Defaults:
-  branch  = \${NEAT_INSIGHT_BRANCH:-main}
-  version = \${NEAT_INSIGHT_VERSION:-latest}
+  branch/version come from deps/manifest.json unless NEAT_INSIGHT_TARGET,
+  NEAT_INSIGHT_BRANCH, or NEAT_INSIGHT_VERSION is set.
 EOF
 }
 
@@ -58,10 +61,17 @@ is_supervisor_running() {
 }
 
 update_insight() {
-  local branch="${1:-${NEAT_INSIGHT_BRANCH:-main}}"
-  local version="${2:-${NEAT_INSIGHT_VERSION:-latest}}"
+  local branch="${1:-${NEAT_INSIGHT_BRANCH:-}}"
+  local version="${2:-${NEAT_INSIGHT_VERSION:-}}"
   local venv_dir="${NEAT_INSIGHT_VENV_DIR:-/opt/neat-insight/venv}"
+  local insight_target
   local tmp_dir
+
+  if [[ -n "${branch}" ]]; then
+    insight_target="insight@${branch}:${version:-latest}"
+  else
+    insight_target="${NEAT_INSIGHT_TARGET:-$(neat_dependency_target insight insight)}"
+  fi
 
   tmp_dir="$(mktemp -d /tmp/install-neat-insight.XXXXXX)"
   trap 'rm -rf "${tmp_dir}"' EXIT
@@ -69,7 +79,7 @@ update_insight() {
   run_as_root env \
     NEAT_INSIGHT_VENV_DIR="${venv_dir}" \
     SIMA_CLI_CHECK_FOR_UPDATE=0 \
-    sima-cli neat install -d "${tmp_dir}" "insight@${branch}:${version}"
+    sima-cli neat install -d "${tmp_dir}" "${insight_target}"
   run_as_root ln -sf "${venv_dir}/bin/neat-insight" /usr/local/bin/neat-insight
   rm -rf "${tmp_dir}"
   trap - EXIT

--- a/scripts/install-neat-resources.sh
+++ b/scripts/install-neat-resources.sh
@@ -2,11 +2,17 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/neat-deps.sh"
+
 mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src
+
+core_target="${NEAT_CORE_TARGET:-$(neat_dependency_target core core)}"
 
 (
   cd /neat-resources/core-extra
-  SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli neat install core@develop -t minimal
+  echo "Installing prepackaged Neat Library: ${core_target}"
+  SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli neat install "${core_target}" -t minimal
 )
 
 find /neat-resources/core-extra -type f \

--- a/scripts/install-sima-cli.sh
+++ b/scripts/install-sima-cli.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 root_venv=/root/.sima-cli/.venv
 install_venv=/opt/sima-cli/venv
 
-if ! curl -fsSL https://docs.sima.ai/_static/tools/sima-cli-installer.sh | bash; then
+if ! curl -fsSL https://artifacts.neat.sima.ai/sima-cli/linux-mac.sh | bash; then
   test -x "${root_venv}/bin/sima-cli"
 fi
 test -x "${root_venv}/bin/sima-cli"
@@ -15,7 +15,7 @@ cp -a "${root_venv}" "${install_venv}"
 while IFS= read -r -d '' launcher; do
   sed -i '1 s#/root/.sima-cli/.venv#/opt/sima-cli/venv#' "${launcher}"
 done < <(grep -IlZ '^#!.*/root/.sima-cli/.venv' "${install_venv}"/bin/* 2>/dev/null || true)
-chmod -R a+rX /opt/sima-cli
+chmod -R a+rwX /opt/sima-cli
 cat >/usr/local/bin/sima-cli <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail

--- a/scripts/neat-deps.sh
+++ b/scripts/neat-deps.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+neat_deps_manifest_path() {
+  local script_dir repo_manifest image_manifest
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_manifest="${script_dir}/../deps/manifest.json"
+  image_manifest="/usr/local/share/sima-sdk/deps/manifest.json"
+
+  if [[ -n "${SDK_DEPS_MANIFEST:-}" ]]; then
+    printf '%s\n' "${SDK_DEPS_MANIFEST}"
+  elif [[ -f "${image_manifest}" ]]; then
+    printf '%s\n' "${image_manifest}"
+  else
+    printf '%s\n' "${repo_manifest}"
+  fi
+}
+
+neat_dependency_target() {
+  local key="$1"
+  local repo="$2"
+  local manifest
+
+  manifest="$(neat_deps_manifest_path)"
+  python3 - "${manifest}" "${key}" "${repo}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+key, repo = sys.argv[2:4]
+
+
+def validate_ref(raw: str) -> str:
+    ref = raw.strip()
+    if not ref:
+        raise SystemExit(f"ERROR: {manifest_path} dependency {key!r} has an empty ref.")
+    if "@" in ref or any(ch.isspace() for ch in ref):
+        raise SystemExit(
+            f"ERROR: {manifest_path} dependency {key!r} ref must not contain '@' or whitespace: {ref!r}"
+        )
+    if ":" not in ref:
+        if not re.fullmatch(r"[A-Za-z0-9._/-]+", ref):
+            raise SystemExit(
+                f"ERROR: {manifest_path} dependency {key!r} ref must be a git tag/ref like v0.1.0: {ref!r}"
+            )
+        return ref
+    if ref.count(":") != 1:
+        raise SystemExit(
+            f"ERROR: {manifest_path} dependency {key!r} ref must be tag, branch:latest, or branch:githash: {ref!r}"
+        )
+    branch, spec = (part.strip() for part in ref.split(":", 1))
+    if not branch or not spec:
+        raise SystemExit(
+            f"ERROR: {manifest_path} dependency {key!r} ref must include both branch and spec: {ref!r}"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9._/-]+", branch):
+        raise SystemExit(
+            f"ERROR: {manifest_path} dependency {key!r} branch contains unsupported characters: {branch!r}"
+        )
+    if spec != "latest" and not re.fullmatch(r"[A-Fa-f0-9]+", spec):
+        raise SystemExit(
+            f"ERROR: {manifest_path} dependency {key!r} spec must be 'latest' or a git hash: {spec!r}"
+        )
+    return f"{branch}:{spec}"
+
+
+if not manifest_path.exists():
+    raise SystemExit(f"ERROR: dependency manifest not found: {manifest_path}")
+
+data = json.loads(manifest_path.read_text(encoding="utf-8"))
+value = data.get(key)
+if value is None:
+    raise SystemExit(f"ERROR: {manifest_path} must define dependency {key!r}.")
+
+if isinstance(value, str):
+    print(f"{repo}@{validate_ref(value)}")
+    raise SystemExit(0)
+
+if isinstance(value, dict):
+    ref = str(value.get("ref", "")).strip()
+    if ref:
+        print(f"{repo}@{validate_ref(ref)}")
+        raise SystemExit(0)
+
+    raise SystemExit(f"ERROR: {manifest_path} dependency {key!r} must define a non-empty ref.")
+
+raise SystemExit(
+    f"ERROR: {manifest_path} field {key!r} must be a string or object with "
+    "{'ref':'...'} using tag, branch:latest, or branch:githash."
+)
+PY
+}


### PR DESCRIPTION
## Summary
- Ports the SDK release-process workflow changes onto the develop line.
- Preserves the develop branch platform context while keeping the release workflow aligned with the main-based PR.
- Adds the DevKit compatibility hard-fail from the main-based branch so incompatible firmware/SDK combinations cannot proceed into Neat framework sync.

## DevKit compatibility behavior
Previously, `devkit.sh` warned when the DevKit firmware version did not match the SDK release metadata, then continued through setup and could install SDK Neat framework packages onto an incompatible DevKit.

This PR makes that check fail closed. DevKit setup now exits before sudo setup, workspace setup, Insight config copy, or Neat framework sync when:
- `/etc/sdk-release` is missing or unreadable in the SDK container.
- `/etc/buildinfo` does not expose `DISTRO_VERSION` on the DevKit.
- The DevKit `DISTRO_VERSION` does not match the SDK release metadata.

## Validation
- Ran `bash -n scripts/devkit.sh`.
