### PR TITLE
Pin SDK aarch64 cross compiler to GCC 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,8 +109,11 @@ RUN apt-get update --allow-releaseinfo-change && \
 
 COPY --from=cross-toolchain /opt/cross-toolchain/ /
 COPY --from=cross-toolchain /opt/cross-toolchain/ /opt/bookworm-cross-toolchain/
+COPY scripts/pin-cross-toolchain.sh /usr/local/bin/pin-cross-toolchain.sh
 
-RUN aarch64-linux-gnu-gcc --version && \
+RUN chmod 755 /usr/local/bin/pin-cross-toolchain.sh && \
+    pin-cross-toolchain.sh && \
+    aarch64-linux-gnu-gcc --version && \
     aarch64-linux-gnu-g++ --version && \
     aarch64-linux-gnu-ld --version && \
     printf 'int main(void) { return 0; }\n' > /tmp/cross-smoke.c && \
@@ -159,6 +162,7 @@ RUN install-rustup.sh
 RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
     install-sima-cli.sh && \
     cp -a /opt/bookworm-cross-toolchain/. / && \
+    pin-cross-toolchain.sh && \
     aarch64-linux-gnu-gcc --version && \
     aarch64-linux-gnu-g++ --version && \
     aarch64-linux-gnu-ld --version && \

--- a/scripts/pin-cross-toolchain.sh
+++ b/scripts/pin-cross-toolchain.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pin_tool() {
+  local tool="$1"
+  local versioned="/usr/bin/${tool}-12"
+  local generic="/usr/bin/${tool}"
+
+  if [[ ! -x "${versioned}" ]]; then
+    echo "Expected GCC 12 cross tool is missing: ${versioned}" >&2
+    return 1
+  fi
+
+  if ! dpkg-divert --list "${generic}" | grep -q .; then
+    dpkg-divert --local --rename --add "${generic}"
+  fi
+
+  ln -sfn "$(basename "${versioned}")" "${generic}"
+}
+
+pin_tool aarch64-linux-gnu-gcc
+pin_tool aarch64-linux-gnu-g++
+
+for tool in aarch64-linux-gnu-gcc-ar aarch64-linux-gnu-gcc-nm aarch64-linux-gnu-gcc-ranlib; do
+  if [[ -x "/usr/bin/${tool}-12" ]]; then
+    pin_tool "${tool}"
+  fi
+done
+
+aarch64-linux-gnu-gcc --version | head -n 1
+aarch64-linux-gnu-g++ --version | head -n 1

--- a/scripts/simaai-init-build-env
+++ b/scripts/simaai-init-build-env
@@ -26,8 +26,16 @@ else
 fi
 
 export CROSS_COMPILE="aarch64-linux-gnu-"
-export CC="${CROSS_COMPILE}gcc"
-export CXX="${CROSS_COMPILE}g++"
+if command -v "${CROSS_COMPILE}gcc-12" >/dev/null 2>&1; then
+	export CC="${CROSS_COMPILE}gcc-12"
+else
+	export CC="${CROSS_COMPILE}gcc"
+fi
+if command -v "${CROSS_COMPILE}g++-12" >/dev/null 2>&1; then
+	export CXX="${CROSS_COMPILE}g++-12"
+else
+	export CXX="${CROSS_COMPILE}g++"
+fi
 export LD="${CROSS_COMPILE}ld"
 export STRIP="${CROSS_COMPILE}strip"
 export OBJDUMP="${CROSS_COMPILE}objdump"


### PR DESCRIPTION
## Summary

Pins the SDK aarch64 cross-compiler entrypoints to the GCC 12 toolchain copied from the Bookworm cross-toolchain stage.

This prevents ARM64 SDK containers from accidentally switching `aarch64-linux-gnu-gcc` / `aarch64-linux-gnu-g++` to Ubuntu 24.04 GCC 13 after package installation. The Modalix sysroot currently carries GCC 12 C++ headers and libraries, so compiling with GCC 13 against the GCC 12 sysroot can break C++ template-heavy builds such as `internals`.

## Why

The failure was reproduced after installing tooling in an `sdk-develop` container:

- `aarch64-linux-gnu-g++` resolved to GCC 13 on ARM64
- `/opt/toolchain/aarch64/modalix/usr/include/c++/12` remained the active sysroot C++ header tree
- `internals` then failed in libstdc++ headers (`type_traits`, `unique_ptr`) while building with the mixed compiler/sysroot combination

On x86 hosts, plain host `gcc` may also be GCC 13, but cross compilation is safe as long as `aarch64-linux-gnu-g++` remains GCC 12. This change enforces that invariant for both x86 and ARM64 SDK images.

## Changes

- Add `scripts/pin-cross-toolchain.sh`.
  - Verifies GCC 12 aarch64 cross tools exist.
  - Uses `dpkg-divert` on generic `aarch64-linux-gnu-*` compiler entrypoints.
  - Relinks the generic compiler names back to the GCC 12 binaries.
- Run the pinning helper in the Docker image after copying the Bookworm cross toolchain.
- Run the pinning helper again after SDK sysroot setup and `sima-cli` installation, since those steps may invoke apt.
- Update `simaai-init-build-env` to prefer explicit `aarch64-linux-gnu-gcc-12` and `aarch64-linux-gnu-g++-12` when available.

## Validation

Local static validation performed:

```bash
bash -n scripts/pin-cross-toolchain.sh
sh -n scripts/simaai-init-build-env
git diff --check
```

Full image validation should verify, on both x86 and ARM64 SDK containers:

```bash
aarch64-linux-gnu-g++ --version
readlink -f "$(command -v aarch64-linux-gnu-g++)"
ls -d /opt/toolchain/aarch64/modalix/usr/include/c++/*
```

Expected invariant:

- `aarch64-linux-gnu-g++` resolves to GCC 12
- Modalix sysroot C++ headers are GCC 12
