### PR TITLE
Fix DevKit workspace validation and remote run cwd

### DIFF
--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -684,7 +684,13 @@ set -euo pipefail
 mp="${mount_point}"
 src="${src}"
 opts="${mount_opts}"
-timeout 5 stat "\${mp}/." >/dev/null 2>&1 && exit 0
+if findmnt -rn -T "\${mp}" -o SOURCE,FSTYPE | awk -v src="\${src}" '
+  \$1 == src && \$2 ~ /^nfs/ { found=1 }
+  END { exit found ? 0 : 1 }
+'; then
+  timeout 5 stat "\${mp}/." >/dev/null 2>&1 && exit 0
+fi
+
 umount -lf "\${mp}" >/dev/null 2>&1 || true
 mount -t nfs -o "\${opts}" "\${src}" "\${mp}"
 EOF

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -853,13 +853,24 @@ devkit-run() {
       ;;
   esac
 
-  local rel remote_path pyneat_activate
+  local rel remote_path remote_cwd pyneat_activate
   rel="${local_path#/workspace/}"
   remote_path="${DEVKIT_SYNC_MOUNT_POINT}/${rel}"
-  pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
   local host_pwd remote_args arg
   host_pwd="$(pwd)"
-  remote_args=("${remote_path}" "${pyneat_activate}")
+  case "${host_pwd}" in
+    /workspace/*)
+      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}/${host_pwd#/workspace/}"
+      ;;
+    /workspace)
+      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}"
+      ;;
+    *)
+      remote_cwd="$(dirname "${remote_path}")"
+      ;;
+  esac
+  pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
+  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}")
 
   normalize_devkit_host_path() {
     local input="$1"
@@ -963,6 +974,7 @@ devkit-run() {
 
   printf "%b[DevKit]%b executing remotely on %s@%s:%s -> %s\n" \
     "${c_out}" "${c_reset}" "${DEVKIT_SYNC_DEVKIT_USER}" "${DEVKIT_SYNC_DEVKIT_IP}" "${DEVKIT_SYNC_DEVKIT_PORT}" "${remote_path}"
+  printf "%b[DevKit]%b cwd: %s\n" "${c_out}" "${c_reset}" "${remote_cwd}"
   printf "%b[DevKit]%b argv:" "${c_out}" "${c_reset}"
   for arg in "${remote_args[@]}"; do
     printf " %q" "${arg}"
@@ -1017,11 +1029,12 @@ __restore_tty() {
 trap __restore_tty EXIT INT TERM HUP
 target="${1:?missing target path}"
 pyneat_activate="${2-}"
+remote_cwd="${3-}"
 if [[ "${pyneat_activate}" == "__NONE__" ]]; then
   pyneat_activate=""
 fi
-if [[ $# -ge 2 ]]; then
-  shift 2
+if [[ $# -ge 3 ]]; then
+  shift 3
 else
   shift 1
 fi
@@ -1047,6 +1060,10 @@ ensure_target_ready() {
 }
 
 ensure_target_ready "${target}"
+if [[ -n "${remote_cwd}" ]]; then
+  ensure_target_ready "${remote_cwd}"
+  cd "${remote_cwd}"
+fi
 
 prepare_command() {
   if [[ "${target}" == *.py ]]; then


### PR DESCRIPTION
## Summary
Fixes #55.

This PR fixes two DevKit workspace issues in `scripts/devkit.sh`:

1. **NFS watchdog mount validation**

   The DevKit NFS watchdog previously treated `stat "${mp}/."` as sufficient proof that the workspace was healthy. With the default `mp=/workspace`, that can be a false positive because `/workspace` may exist as a normal local directory on the DevKit root filesystem even when the NFS mount is missing. In that state, the watchdog reported success and skipped the remount path, leaving SDK and DevKit pointed at different workspaces.

   The watchdog now validates mount identity first: the mount point must be backed by the expected NFS source, the filesystem type must be `nfs`/`nfs4`, and `stat` must succeed before it exits early. Otherwise, it unmounts/remounts the configured SDK export.

2. **`dk` remote working directory**

   `dk`/`devkit-run` executed targets by absolute path on the DevKit but did not preserve the SDK current working directory. This made sample apps fail when they used project-relative assets such as `assets/tutorial_sample_image.png`.

   `devkit-run` now maps the SDK cwd into the DevKit workspace, passes it to the remote runner, and `cd`s there before executing the target. For example:

   ```bash
   cd /workspace/neat/hello_neat
   dk build/sima_neat_app
   ```

   now runs the target from `/workspace/neat/hello_neat` on the DevKit.

---

## Type of Change
Please mark the relevant options with an `x`:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] Tests / CI improvements

---

## Testing & Verification
Describe how you tested your changes:

- [ ] Unit tests added/updated
- [ ] Built successfully on hardware (e.g., Modalix, Davinci DevKit)
- [ ] Verified with Yocto/SDK build
- [x] Manual functional tests (describe below)

Manual verification for NFS watchdog:

- Applied the live watchdog fix on the DevKit at `/usr/local/sbin/devkit-nfs-watchdog.sh`.
- Verified the previous failure mode: `/workspace` could exist locally, causing `stat /workspace/.` to succeed even when NFS was not mounted.
- Confirmed manual NFS mount worked, indicating the host export and network were healthy.
- Verified the corrected watchdog only reports success when `/workspace` is mounted from the expected NFS export.
- Confirmed the resulting mount identity:

```text
/workspace 10.42.0.1:/home/florian-voss/workspace nfs4
```

Manual verification for `dk` cwd handling:

- Reproduced that `dk build/sima_neat_app` from `/workspace/neat/hello_neat` executed the target with remote cwd `/workspace`, causing `assets/tutorial_sample_image.png` to fail to load.
- Updated `devkit-run` to pass the mapped SDK cwd to the remote runner and `cd` there before exec.
- Verified shell syntax:

```bash
bash -n sdk/scripts/devkit.sh
```

---

## Checklist
- [x] Code follows project style guidelines
- [x] Comments/documentation updated where needed
- [x] New dependencies documented in README or `requirements.txt`
- [x] Related issues linked in PR description
- [ ] Planned merge method matches the target branch policy in `CONTRIBUTING.md`
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)

---

## Additional Notes
Both fixes keep the existing DevKit workflow intact: `dk` still maps target paths and argument paths through the NFS workspace, and now also preserves the workspace cwd expected by tutorial/sample applications.
