### PR TITLE
Sync Neat dev package to DevKit

### DIFF
--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -184,7 +184,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'sima-neat-*-Linux-dev.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then


### PR DESCRIPTION
## Summary

Include the new `sima-neat-*-Linux-dev.deb` artifact when syncing Neat framework packages from the SDK cache to a paired DevKit.

This is needed for the package split in sima-neat/core#402, where the runtime package remains `sima-neat` and headers/CMake exports move into `sima-neat-dev`.

Merge order: merge this after sima-neat/core#402 and sima-neat/llima#39 are merged, because this SDK change expects the new core packaging artifacts to exist.

Depends on:

- sima-neat/core#402
- sima-neat/llima#39

## Change Type

- [x] Bug fix
- [ ] Refactor
- [ ] Feature
- [ ] Docs
- [ ] Test-only
- [x] Build/CI
- [ ] Breaking change

## Risk

- [x] Low
- [ ] Medium
- [ ] High

Risk notes (required for Medium/High):

## Test Evidence

Commands run and outcomes:

```text
bash -n scripts/devkit.sh
passed
```

## Docs Impact

- [x] No docs update needed
- [ ] Docs updated in this PR
- [ ] Docs follow-up required (linked issue)

Docs notes:

SDK sync behavior only.

## Migration Impact

- [x] No migration impact
- [ ] Migration required and documented

Migration notes (required if impact exists):

## Breaking API Change

- [x] Not applicable
- [ ] This PR changes public API signatures under `include/*`

If applicable, provide:

- Affected headers/symbols:
- Downstream breakage risk:
- Migration steps:
- Planned release/version for the break:
- Explicit maintainer approval reference:

## API / Deprecation Checklist

- [x] Public API unchanged
- [ ] Public API changed with deprecation path documented in docs/how-to
- [x] Naming contract respected (`docs/architecture/naming.md`)

## Release Hygiene Checklist

- [ ] `scripts/ci/check_naming_and_conflicts.sh` passed
- [ ] `scripts/ci/check_artifacts.sh` passed
- [ ] `scripts/ci/check_release_policy.sh` passed
