### PR TITLE
Source SDK build env in login shells

### DIFF
--- a/config/profile.d/pkg-config-sysroot.sh
+++ b/config/profile.d/pkg-config-sysroot.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [[ -f /opt/bin/simaai-init-build-env ]]; then
+  # shellcheck source=/dev/null
+  source /opt/bin/simaai-init-build-env modalix >/dev/null 2>&1 || true
+fi
 export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
 if [[ -z "${PKG_CONFIG:-}" || ! -x "${PKG_CONFIG}" ]]; then
   export PKG_CONFIG="/usr/bin/pkg-config"


### PR DESCRIPTION
## Summary

This PR makes SDK login shells source the standard Modalix build environment from `/opt/bin/simaai-init-build-env modalix` through the existing `/etc/profile.d/pkg-config-sysroot.sh` profile script.

## Why

`sima-cli sdk neat` enters an already-running SDK container with `docker exec ... bash -l`. That path does not rerun the SDK container entrypoint, so the shell can have `SYSROOT` from profile setup without the matching cross-build variables normally exported by the entrypoint:

- `CROSS_COMPILE=aarch64-linux-gnu-`
- `CC=aarch64-linux-gnu-gcc`
- `CXX=aarch64-linux-gnu-g++`

That partial environment can make downstream builds detect SDK cross-build mode from `SYSROOT` while CMake still discovers the host compiler, resulting in a host-compiler plus target-sysroot mismatch.

## Change

The profile script now quietly sources `/opt/bin/simaai-init-build-env modalix` when present before applying the existing pkg-config/sysroot defaults. This keeps interactive SDK shells aligned with the container entrypoint environment while keeping the patch intentionally small for GA.

## Validation

- Ran `bash -n config/profile.d/pkg-config-sysroot.sh`.
- Reproduced the root cause on `ll2`: `sima-cli sdk neat` uses `docker exec ... bash -l`, so this profile path is the right place to normalize the shell environment.
