### PR TITLE
Backport SDK patch release versioning to release-2.1

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -133,10 +133,10 @@ jobs:
           promote_latest=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             release_tag="${GITHUB_REF_NAME}"
-            if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+$ ]]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+([.][0-9]+)?$ ]]; then
               release_latest_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-latest"
             else
-              echo "Release tags must use vX.Y.Z format: ${GITHUB_REF_NAME}" >&2
+              echo "Release tags must use vX.Y.Z or vX.Y.Z.N format: ${GITHUB_REF_NAME}" >&2
               exit 1
             fi
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       tag:
-        description: Patch release version without v prefix, for example 2.1.2.
+        description: SDK release version without v prefix, for example 2.1.2 or 2.1.2.1.
         required: true
         type: string
       source_branch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,13 +203,15 @@ RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
               /etc/profile.d/pkg-config-sysroot.sh
 
 RUN if printf '%s' "${SDK_RELEASE_REF}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+'; then \
-      printf 'SDK Release = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
+      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
         "${SDK_RELEASE_REF}" \
+        "${BASE_SDK_VERSION}" \
         "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}" \
         "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}"; \
     else \
-      printf 'SDK Release = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
+      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
         "${SDK_RELEASE_REF}" \
+        "${BASE_SDK_VERSION}" \
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}"; \
     fi > /etc/sdk-release

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -18,6 +18,39 @@ check_remote_passwordless_sudo() {
   ssh -tt -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "sudo -n true" >/dev/null 2>&1
 }
 
+sdk_platform_version_from_release_file() {
+  local sdk_release="$1"
+  local platform_version=""
+
+  platform_version="$(
+    awk -F= '
+      /^[[:space:]]*Platform Version[[:space:]]*=/ {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+        print $2
+        exit
+      }
+    ' "${sdk_release}"
+  )"
+
+  if [[ -n "${platform_version}" ]]; then
+    printf "%s\n" "${platform_version}"
+    return 0
+  fi
+
+  platform_version="$(
+    grep -E '^[[:space:]]*eLXr Version[[:space:]]*=' "${sdk_release}" \
+      | grep -Eo '[0-9]+([.][0-9]+){2}' \
+      | head -n1 || true
+  )"
+
+  if [[ -n "${platform_version}" ]]; then
+    printf "%s\n" "${platform_version}"
+    return 0
+  fi
+
+  grep -Eo '[0-9]+([.][0-9]+){2}' "${sdk_release}" | head -n1 || true
+}
+
 check_devkit_sdk_version_compatibility() {
   local user="$1"
   local ip="$2"
@@ -61,33 +94,28 @@ EOS
     return 1
   fi
 
-  if grep -Fq "${devkit_distro_version}" "${sdk_release}"; then
-    echo "DevKit DISTRO_VERSION ${devkit_distro_version} is compatible with this SDK."
-    return 0
+  sdk_expected_version="$(sdk_platform_version_from_release_file "${sdk_release}")"
+  if [[ -z "${sdk_expected_version}" ]]; then
+    {
+      printf "%bERROR:%b Could not determine SDK platform compatibility version from %s.\n" "${c_warn}" "${c_reset}" "${sdk_release}"
+      sed 's/^/    /' "${sdk_release}"
+      printf "\nUse an SDK image that includes Platform Version in %s, then reconnect.\n" "${sdk_release}"
+    } >&2
+    return 1
   fi
 
-  sdk_expected_version="$(
-    grep -E '^[[:space:]]*eLXr Version[[:space:]]*=' "${sdk_release}" \
-      | grep -Eo '[0-9]+([.][0-9]+){2}' \
-      | head -n1 || true
-  )"
-  if [[ -z "${sdk_expected_version}" ]]; then
-    sdk_expected_version="$(
-      grep -Eo '[0-9]+([.][0-9]+){2}' "${sdk_release}" \
-        | head -n1 || true
-    )"
+  if [[ "${devkit_distro_version}" == "${sdk_expected_version}" ]]; then
+    echo "DevKit DISTRO_VERSION ${devkit_distro_version} is compatible with SDK platform ${sdk_expected_version}."
+    return 0
   fi
 
   {
     printf "%bERROR: DevKit/SDK version mismatch.\n" "${c_warn}"
     printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}"
+    printf "  SDK Platform Version : %s\n" "${sdk_expected_version}"
     printf "  SDK release file     : %s\n" "${sdk_release}"
     sed 's/^/    /' "${sdk_release}"
-    if [[ -n "${sdk_expected_version}" ]]; then
-      printf "\nPlease update your DevKit to %s, then reconnect.%b\n" "${sdk_expected_version}" "${c_reset}"
-    else
-      printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.%b\n" "${sdk_release}" "${c_reset}"
-    fi
+    printf "\nPlease update your DevKit to %s, then reconnect.%b\n" "${sdk_expected_version}" "${c_reset}"
   } >&2
   return 1
 }

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -156,7 +156,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then


### PR DESCRIPTION
## Summary

Backports two SDK 2.1 patch-line changes to `release-2.1`:

- PR #59: include `sima-lmm-*.deb` packages in DevKit Neat sync.
- Issue #57 / PR #60 change: support SDK patch release revisions such as `v2.1.2.1` while preserving platform compatibility checks against `2.1.2`.

## Changes

### DevKit Neat sync package coverage

- Extends the DevKit sync package discovery to include `sima-lmm-*.deb` alongside Neat framework packages.
- This ensures LLiMa/SimaLMM runtime packages are copied to the DevKit during SDK sync when present in the SDK cache.

### SDK patch release versioning

- Allows SDK tag builds in both `vX.Y.Z` and `vX.Y.Z.N` forms.
- Keeps release-line latest promotion based on the platform minor line, so `v2.1.2.1` promotes `v2.1-latest`.
- Adds explicit `Platform Version = <base platform>` to `/etc/sdk-release`.
- Updates DevKit compatibility checks to compare DevKit `DISTRO_VERSION` against the SDK platform version exactly.
- Preserves fallback parsing for older `/etc/sdk-release` files without `Platform Version`.

## Why

We need SDK-only patch releases on the 2.1 platform line without changing the platform compatibility contract. For example:

```text
SDK Release      = v2.1.2.1
Platform Version = 2.1.2
```

This lets the SDK release identity carry patch revision information while keeping DevKit compatibility anchored to platform `2.1.2`.

## Validation

- `bash -n scripts/devkit.sh`
- `git diff --check`
- Verified release tag regex accepts:
  - `v2.1.2`
  - `v2.1.2.1`
  - `v2.1.2.22`
- Verified malformed/non-supported examples are rejected:
  - `v2.1`
  - `v2.1.2-alpha`
  - `v2.1.2.1.2`
- Verified platform-version parsing for both new and legacy `/etc/sdk-release` formats.

Related:

- #57
- #59
- #60
