### PR TITLE
Pin SDK Insight dependency to v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # SiMa.ai Neat SDK
 
 [![Build Docker Image](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/docker-build.yml)
-[![Smoke Test](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/sima-neat/sdk/actions/workflows/smoke-test.yml)
 ![Ubuntu](https://img.shields.io/badge/Ubuntu-supported-E95420?logo=ubuntu&logoColor=white)
 ![Windows 11](https://img.shields.io/badge/Windows%2011-supported-0078D4?logo=windows&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-supported-000000?logo=apple&logoColor=white)

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -3,7 +3,7 @@
     "ref": "v0.1.0"
   },
   "insight": {
-    "ref": "main:latest"
+    "ref": "v0.0.2"
   },
   "platform-version": "2.0.0"
 }

--- a/tests/sdk/neat-status/validate_neat_status.py
+++ b/tests/sdk/neat-status/validate_neat_status.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import re
 import sys
 
 
@@ -7,7 +8,28 @@ def add_error(errors, message):
     errors.append(message)
 
 
-def validate_status(data):
+def expected_dependency_ref(manifest, key):
+    if not manifest:
+        return None
+    value = manifest.get(key)
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, dict):
+        ref = str(value.get("ref", "")).strip()
+        return ref or None
+    return None
+
+
+def version_from_tag_ref(ref):
+    if not ref or ":" in ref:
+        return None
+    match = re.fullmatch(r"v?([0-9]+(?:\.[0-9]+){1,3}(?:[A-Za-z0-9._+-]*)?)", ref)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def validate_status(data, manifest=None):
     errors = []
 
     if data.get("schema") != "sima.neat.status.v1":
@@ -44,9 +66,17 @@ def validate_status(data):
             add_error(errors, f"Missing components.{name}.version")
 
     insight = components.get("insight") or {}
+    expected_insight_ref = expected_dependency_ref(manifest, "insight")
+    expected_insight_version = version_from_tag_ref(expected_insight_ref)
     if not insight.get("version"):
         add_error(errors, "Missing components.insight.version")
-    if not insight.get("tag"):
+    elif expected_insight_version and insight.get("version") != expected_insight_version:
+        add_error(
+            errors,
+            "Unexpected components.insight.version: "
+            f"{insight.get('version')} (expected {expected_insight_version} from {expected_insight_ref})",
+        )
+    if not insight.get("tag") and not expected_insight_version:
         add_error(errors, "Missing components.insight.tag")
     if not insight.get("venv"):
         add_error(errors, "Missing components.insight.venv")
@@ -72,14 +102,21 @@ def validate_status(data):
 
 
 def main():
-    if len(sys.argv) != 2:
-        print("Usage: validate_neat_status.py <neat-status.json>", file=sys.stderr)
+    if len(sys.argv) not in {2, 3}:
+        print(
+            "Usage: validate_neat_status.py <neat-status.json> [deps-manifest.json]",
+            file=sys.stderr,
+        )
         return 2
 
     with open(sys.argv[1], encoding="utf-8") as f:
         data = json.load(f)
+    manifest = None
+    if len(sys.argv) == 3:
+        with open(sys.argv[2], encoding="utf-8") as f:
+            manifest = json.load(f)
 
-    errors = validate_status(data)
+    errors = validate_status(data, manifest)
     if errors:
         for error in errors:
             print(error, file=sys.stderr)

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -6,6 +6,7 @@ WORK_DIR="${NEAT_SDK_TEST_WORK_DIR:-/tmp/neat-sdk-smoke-work}"
 HELLO_SRC="${ROOT_DIR}/hello-neat"
 HELLO_WORK="${WORK_DIR}/hello-neat"
 STATUS_JSON="${WORK_DIR}/neat-status.json"
+SDK_DEPS_MANIFEST="${SDK_DEPS_MANIFEST:-/usr/local/share/sima-sdk/deps/manifest.json}"
 
 setup_sdk_environment() {
   if [[ -f /opt/bin/simaai-init-build-env ]]; then
@@ -32,7 +33,7 @@ run_test() {
 test_neat_status() {
   echo "::group::Neat status"
   neat --json | tee "${STATUS_JSON}"
-  python3 "${ROOT_DIR}/neat-status/validate_neat_status.py" "${STATUS_JSON}"
+  python3 "${ROOT_DIR}/neat-status/validate_neat_status.py" "${STATUS_JSON}" "${SDK_DEPS_MANIFEST}"
   echo "::endgroup::"
 }
 


### PR DESCRIPTION
## Summary
- Remove the stale README badge for the retired `smoke-test.yml` workflow.
- Keep the active Docker build workflow badge, which now owns the SDK build and smoke-test flow.
- Pin the SDK Insight dependency in `deps/manifest.json` to the released `v0.0.2` artifact instead of tracking `main:latest`.
- Update the SDK smoke validator to validate the installed Insight version against `deps/manifest.json` when Insight is pinned to a tag.

## Why
The standalone smoke workflow has been deprecated, so the README badge points to a dead workflow. The SDK should also consume the released Insight package for reproducible main-branch SDK builds instead of pulling the latest Insight main artifact.

The smoke failure in run `27484207321` showed that Insight installed successfully as `version: 0.0.2` and the service was running, but `neat --json` reported `components.insight.tag: null`. For a manifest-pinned tag such as `v0.0.2`, the smoke test should validate the installed package version directly instead of failing solely because the status payload cannot populate the optional tag/provenance field.

## Testing
- Reproduced the failed status shape locally with `components.insight.version = 0.0.2` and `components.insight.tag = null`.
- `python3 tests/sdk/neat-status/validate_neat_status.py <status.json> deps/manifest.json`
- `bash -n tests/sdk/run-in-container.sh`
- `git diff --check`
