### PR TITLE
Source SDK build env in login shells

### DIFF
--- a/config/profile.d/pkg-config-sysroot.sh
+++ b/config/profile.d/pkg-config-sysroot.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [[ -f /opt/bin/simaai-init-build-env ]]; then
+  # shellcheck source=/dev/null
+  source /opt/bin/simaai-init-build-env modalix >/dev/null 2>&1 || true
+fi
 export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
 if [[ -z "${PKG_CONFIG:-}" || ! -x "${PKG_CONFIG}" ]]; then
   export PKG_CONFIG="/usr/bin/pkg-config"


### PR DESCRIPTION
## Summary

This PR patches the 2.0.0 SDK line so SDK login shells source the standard Modalix build environment from `/opt/bin/simaai-init-build-env modalix` through `/etc/profile.d/pkg-config-sysroot.sh`.

## Why

`sima-cli sdk neat` attaches to an already-running SDK container using `docker exec ... bash -l`. That path does not rerun the container entrypoint, so manual SDK shells can inherit `SYSROOT` without the cross-build compiler variables normally prepared by the entrypoint:

- `CROSS_COMPILE=aarch64-linux-gnu-`
- `CC=aarch64-linux-gnu-gcc`
- `CXX=aarch64-linux-gnu-g++`

That partial environment can make downstream builds detect SDK cross-build mode from `SYSROOT` while CMake still discovers `/usr/bin/c++`, causing a host compiler plus Modalix target sysroot mismatch.

## Change

The existing pkg-config/sysroot profile script now quietly sources `/opt/bin/simaai-init-build-env modalix` when present. This keeps `sima-cli sdk neat` interactive shells aligned with the SDK entrypoint environment while keeping the patch intentionally minimal for the 2.0.0 patch line.

## Validation

- Ran `bash -n config/profile.d/pkg-config-sysroot.sh`.
- Confirmed on `ll2` that `sima-cli sdk neat` enters via `docker exec ... bash -l`, so `/etc/profile.d` is the relevant startup path for this issue.
