### PR TITLE
Include LLiMa packages in DevKit Neat sync

### DIFF
--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -156,7 +156,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then


### PR DESCRIPTION
# Pull Request Template

## Summary
Fixes the DevKit Neat framework sync path used by `sima-cli sdk setup --devkit`.

The SDK cache includes `sima-lmm-*.deb` packages, but `scripts/devkit.sh` only copied `sima-neat-*-Linux-core.deb` and `neat-*.deb` to the DevKit. As a result, the remote installer could fail to install `sima-neat` because `sima-lmm-core` and `sima-lmm-dev` were not available to apt.

This PR includes `sima-lmm-*.deb` in the DevKit sync package set so `sima-neat` dependencies resolve during setup.

---

## Type of Change
Please mark the relevant options with an `x`:

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor / code cleanup  
- [ ] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [ ] Unit tests added/updated  
- [x] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [ ] Verified with Yocto/SDK build  
- [x] Manual functional tests (describe below)  

Manual verification:
- Ran `bash -n scripts/devkit.sh`.
- Reran the patched DevKit sync against Modalix DevKit `10.42.0.78`.
- Verified these packages installed on the DevKit: `neat-appcomplex`, `neat-common`, `neat-ev74-firmware`, `neat-gst-plugins`, `neat-internals-dev`, `neat-runtime`, `sima-lmm-cli`, `sima-lmm-core`, `sima-lmm-dev`, `sima-neat`.
- Verified `pyneat` imports successfully from `/home/sima/pyneat/bin/python`.
- Verified `simaai-appcomplex.service`, `encoder.service`, and `decoder.service` are active.

---

## Checklist
- [x] Code follows project style guidelines  
- [x] Comments/documentation updated where needed  
- [x] New dependencies documented in README or `requirements.txt`  
- [ ] Related issues linked in PR description  
- [x] Planned merge method matches the target branch policy in `CONTRIBUTING.md`
- [x] I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md)  

---

## Additional Notes
No new dependency is introduced; this only copies already-packaged `sima-lmm` artifacts that are present in the SDK cache.

No related issue is linked.
