### PR TITLE
Pass GitHub token to SDK smoke setup

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -170,6 +170,7 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     env:
       SIMA_CLI_CHECK_FOR_UPDATE: "0"
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Pass the GitHub Actions token into the SDK smoke job environment so `sima-cli sdk setup` can authenticate GitHub-backed playbook installation inside the SDK container.

## Why

The develop smoke job failed during SDK setup while installing Neat coding-agent playbooks:

```text
Failed to resolve GitHub metadata URL gh:sima-neat/playbooks: 403 Client Error: rate limit exceeded
```

`sima-cli sdk setup` already forwards `GITHUB_TOKEN` into the SDK container for the playbook install command, but the workflow did not define `GITHUB_TOKEN` in the smoke job environment. As a result, `sima-cli install gh:sima-neat/playbooks` could fall back to anonymous GitHub API access and hit rate limits.

## Change

The smoke job now exports:

```yaml
GITHUB_TOKEN: ${{ github.token }}
```

This keeps playbook resolution authenticated during smoke setup without changing the SDK image or playbook installer behavior.

## Validation

- Confirmed the failing job was `Smoke on linux-amd64` in `Run SDK setup`.
- Confirmed the failure was GitHub API rate limiting while resolving `gh:sima-neat/playbooks`.
- Ran `git diff --check`.
