### PR TITLE
Sync main fixes into release-2.0

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -170,6 +170,7 @@ jobs:
     runs-on: ${{ matrix.runs_on }}
     env:
       SIMA_CLI_CHECK_FOR_UPDATE: "0"
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
       matrix:

--- a/config/profile.d/pkg-config-sysroot.sh
+++ b/config/profile.d/pkg-config-sysroot.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+if [[ -f /opt/bin/simaai-init-build-env ]]; then
+  # shellcheck source=/dev/null
+  source /opt/bin/simaai-init-build-env modalix >/dev/null 2>&1 || true
+fi
 export SYSROOT="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
 if [[ -z "${PKG_CONFIG:-}" || ! -x "${PKG_CONFIG}" ]]; then
   export PKG_CONFIG="/usr/bin/pkg-config"


### PR DESCRIPTION
## Summary

Merge the current `main` branch fixes into the protected `release-2.0` branch before re-cutting the SDK `v2.0.0` pre-release tag.

This carries over the two small fixes that landed on `main` after `release-2.0` was cut:

- Source `/opt/bin/simaai-init-build-env modalix` from `pkg-config-sysroot.sh` so SDK login shells get the complete Modalix cross-build environment, including compiler and pkg-config settings.
- Pass `GITHUB_TOKEN` into the SDK smoke job so `sima-cli sdk setup` can resolve authenticated GitHub-hosted playbook resources during CI validation.

## Why

`release-2.0` is protected, so this PR provides the reviewable path for bringing the 2.0 release branch up to the current `main` fix level. These changes are intended to be included before deleting and recreating the `v2.0.0` pre-release tag on the updated `release-2.0` head.

## Validation

Not run locally. The change set is limited to one workflow environment variable and one SDK profile script update that already landed on `main`.
