### PR TITLE
Pin Neat core dependency to v0.2.0

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,6 +1,6 @@
 {
   "core": {
-    "ref": "develop:latest"
+    "ref": "v0.2.0"
   },
   "insight": {
     "ref": "v0.0.2"


### PR DESCRIPTION
## Summary

Update the SDK dependency manifest to install Neat core from the released `v0.2.0` artifact instead of `develop:latest`.

```json
"core": {
  "ref": "v0.2.0"
}
```

Insight remains pinned to `v0.0.2`, and the SDK platform compatibility remains `2.1.2`.

## Why

The `v0.2.0` core artifact is now available and should be the dependency baked into the SDK develop/2.1.2 flow. Relying on `develop:latest` keeps the SDK tied to a moving branch artifact rather than the GA core release.

I also checked the current artifact resolution:

- `core/develop/latest.tag` resolves to `8e9e8fcfabc2`
- `core/v0.2.0/latest.tag` resolves to `cab68312e027`

So `develop:latest` is not currently equivalent to the released `v0.2.0` artifact. Pinning the tag makes the SDK dependency explicit and reproducible.

## Validation

- Validated `deps/manifest.json` with `python3 -m json.tool`.
- Compared SDK manifest values with `release-2.0`, which remains pinned to `core@v0.1.0` for platform `2.0.0`.
