### PR TITLE
Add DevKit rsync fallback when NFS setup fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,7 @@ COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.con
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
+COPY scripts/devkit-sync-rsync.sh /usr/local/bin/devkit-sync-rsync.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/install-sdk-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/sysroot && \
@@ -189,6 +190,7 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
+    chmod 755 /usr/local/bin/devkit-sync-rsync.sh && \
     install-sdk-sysroot-overlay.sh
 
 RUN if [ -n "${NEAT_INSIGHT_BRANCH}${NEAT_INSIGHT_VERSION}" ]; then \

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -132,8 +132,34 @@ case "${cmd}" in
     ssh_bash "${remote_root}" <<'EOS' || {
 set -euo pipefail
 remote_root="$1"
+if [[ "$(id -u)" -eq 0 ]]; then
+  SUDO=""
+elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO="__missing_sudo__"
+fi
+
+as_root() {
+  if [[ -z "${SUDO}" ]]; then
+    "$@"
+  elif [[ "${SUDO}" == "__missing_sudo__" ]]; then
+    echo "Passwordless sudo is required on the DevKit for rsync fallback setup." >&2
+    return 1
+  else
+    sudo "$@"
+  fi
+}
+
 if ! command -v rsync >/dev/null 2>&1; then
-  echo "rsync is not installed on the DevKit." >&2
+  if command -v apt-get >/dev/null 2>&1; then
+    as_root apt-get update --allow-releaseinfo-change
+    as_root apt-get install -y --no-install-recommends rsync
+  fi
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "rsync is not installed on the DevKit and could not be installed automatically." >&2
   exit 1
 fi
 
@@ -142,16 +168,16 @@ if [[ "$(id -u)" -eq 0 ]]; then
   chmod 0755 "${remote_root}"
 elif mkdir -p "${remote_root}" >/dev/null 2>&1; then
   chmod 0755 "${remote_root}" || true
-elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
-  sudo mkdir -p "${remote_root}"
-  sudo chown "$(id -u):$(id -g)" "${remote_root}"
-  sudo chmod 0755 "${remote_root}"
+elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
+  as_root mkdir -p "${remote_root}"
+  as_root chown "$(id -u):$(id -g)" "${remote_root}"
+  as_root chmod 0755 "${remote_root}"
 else
   echo "Cannot create ${remote_root}; passwordless sudo is required." >&2
   exit 1
 fi
 EOS
-      echo "DevKit rsync setup failed. Ensure rsync is installed and ${remote_root} is writable." >&2
+      echo "DevKit rsync setup failed. Ensure rsync can be installed and ${remote_root} is writable." >&2
       exit 1
     }
     ;;

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -5,9 +5,10 @@ usage() {
   cat >&2 <<'EOF'
 Usage:
   devkit-sync-rsync.sh setup --devkit IP --user USER --port PORT --local PATH --remote PATH
-  devkit-sync-rsync.sh sync --devkit IP --user USER --port PORT --local PATH --remote PATH [--status-file PATH]
+  devkit-sync-rsync.sh sync --devkit IP --user USER --port PORT --local PATH --remote PATH [--scope PATH] [--status-file PATH]
   devkit-sync-rsync.sh status --devkit IP --user USER --port PORT --remote PATH [--status-file PATH]
   devkit-sync-rsync.sh map-path --local-root PATH --remote-root PATH --path PATH
+  devkit-sync-rsync.sh scope-for-path --local-root PATH --path PATH
   devkit-sync-rsync.sh print-excludes --local PATH
 EOF
 }
@@ -25,6 +26,7 @@ port="22"
 local_root="/workspace"
 remote_root="/workspace-rsync"
 path=""
+scope=""
 status_file="${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
 
 while [[ $# -gt 0 ]]; do
@@ -45,6 +47,8 @@ while [[ $# -gt 0 ]]; do
       remote_root="${2:-}"; shift 2 ;;
     --path)
       path="${2:-}"; shift 2 ;;
+    --scope)
+      scope="${2:-}"; shift 2 ;;
     --status-file)
       status_file="${2:-}"; shift 2 ;;
     -h|--help)
@@ -100,18 +104,110 @@ EOF
 write_status() {
   local state="$1"
   local detail="$2"
+  local sync_scope="${3:-}"
   mkdir -p "$(dirname "${status_file}")"
   {
     printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'state=%s\n' "${state}"
+    if [[ -n "${sync_scope}" ]]; then
+      printf 'scope=%q\n' "${sync_scope}"
+    fi
     printf 'detail=%q\n' "${detail}"
   } > "${status_file}"
 }
 
+normalize_local_path() {
+  local input="$1"
+  local part
+  local -a parts=()
+  local -a normalized_parts=()
+
+  if [[ "${input}" != /* ]]; then
+    input="${PWD}/${input}"
+  fi
+
+  IFS='/' read -r -a parts <<< "${input#/}"
+  for part in "${parts[@]}"; do
+    case "${part}" in
+      ""|".")
+        continue
+        ;;
+      "..")
+        if (( ${#normalized_parts[@]} > 0 )); then
+          unset 'normalized_parts[${#normalized_parts[@]}-1]'
+        fi
+        ;;
+      *)
+        normalized_parts+=("${part}")
+        ;;
+    esac
+  done
+
+  if (( ${#normalized_parts[@]} == 0 )); then
+    printf '/\n'
+    return 0
+  fi
+
+  local joined
+  printf -v joined '%s/' "${normalized_parts[@]}"
+  printf '/%s\n' "${joined%/}"
+}
+
+scope_for_path() {
+  local input="$1"
+  local normalized
+
+  if [[ -z "${input}" ]]; then
+    input="${local_root}"
+  fi
+  normalized="$(normalize_local_path "${input}")"
+
+  case "${normalized}" in
+    "${local_root}")
+      printf '%s\n' "${local_root}"
+      ;;
+    "${local_root}"/*)
+      local rel first
+      rel="${normalized#"${local_root%/}/"}"
+      first="${rel%%/*}"
+      if [[ -n "${first}" ]]; then
+        printf '%s/%s\n' "${local_root%/}" "${first}"
+      else
+        printf '%s\n' "${local_root}"
+      fi
+      ;;
+    *)
+      echo "Scope must be inside ${local_root}: ${input}" >&2
+      return 2
+      ;;
+  esac
+}
+
+remote_for_local_path() {
+  local input="$1"
+  local normalized
+  normalized="$(normalize_local_path "${input}")"
+  case "${normalized}" in
+    "${local_root}")
+      printf '%s\n' "${remote_root%/}"
+      ;;
+    "${local_root}"/*)
+      printf '%s/%s\n' "${remote_root%/}" "${normalized#"${local_root%/}/"}"
+      ;;
+    *)
+      echo "Path must be inside ${local_root}: ${input}" >&2
+      return 2
+      ;;
+  esac
+}
+
 build_exclude_args() {
   local tmp="$1"
+  local exclude_base="${2:-${local_root}}"
   default_excludes > "${tmp}"
-  if [[ -f "${local_root}/.devkit-rsync-exclude" ]]; then
+  if [[ -f "${exclude_base}/.devkit-rsync-exclude" ]]; then
+    cat "${exclude_base}/.devkit-rsync-exclude" >> "${tmp}"
+  elif [[ "${exclude_base}" != "${local_root}" && -f "${local_root}/.devkit-rsync-exclude" ]]; then
     cat "${local_root}/.devkit-rsync-exclude" >> "${tmp}"
   fi
   if [[ -n "${DEVKIT_RSYNC_EXCLUDES_FILE:-}" && -f "${DEVKIT_RSYNC_EXCLUDES_FILE}" ]]; then
@@ -163,19 +259,58 @@ if ! command -v rsync >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ "$(id -u)" -eq 0 ]]; then
-  mkdir -p "${remote_root}"
-  chmod 0755 "${remote_root}"
-elif mkdir -p "${remote_root}" >/dev/null 2>&1; then
-  chmod 0755 "${remote_root}" || true
-elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
-  as_root mkdir -p "${remote_root}"
-  as_root chown "$(id -u):$(id -g)" "${remote_root}"
-  as_root chmod 0755 "${remote_root}"
-else
-  echo "Cannot create ${remote_root}; passwordless sudo is required." >&2
-  exit 1
+physical_root="${remote_root}"
+if [[ "${remote_root}" == "/workspace-rsync" && -d "/nvme/media" ]]; then
+  physical_root="/nvme/media/workspace-rsync"
 fi
+
+if [[ "${physical_root}" == "${remote_root}" ]]; then
+  if [[ "$(id -u)" -eq 0 ]]; then
+    mkdir -p "${remote_root}"
+    chmod 0755 "${remote_root}"
+  elif mkdir -p "${remote_root}" >/dev/null 2>&1; then
+    chmod 0755 "${remote_root}" || true
+  elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
+    as_root mkdir -p "${remote_root}"
+    as_root chown "$(id -u):$(id -g)" "${remote_root}"
+    as_root chmod 0755 "${remote_root}"
+  else
+    echo "Cannot create ${remote_root}; passwordless sudo is required." >&2
+    exit 1
+  fi
+else
+  if [[ "$(id -u)" -eq 0 ]]; then
+    mkdir -p "${physical_root}"
+    chown "$(id -u):$(id -g)" "${physical_root}"
+    chmod 0755 "${physical_root}"
+  elif mkdir -p "${physical_root}" >/dev/null 2>&1; then
+    chmod 0755 "${physical_root}" || true
+  elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
+    as_root mkdir -p "${physical_root}"
+    as_root chown "$(id -u):$(id -g)" "${physical_root}"
+    as_root chmod 0755 "${physical_root}"
+  else
+    echo "Cannot create ${physical_root}; passwordless sudo is required." >&2
+    exit 1
+  fi
+
+  if [[ -L "${remote_root}" ]]; then
+    as_root ln -sfn "${physical_root}" "${remote_root}"
+  elif [[ -e "${remote_root}" ]]; then
+    if rmdir "${remote_root}" >/dev/null 2>&1 || as_root rmdir "${remote_root}"; then
+      as_root ln -sfn "${physical_root}" "${remote_root}"
+    else
+      echo "WARNING: ${remote_root} already exists and is not empty; using existing root filesystem path." >&2
+      physical_root="${remote_root}"
+    fi
+  else
+    as_root ln -sfn "${physical_root}" "${remote_root}"
+  fi
+fi
+
+df -h "${physical_root}" 2>/dev/null | tail -n 1 | awk -v logical="${remote_root}" -v physical="${physical_root}" '
+  { printf "rsync remote workspace: logical=%s physical=%s available=%s filesystem=%s\n", logical, physical, $4, $1 }
+'
 EOS
       echo "DevKit rsync setup failed. Ensure rsync can be installed and ${remote_root} is writable." >&2
       exit 1
@@ -183,19 +318,35 @@ EOS
     ;;
   sync)
     require_connection_args
-    if [[ ! -d "${local_root}" ]]; then
-      echo "Local sync root not found: ${local_root}" >&2
-      write_status failed "local root not found: ${local_root}" || true
+    local_sync_root="$(scope_for_path "${scope:-${PWD}}")"
+    remote_sync_root="$(remote_for_local_path "${local_sync_root}")"
+    if [[ ! -d "${local_sync_root}" ]]; then
+      echo "Local sync root not found: ${local_sync_root}" >&2
+      write_status failed "local root not found: ${local_sync_root}" "${local_sync_root}" || true
       exit 1
     fi
     tmp_excludes="$(mktemp)"
     trap 'rm -f "${tmp_excludes}"' EXIT
-    build_exclude_args "${tmp_excludes}"
-    if rsync -az --delete --exclude-from="${tmp_excludes}" -e "ssh -p ${port} -o BatchMode=yes -o ConnectTimeout=8" "${local_root%/}/" "$(ssh_target):${remote_root%/}/"; then
-      write_status ok "synced ${local_root} to ${remote_root}" || true
+    build_exclude_args "${tmp_excludes}" "${local_sync_root}"
+    rsync_args=(-az --delete "--exclude-from=${tmp_excludes}")
+    case "${DEVKIT_RSYNC_PROGRESS:-AUTO}" in
+      OFF|off|0|false|FALSE|no|NO)
+        ;;
+      AUTO|auto|"")
+        if [[ -t 1 ]]; then
+          rsync_args+=("--info=progress2,stats2" --human-readable)
+        fi
+        ;;
+      *)
+        rsync_args+=("--info=progress2,stats2" --human-readable)
+        ;;
+    esac
+    echo "Syncing ${local_sync_root} -> $(ssh_target):${remote_sync_root}"
+    if rsync "${rsync_args[@]}" -e "ssh -p ${port} -o BatchMode=yes -o ConnectTimeout=8" "${local_sync_root%/}/" "$(ssh_target):${remote_sync_root%/}/"; then
+      write_status ok "synced ${local_sync_root} to ${remote_sync_root}" "${local_sync_root}" || true
     else
       rc=$?
-      write_status failed "rsync exited ${rc}" || true
+      write_status failed "rsync exited ${rc}" "${local_sync_root}" || true
       exit "${rc}"
     fi
     ;;
@@ -204,6 +355,7 @@ EOS
     echo "rsync remote root: ${remote_root}"
     if ssh_base "test -d '${remote_root}'"; then
       echo "remote root: present"
+      ssh_base "if [ -L '${remote_root}' ]; then printf 'physical root: '; readlink -f '${remote_root}'; else echo 'physical root: ${remote_root}'; fi; df -h '${remote_root}' 2>/dev/null | tail -n 1 | awk '{print \"available space: \" \$4 \" on \" \$1}'" || true
     else
       echo "remote root: missing"
     fi
@@ -236,6 +388,13 @@ EOS
         printf '%s\n' "${path}"
         ;;
     esac
+    ;;
+  scope-for-path)
+    if [[ -z "${path}" ]]; then
+      echo "--path is required for scope-for-path." >&2
+      exit 2
+    fi
+    scope_for_path "${path}"
     ;;
   *)
     echo "Unknown command: ${cmd}" >&2

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -105,7 +105,12 @@ write_status() {
   local state="$1"
   local detail="$2"
   local sync_scope="${3:-}"
-  mkdir -p "$(dirname "${status_file}")"
+  local status_dir tmp_status
+  status_dir="$(dirname "${status_file}")"
+  if ! mkdir -p "${status_dir}" >/dev/null 2>&1; then
+    return 0
+  fi
+  tmp_status="$(mktemp "${status_dir}/.devkit-rsync-status.XXXXXX" 2>/dev/null)" || return 0
   {
     printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'state=%s\n' "${state}"
@@ -113,7 +118,11 @@ write_status() {
       printf 'scope=%q\n' "${sync_scope}"
     fi
     printf 'detail=%q\n' "${detail}"
-  } > "${status_file}"
+  } > "${tmp_status}" || {
+    rm -f "${tmp_status}"
+    return 0
+  }
+  mv -f "${tmp_status}" "${status_file}" >/dev/null 2>&1 || rm -f "${tmp_status}"
 }
 
 normalize_local_path() {

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  devkit-sync-rsync.sh setup --devkit IP --user USER --port PORT --local PATH --remote PATH
+  devkit-sync-rsync.sh sync --devkit IP --user USER --port PORT --local PATH --remote PATH [--status-file PATH]
+  devkit-sync-rsync.sh status --devkit IP --user USER --port PORT --remote PATH [--status-file PATH]
+  devkit-sync-rsync.sh map-path --local-root PATH --remote-root PATH --path PATH
+  devkit-sync-rsync.sh print-excludes --local PATH
+EOF
+}
+
+cmd="${1:-}"
+if [[ -z "${cmd}" ]]; then
+  usage
+  exit 2
+fi
+shift
+
+devkit=""
+user="sima"
+port="22"
+local_root="/workspace"
+remote_root="/workspace-rsync"
+path=""
+status_file="${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --devkit)
+      devkit="${2:-}"; shift 2 ;;
+    --user)
+      user="${2:-}"; shift 2 ;;
+    --port)
+      port="${2:-}"; shift 2 ;;
+    --local)
+      local_root="${2:-}"; shift 2 ;;
+    --remote)
+      remote_root="${2:-}"; shift 2 ;;
+    --local-root)
+      local_root="${2:-}"; shift 2 ;;
+    --remote-root)
+      remote_root="${2:-}"; shift 2 ;;
+    --path)
+      path="${2:-}"; shift 2 ;;
+    --status-file)
+      status_file="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+ssh_target() {
+  printf '%s@%s' "${user}" "${devkit}"
+}
+
+require_connection_args() {
+  if [[ -z "${devkit}" || -z "${user}" || -z "${port}" ]]; then
+    echo "--devkit, --user, and --port are required." >&2
+    exit 2
+  fi
+  if [[ ! "${port}" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo "Invalid SSH port: ${port}" >&2
+    exit 2
+  fi
+}
+
+ssh_base() {
+  ssh -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "$(ssh_target)" "$@"
+}
+
+ssh_bash() {
+  ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "$(ssh_target)" bash -s -- "$@"
+}
+
+default_excludes() {
+  cat <<'EOF'
+.git/
+.gitmodules
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.cache/
+.venv/
+venv/
+node_modules/
+*.log
+.DS_Store
+EOF
+}
+
+write_status() {
+  local state="$1"
+  local detail="$2"
+  mkdir -p "$(dirname "${status_file}")"
+  {
+    printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'state=%s\n' "${state}"
+    printf 'detail=%q\n' "${detail}"
+  } > "${status_file}"
+}
+
+build_exclude_args() {
+  local tmp="$1"
+  default_excludes > "${tmp}"
+  if [[ -f "${local_root}/.devkit-rsync-exclude" ]]; then
+    cat "${local_root}/.devkit-rsync-exclude" >> "${tmp}"
+  fi
+  if [[ -n "${DEVKIT_RSYNC_EXCLUDES_FILE:-}" && -f "${DEVKIT_RSYNC_EXCLUDES_FILE}" ]]; then
+    cat "${DEVKIT_RSYNC_EXCLUDES_FILE}" >> "${tmp}"
+  fi
+  if [[ -n "${DEVKIT_RSYNC_EXTRA_EXCLUDES:-}" ]]; then
+    printf '%s\n' "${DEVKIT_RSYNC_EXTRA_EXCLUDES}" >> "${tmp}"
+  fi
+}
+
+case "${cmd}" in
+  setup)
+    require_connection_args
+    if ! command -v rsync >/dev/null 2>&1; then
+      echo "rsync is not installed in the SDK container." >&2
+      exit 1
+    fi
+    ssh_bash "${remote_root}" <<'EOS' || {
+set -euo pipefail
+remote_root="$1"
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "rsync is not installed on the DevKit." >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  mkdir -p "${remote_root}"
+  chmod 0755 "${remote_root}"
+elif mkdir -p "${remote_root}" >/dev/null 2>&1; then
+  chmod 0755 "${remote_root}" || true
+elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  sudo mkdir -p "${remote_root}"
+  sudo chown "$(id -u):$(id -g)" "${remote_root}"
+  sudo chmod 0755 "${remote_root}"
+else
+  echo "Cannot create ${remote_root}; passwordless sudo is required." >&2
+  exit 1
+fi
+EOS
+      echo "DevKit rsync setup failed. Ensure rsync is installed and ${remote_root} is writable." >&2
+      exit 1
+    }
+    ;;
+  sync)
+    require_connection_args
+    if [[ ! -d "${local_root}" ]]; then
+      echo "Local sync root not found: ${local_root}" >&2
+      write_status failed "local root not found: ${local_root}" || true
+      exit 1
+    fi
+    tmp_excludes="$(mktemp)"
+    trap 'rm -f "${tmp_excludes}"' EXIT
+    build_exclude_args "${tmp_excludes}"
+    if rsync -az --delete --exclude-from="${tmp_excludes}" -e "ssh -p ${port} -o BatchMode=yes -o ConnectTimeout=8" "${local_root%/}/" "$(ssh_target):${remote_root%/}/"; then
+      write_status ok "synced ${local_root} to ${remote_root}" || true
+    else
+      rc=$?
+      write_status failed "rsync exited ${rc}" || true
+      exit "${rc}"
+    fi
+    ;;
+  status)
+    require_connection_args
+    echo "rsync remote root: ${remote_root}"
+    if ssh_base "test -d '${remote_root}'"; then
+      echo "remote root: present"
+    else
+      echo "remote root: missing"
+    fi
+    if [[ -f "${status_file}" ]]; then
+      echo "last sync:"
+      sed 's/^/  /' "${status_file}"
+    else
+      echo "last sync: never"
+    fi
+    ;;
+  print-excludes)
+    tmp_excludes="$(mktemp)"
+    trap 'rm -f "${tmp_excludes}"' EXIT
+    build_exclude_args "${tmp_excludes}"
+    cat "${tmp_excludes}"
+    ;;
+  map-path)
+    if [[ -z "${path}" ]]; then
+      echo "--path is required for map-path." >&2
+      exit 2
+    fi
+    case "${path}" in
+      "${local_root}"/*)
+        printf '%s/%s\n' "${remote_root%/}" "${path#"${local_root%/}/"}"
+        ;;
+      "${local_root}")
+        printf '%s\n' "${remote_root%/}"
+        ;;
+      *)
+        printf '%s\n' "${path}"
+        ;;
+    esac
+    ;;
+  *)
+    echo "Unknown command: ${cmd}" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -446,6 +446,10 @@ _HOST_IP="${NFS_SERVER_HOST_IP:-}"
 _HOST_EXPORT_PATH="${DEVKIT_HOST_EXPORT_PATH:-}"
 _HOST_PLATFORM="${DEVKIT_HOST_PLATFORM:-linux}"
 _DEFAULT_MOUNT_PATH="${DEVKIT_SYNC_MOUNT_PATH:-/workspace}"
+_LOCAL_WORKSPACE_ROOT="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+_RSYNC_REMOTE_ROOT="${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}"
+_RSYNC_HELPER="${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}"
+_RSYNC_STATUS_FILE="${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
 
 devkit_sync_noninteractive() {
   case "${DEVKIT_SYNC_NONINTERACTIVE:-}" in
@@ -486,9 +490,11 @@ if [[ ! "${_DEVKIT_PORT}" =~ ^[0-9]+$ ]] || (( _DEVKIT_PORT < 1 || _DEVKIT_PORT 
   return 2
 fi
 
-_c_info="" _c_reset=""
+_c_info="" _c_error="" _c_warn="" _c_reset=""
 if [[ -t 1 ]]; then
   _c_info=$'\033[1;34m'
+  _c_error=$'\033[1;31m'
+  _c_warn=$'\033[1;33m'
   _c_reset=$'\033[0m'
 fi
 cat <<EOF
@@ -638,6 +644,7 @@ if ! sync_neat_framework_to_devkit "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_
 fi
 
 echo "Configuring remote NFS mount..."
+_NFS_CONFIGURED=0
 if ! ssh -T -p "${_DEVKIT_PORT}" -o BatchMode=yes -o ConnectTimeout=8 "${_DEVKIT_USER}@${_DEVKIT_IP}" bash -s -- "${_HOST_IP}" "${_HOST_EXPORT_PATH}" "${_MOUNT_POINT}" "${_NFS_OPTS}" "${_DEVKIT_USER}" <<'EOS'
 set -euo pipefail
 host_ip="$1"
@@ -775,12 +782,53 @@ if command -v git >/dev/null 2>&1; then
 fi
 EOS
 then
+  printf "%bERROR: DevKit NFS workspace setup was not successful.%b\n" "${_c_error}" "${_c_reset}" >&2
   echo "Failed to configure NFS mount on ${_DEVKIT_USER}@${_DEVKIT_IP}." >&2
+  echo "SSH is configured, so the SDK will continue and keep dk shell available." >&2
   echo "Hint: ensure ${_DEVKIT_USER} has passwordless sudo, or rerun as root: source devkit.sh ${_DEVKIT_IP} root ${_DEVKIT_PORT}" >&2
-  return 1
+else
+  _NFS_CONFIGURED=1
 fi
 
-export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_MOUNT_POINT}"
+_SYNC_METHOD="none"
+_ACTIVE_REMOTE_ROOT="${_MOUNT_POINT}"
+_SYNC_HINT=""
+if [[ "${_NFS_CONFIGURED}" == "1" ]]; then
+  _SYNC_METHOD="nfs"
+  _ACTIVE_REMOTE_ROOT="${_MOUNT_POINT}"
+else
+  case "${DEVKIT_RSYNC_FALLBACK:-ON}" in
+    OFF|off|0|false|FALSE|no|NO)
+      _SYNC_METHOD="none"
+      _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+      _SYNC_HINT="NFS failed and rsync fallback is disabled by DEVKIT_RSYNC_FALLBACK=${DEVKIT_RSYNC_FALLBACK}."
+      printf "%bWARNING:%b rsync fallback disabled; only dk shell will be available.\n" "${_c_warn}" "${_c_reset}" >&2
+      ;;
+    *)
+      if [[ -x "${_RSYNC_HELPER}" ]] && "${_RSYNC_HELPER}" setup --devkit "${_DEVKIT_IP}" --user "${_DEVKIT_USER}" --port "${_DEVKIT_PORT}" --local "${_LOCAL_WORKSPACE_ROOT}" --remote "${_RSYNC_REMOTE_ROOT}"; then
+        _SYNC_METHOD="rsync"
+        _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+        _SYNC_HINT="NFS failed; using rsync-over-SSH fallback."
+        printf "%bWARNING:%b using rsync fallback: %s -> %s@%s:%s\n" "${_c_warn}" "${_c_reset}" "${_LOCAL_WORKSPACE_ROOT}" "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_RSYNC_REMOTE_ROOT}" >&2
+      else
+        _SYNC_METHOD="none"
+        _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+        _SYNC_HINT="NFS failed and rsync fallback setup was not available."
+        printf "%bWARNING:%b rsync fallback setup failed; only dk shell will be available.\n" "${_c_warn}" "${_c_reset}" >&2
+      fi
+      ;;
+  esac
+fi
+
+export DEVKIT_SYNC_METHOD="${_SYNC_METHOD}"
+export DEVKIT_SYNC_LOCAL_ROOT="${_LOCAL_WORKSPACE_ROOT}"
+export DEVKIT_SYNC_REMOTE_ROOT="${_ACTIVE_REMOTE_ROOT}"
+export DEVKIT_SYNC_NFS_MOUNT_POINT="${_MOUNT_POINT}"
+export DEVKIT_RSYNC_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+export DEVKIT_RSYNC_HELPER="${_RSYNC_HELPER}"
+export DEVKIT_RSYNC_STATUS_FILE="${_RSYNC_STATUS_FILE}"
+export DEVKIT_SYNC_HINT="${_SYNC_HINT}"
+export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_DEVKIT_IP="${_DEVKIT_IP}"
 if [[ -z "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
   export DEVKIT_SYNC_ORIG_PS1="${PS1:-\u@\h:\w\$ }"
@@ -821,8 +869,84 @@ fi
 export PS1="$(__devkit_rewrite_prompt_hostname "${PS1:-${DEVKIT_SYNC_ORIG_PS1}}")"
 
 echo ""
-echo "NFS client mount configured."
+case "${DEVKIT_SYNC_METHOD}" in
+  nfs)
+    echo "NFS client mount configured."
+    ;;
+  rsync)
+    echo "NFS client mount was not configured; rsync fallback is active."
+    ;;
+  *)
+    echo "NFS client mount was not configured; no workspace sync method is active."
+    ;;
+esac
 echo "Target: ${DEVKIT_SYNC_TARGET}"
+
+devkit-sync() {
+  case "${DEVKIT_SYNC_METHOD:-nfs}" in
+    nfs)
+      echo "Sync method: nfs"
+      echo "No rsync is needed because the DevKit workspace is mounted from the host."
+      return 0
+      ;;
+    rsync)
+      if [[ ! -x "${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" ]]; then
+        echo "rsync helper not found: ${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" >&2
+        return 1
+      fi
+      "${DEVKIT_RSYNC_HELPER}" sync \
+        --devkit "${DEVKIT_SYNC_DEVKIT_IP}" \
+        --user "${DEVKIT_SYNC_DEVKIT_USER:-sima}" \
+        --port "${DEVKIT_SYNC_DEVKIT_PORT:-22}" \
+        --local "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}" \
+        --remote "${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}" \
+        --status-file "${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
+      ;;
+    *)
+      echo "No workspace sync method is active."
+      echo "Use 'dk shell' to connect to the DevKit, then copy files manually or rerun DevKit setup."
+      return 1
+      ;;
+  esac
+}
+
+devkit-status() {
+  local ssh_status="unknown"
+  if ssh -p "${DEVKIT_SYNC_DEVKIT_PORT:-22}" -o BatchMode=yes -o ConnectTimeout=5 "${DEVKIT_SYNC_DEVKIT_USER:-sima}@${DEVKIT_SYNC_DEVKIT_IP}" true >/dev/null 2>&1; then
+    ssh_status="reachable"
+  else
+    ssh_status="not reachable"
+  fi
+
+  cat <<EOF
+DevKit target       : ${DEVKIT_SYNC_DEVKIT_USER:-sima}@${DEVKIT_SYNC_DEVKIT_IP}:${DEVKIT_SYNC_DEVKIT_PORT:-22}
+SSH status          : ${ssh_status}
+Sync method         : ${DEVKIT_SYNC_METHOD:-unknown}
+Local workspace     : ${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}
+Remote workspace    : ${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT:-/workspace}}
+NFS mount path      : ${DEVKIT_SYNC_NFS_MOUNT_POINT:-${DEVKIT_SYNC_MOUNT_POINT:-/workspace}}
+EOF
+
+  if [[ -n "${DEVKIT_SYNC_HINT:-}" ]]; then
+    echo "Status hint         : ${DEVKIT_SYNC_HINT}"
+  fi
+
+  case "${DEVKIT_SYNC_METHOD:-}" in
+    rsync)
+      if [[ -x "${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" ]]; then
+        "${DEVKIT_RSYNC_HELPER}" status \
+          --devkit "${DEVKIT_SYNC_DEVKIT_IP}" \
+          --user "${DEVKIT_SYNC_DEVKIT_USER:-sima}" \
+          --port "${DEVKIT_SYNC_DEVKIT_PORT:-22}" \
+          --remote "${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}" \
+          --status-file "${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}" || true
+      fi
+      ;;
+    none)
+      echo "Workspace sync is not active. 'dk shell' can still be used over SSH."
+      ;;
+  esac
+}
 
 # Run a local /workspace binary or Python script on the paired DevKit.
 devkit-run() {
@@ -847,6 +971,12 @@ devkit-run() {
     ssh_args+=("$@")
     "${ssh_args[@]}"
     return $?
+  fi
+
+  if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "none" ]]; then
+    echo "No workspace sync method is active; cannot map ${local_path} to the DevKit." >&2
+    echo "Use 'dk shell' to connect, or manually copy files to the DevKit." >&2
+    return 2
   fi
 
   if [[ "${local_path}" != /* ]]; then
@@ -874,31 +1004,33 @@ devkit-run() {
   fi
 
   case "${local_path}" in
-    /workspace/*) ;;
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*) ;;
     *)
-      echo "Path must be inside /workspace so DevKit can access it via NFS." >&2
+      echo "Path must be inside ${DEVKIT_SYNC_LOCAL_ROOT:-/workspace} so DevKit can access it via ${DEVKIT_SYNC_METHOD:-nfs}." >&2
       return 2
       ;;
   esac
 
   local rel remote_path remote_cwd pyneat_activate
-  rel="${local_path#/workspace/}"
-  remote_path="${DEVKIT_SYNC_MOUNT_POINT}/${rel}"
+  rel="${local_path#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+  remote_path="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${rel}"
+  remote_path="${remote_path//\/\//\/}"
   local host_pwd remote_args arg
   host_pwd="$(pwd)"
   case "${host_pwd}" in
-    /workspace/*)
-      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}/${host_pwd#/workspace/}"
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
+      remote_cwd="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${host_pwd#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+      remote_cwd="${remote_cwd//\/\//\/}"
       ;;
-    /workspace)
-      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}"
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}")
+      remote_cwd="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}"
       ;;
     *)
       remote_cwd="$(dirname "${remote_path}")"
       ;;
   esac
   pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
-  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}")
+  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}" "${DEVKIT_SYNC_METHOD:-nfs}")
 
   normalize_devkit_host_path() {
     local input="$1"
@@ -941,7 +1073,6 @@ devkit-run() {
     local raw="$1"
     local prefix=""
     local value="${raw}"
-    local candidate=""
     local normalized=""
     local looks_like_path="0"
 
@@ -980,8 +1111,11 @@ devkit-run() {
     fi
 
     case "${normalized}" in
-      /workspace/*)
-        printf '%s%s\n' "${prefix}" "${DEVKIT_SYNC_MOUNT_POINT}/${normalized#/workspace/}"
+      "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
+        local mapped
+        mapped="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${normalized#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+        mapped="${mapped//\/\//\/}"
+        printf '%s%s\n' "${prefix}" "${mapped}"
         ;;
       *)
         printf '%s\n' "${raw}"
@@ -992,6 +1126,19 @@ devkit-run() {
   for arg in "$@"; do
     remote_args+=("$(map_devkit_arg_path "${arg}")")
   done
+
+  if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" ]]; then
+    case "${DEVKIT_RSYNC_AUTO_SYNC:-ON}" in
+      OFF|off|0|false|FALSE|no|NO)
+        ;;
+      *)
+        if ! devkit-sync; then
+          echo "rsync fallback sync failed; not running remote command." >&2
+          return 1
+        fi
+        ;;
+    esac
+  fi
 
   local c_out="" c_stderr="" c_reset=""
   if [[ -t 1 ]]; then
@@ -1058,11 +1205,12 @@ trap __restore_tty EXIT INT TERM HUP
 target="${1:?missing target path}"
 pyneat_activate="${2-}"
 remote_cwd="${3-}"
+sync_method="${4:-nfs}"
 if [[ "${pyneat_activate}" == "__NONE__" ]]; then
   pyneat_activate=""
 fi
-if [[ $# -ge 3 ]]; then
-  shift 3
+if [[ $# -ge 4 ]]; then
+  shift 4
 else
   shift 1
 fi
@@ -1076,7 +1224,7 @@ ensure_target_ready() {
   mount_root="/${seg}"
 
   # Best effort: ask watchdog to recover stale NFS mount.
-  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  if [[ "${sync_method}" == "nfs" ]] && command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     sudo systemctl start devkit-nfs-watchdog.service >/dev/null 2>&1 || true
   fi
   sleep 1
@@ -1147,26 +1295,51 @@ EOS
 unalias dk >/dev/null 2>&1 || true
 dk() {
   if [[ $# -lt 1 ]]; then
-    echo "Usage: dk <local-executable-path|shell> [args...]" >&2
+    echo "Usage: dk <local-executable-path|shell|sync|status> [args...]" >&2
     return 0
   fi
+  case "$1" in
+    sync)
+      shift
+      devkit-sync "$@"
+      return $?
+      ;;
+    status)
+      shift
+      devkit-status "$@"
+      return $?
+      ;;
+  esac
   devkit-run "$@"
 }
 
 # Persist session helpers for future container shells.
 _persist_file="${HOME}/.devkit-sync.rc"
+__devkit_persist_export() {
+  local name="$1"
+  local value="${!name-}"
+  printf 'export %s=%q\n' "${name}" "${value}"
+}
 {
-  echo "export DEVKIT_SYNC_TARGET='${DEVKIT_SYNC_TARGET}'"
-  echo "export DEVKIT_SYNC_DEVKIT_IP='${DEVKIT_SYNC_DEVKIT_IP}'"
-  echo "export DEVKIT_SYNC_MOUNT_POINT='${DEVKIT_SYNC_MOUNT_POINT}'"
-  echo "export DEVKIT_SYNC_DEVKIT_USER='${DEVKIT_SYNC_DEVKIT_USER}'"
-  echo "export DEVKIT_SYNC_DEVKIT_PORT='${DEVKIT_SYNC_DEVKIT_PORT}'"
-  echo "export SDK_RELEASE_REF='${SDK_RELEASE_REF:-}'"
-  echo "export SDK_PROMPT_REF='${SDK_PROMPT_REF}'"
-  echo "export SDK_IMAGE_BRANCH='${SDK_IMAGE_BRANCH}'"
-  echo "export SDK_IMAGE_TAG='${SDK_IMAGE_TAG}'"
-  echo "export SDK_PROMPT_HOSTNAME='${SDK_PROMPT_HOSTNAME}'"
-  echo "export DEVKIT_PROMPT_DIRTRIM='${DEVKIT_PROMPT_DIRTRIM}'"
+  __devkit_persist_export DEVKIT_SYNC_TARGET
+  __devkit_persist_export DEVKIT_SYNC_METHOD
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_IP
+  __devkit_persist_export DEVKIT_SYNC_MOUNT_POINT
+  __devkit_persist_export DEVKIT_SYNC_NFS_MOUNT_POINT
+  __devkit_persist_export DEVKIT_SYNC_LOCAL_ROOT
+  __devkit_persist_export DEVKIT_SYNC_REMOTE_ROOT
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_USER
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_PORT
+  __devkit_persist_export DEVKIT_RSYNC_REMOTE_ROOT
+  __devkit_persist_export DEVKIT_RSYNC_HELPER
+  __devkit_persist_export DEVKIT_RSYNC_STATUS_FILE
+  __devkit_persist_export DEVKIT_SYNC_HINT
+  __devkit_persist_export SDK_RELEASE_REF
+  __devkit_persist_export SDK_PROMPT_REF
+  __devkit_persist_export SDK_IMAGE_BRANCH
+  __devkit_persist_export SDK_IMAGE_TAG
+  __devkit_persist_export SDK_PROMPT_HOSTNAME
+  __devkit_persist_export DEVKIT_PROMPT_DIRTRIM
   echo 'export PROMPT_DIRTRIM="${DEVKIT_PROMPT_DIRTRIM}"'
   echo 'export DEVKIT_SYNC_PROMPT_PREFIX="\[\e[1;32m\][DevKit ${DEVKIT_SYNC_TARGET}]\[\e[0m\] "'
   echo '__devkit_rewrite_prompt_hostname() {'
@@ -1193,6 +1366,8 @@ _persist_file="${HOME}/.devkit-sync.rc"
   echo '  fi'
   echo '}'
   echo '__devkit_apply_prompt'
+  declare -f devkit-sync
+  declare -f devkit-status
   declare -f devkit-run
   echo 'unalias dk >/dev/null 2>&1 || true'
   declare -f dk
@@ -1286,13 +1461,31 @@ ${_c_ok}
   DevKit Connected
 ============================================================
   DevKit target : ${DEVKIT_SYNC_DEVKIT_USER}@${DEVKIT_SYNC_DEVKIT_IP}:${DEVKIT_SYNC_DEVKIT_PORT}
-  Mounted path  : ${DEVKIT_SYNC_MOUNT_POINT}
+  Sync method   : ${DEVKIT_SYNC_METHOD}
+  Remote path   : ${DEVKIT_SYNC_REMOTE_ROOT}
   Host export   : ${_HOST_IP}:${_HOST_EXPORT_PATH}
-
+EOF
+case "${DEVKIT_SYNC_METHOD}" in
+  nfs|rsync)
+    cat <<EOF
   You can now run DevKit binaries from this SDK shell:
     dk /workspace/<path-to-arm64-binary> [args...]
   Or connect to a DevKit shell directly:
     dk shell
+  Check sync status:
+    dk status
+EOF
+    ;;
+  *)
+    cat <<EOF
+  Workspace sync is not active. You can still connect to a DevKit shell:
+    dk shell
+  Check sync status:
+    dk status
+EOF
+    ;;
+esac
+cat <<EOF
 ============================================================
 ${_c_rst}
 EOF

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -883,6 +883,10 @@ esac
 echo "Target: ${DEVKIT_SYNC_TARGET}"
 
 devkit-sync() {
+  local sync_scope="${1:-${PWD}}"
+  if [[ "${sync_scope}" == "--all" ]]; then
+    sync_scope="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+  fi
   case "${DEVKIT_SYNC_METHOD:-nfs}" in
     nfs)
       echo "Sync method: nfs"
@@ -900,6 +904,7 @@ devkit-sync() {
         --port "${DEVKIT_SYNC_DEVKIT_PORT:-22}" \
         --local "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}" \
         --remote "${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}" \
+        --scope "${sync_scope}" \
         --status-file "${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
       ;;
     *)
@@ -1132,7 +1137,7 @@ devkit-run() {
       OFF|off|0|false|FALSE|no|NO)
         ;;
       *)
-        if ! devkit-sync; then
+        if ! devkit-sync "${local_path}"; then
           echo "rsync fallback sync failed; not running remote command." >&2
           return 1
         fi

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -449,7 +449,6 @@ _DEFAULT_MOUNT_PATH="${DEVKIT_SYNC_MOUNT_PATH:-/workspace}"
 _LOCAL_WORKSPACE_ROOT="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
 _RSYNC_REMOTE_ROOT="${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}"
 _RSYNC_HELPER="${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}"
-_RSYNC_STATUS_FILE="${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
 
 devkit_sync_noninteractive() {
   case "${DEVKIT_SYNC_NONINTERACTIVE:-}" in
@@ -826,7 +825,6 @@ export DEVKIT_SYNC_REMOTE_ROOT="${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_NFS_MOUNT_POINT="${_MOUNT_POINT}"
 export DEVKIT_RSYNC_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
 export DEVKIT_RSYNC_HELPER="${_RSYNC_HELPER}"
-export DEVKIT_RSYNC_STATUS_FILE="${_RSYNC_STATUS_FILE}"
 export DEVKIT_SYNC_HINT="${_SYNC_HINT}"
 export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_DEVKIT_IP="${_DEVKIT_IP}"
@@ -1337,7 +1335,6 @@ __devkit_persist_export() {
   __devkit_persist_export DEVKIT_SYNC_DEVKIT_PORT
   __devkit_persist_export DEVKIT_RSYNC_REMOTE_ROOT
   __devkit_persist_export DEVKIT_RSYNC_HELPER
-  __devkit_persist_export DEVKIT_RSYNC_STATUS_FILE
   __devkit_persist_export DEVKIT_SYNC_HINT
   __devkit_persist_export SDK_RELEASE_REF
   __devkit_persist_export SDK_PROMPT_REF

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="${ROOT_DIR}/scripts/devkit-sync-rsync.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  grep -Fxq "${needle}" <<< "${haystack}" || fail "expected exclude '${needle}'"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fxq "${needle}" <<< "${haystack}"; then
+    fail "unexpected exclude '${needle}'"
+  fi
+}
+
+mapped="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-rsync --path /workspace/apps/demo.py)"
+[[ "${mapped}" == "/workspace-rsync/apps/demo.py" ]] || fail "unexpected mapped path: ${mapped}"
+
+unchanged="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-rsync --path /tmp/demo.py)"
+[[ "${unchanged}" == "/tmp/demo.py" ]] || fail "unexpected unchanged path: ${unchanged}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+mkdir -p "${tmpdir}/workspace"
+printf 'project-cache/\n' > "${tmpdir}/workspace/.devkit-rsync-exclude"
+printf 'external-cache/\n' > "${tmpdir}/external-excludes"
+
+excludes="$(
+  DEVKIT_RSYNC_EXCLUDES_FILE="${tmpdir}/external-excludes" \
+  DEVKIT_RSYNC_EXTRA_EXCLUDES=$'scratch/\ntmp-artifacts/' \
+    "${HELPER}" print-excludes --local "${tmpdir}/workspace"
+)"
+
+assert_contains "${excludes}" ".git/"
+assert_contains "${excludes}" "__pycache__/"
+assert_contains "${excludes}" "project-cache/"
+assert_contains "${excludes}" "external-cache/"
+assert_contains "${excludes}" "scratch/"
+assert_contains "${excludes}" "tmp-artifacts/"
+
+assert_not_contains "${excludes}" "dist/"
+assert_not_contains "${excludes}" "build/"
+assert_not_contains "${excludes}" "build-*/"
+assert_not_contains "${excludes}" "cmake-build-*/"
+assert_not_contains "${excludes}" "CMakeFiles/"
+assert_not_contains "${excludes}" "CMakeCache.txt"
+assert_not_contains "${excludes}" "*.o"
+assert_not_contains "${excludes}" "*.a"
+assert_not_contains "${excludes}" "*.so"
+assert_not_contains "${excludes}" "*.dylib"
+
+echo "devkit rsync helper tests passed"

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -29,6 +29,12 @@ mapped="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-
 unchanged="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-rsync --path /tmp/demo.py)"
 [[ "${unchanged}" == "/tmp/demo.py" ]] || fail "unexpected unchanged path: ${unchanged}"
 
+scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace/apps/examples/demo.py)"
+[[ "${scope}" == "/workspace/apps" ]] || fail "unexpected scope: ${scope}"
+
+root_scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace)"
+[[ "${root_scope}" == "/workspace" ]] || fail "unexpected root scope: ${root_scope}"
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 mkdir -p "${tmpdir}/workspace"


### PR DESCRIPTION
## Summary

Adds a resilient DevKit workspace sync fallback for cases where NFS setup fails during `devkit.sh` configuration.

Before this change, NFS was the only workspace synchronization path. If the NFS export or DevKit mount failed, users could still SSH into the DevKit, but `dk /workspace/...` could not execute because there was no mapped workspace on the device. This PR keeps `dk shell` available and adds an rsync-over-SSH fallback that preserves the same logical `/workspace` to DevKit path mapping.

Fixes #66.

## What changed

- Adds `scripts/devkit-sync-rsync.sh`, a standalone helper for fallback setup, sync, status, path mapping, scope detection, and exclude generation.
- Installs the helper into the SDK image at `/usr/local/bin/devkit-sync-rsync.sh`.
- Updates `scripts/devkit.sh` to track the active sync method: `nfs`, `rsync`, or `none`.
- Allows DevKit setup to continue after NFS failure so `dk shell` remains available.
- Adds `dk status` to show DevKit reachability, sync method, local and remote workspace roots, rsync status, physical backing path, and available remote space.
- Adds `dk sync` for explicit synchronization in rsync fallback mode.
- Automatically syncs before `dk /workspace/...` execution in fallback mode unless `DEVKIT_RSYNC_AUTO_SYNC=OFF` is set.
- Adds focused shell tests for rsync helper path mapping, scope detection, and conservative default excludes.

## Rsync fallback behavior

When NFS setup succeeds, behavior remains NFS-based. `dk` maps `/workspace/...` to the DevKit NFS mount and `dk sync` is a successful no-op because no copy is needed.

When NFS setup fails:

- The user sees a clear error explaining that DevKit NFS workspace setup was not successful.
- SSH configuration is preserved.
- The SDK attempts to configure rsync fallback.
- If `rsync` is missing on the DevKit, setup attempts to install it using root or passwordless sudo.
- If fallback setup succeeds, `dk /workspace/...` syncs the relevant workspace scope and runs the command from the mapped DevKit path.
- If fallback setup fails, `dk shell` remains available and `dk status` reports that workspace sync is not active.

## Remote storage layout

The logical remote root remains stable:

```text
/workspace-rsync
```

If `/nvme/media` exists on the DevKit, the fallback uses NVMe-backed storage:

```text
/nvme/media/workspace-rsync
/workspace-rsync -> /nvme/media/workspace-rsync
```

If `/nvme/media` is unavailable, fallback uses root filesystem storage:

```text
/workspace-rsync
```

The setup is conservative with existing data. If `/workspace-rsync` already exists and is not empty, the script does not delete it. It warns and uses the existing path instead.

## Lazy sync and progress

The fallback no longer syncs all of `/workspace` by default.

Examples:

```text
/workspace/core/build.sh        -> sync /workspace/core
/workspace/apps/examples/app.py -> sync /workspace/apps
```

This keeps the remote layout predictable:

```text
/workspace/core/... -> /workspace-rsync/core/...
/workspace/apps/... -> /workspace-rsync/apps/...
```

Manual sync behavior:

```bash
dk sync        # sync the current top-level workspace scope
dk sync --all  # sync all of /workspace
```

Interactive rsync uses progress and final stats:

```bash
--info=progress2,stats2 --human-readable
```

Progress can be disabled with:

```bash
DEVKIT_RSYNC_PROGRESS=OFF
```

Automatic sync before `dk /workspace/...` can be disabled with:

```bash
DEVKIT_RSYNC_AUTO_SYNC=OFF
```

The fallback itself can be disabled with:

```bash
DEVKIT_RSYNC_FALLBACK=OFF
```

## Notes and risks

- `rsync --delete` is scoped to the selected remote sync scope under `/workspace-rsync`. Users should not treat `/workspace-rsync` as persistent manual storage.
- Lazy sync intentionally syncs the top-level workspace directory containing the command. If a command depends on sibling checkouts, the user may need `dk sync --all` or an explicit sync from the relevant scope.
- The default exclude list is conservative. It excludes obvious local noise such as `.git/`, Python caches, virtualenvs, `node_modules/`, logs, and `.DS_Store`, but does not exclude build outputs or compiled artifacts because those may be intentional DevKit inputs.
- `dk sync` and `dk status` are reserved helper subcommands. A workspace executable named exactly `sync` or `status` should be run with an explicit path such as `dk ./sync` or `dk /workspace/...`.

## Validation

Ran locally:

```bash
bash -n scripts/devkit.sh
bash -n scripts/devkit-sync-rsync.sh
bash tests/sdk/test-devkit-rsync-helper.sh
shellcheck scripts/devkit-sync-rsync.sh tests/sdk/test-devkit-rsync-helper.sh
```

Remaining real-device validation recommended:

- NFS success path remains unchanged.
- Forced NFS failure enters rsync fallback.
- `dk shell` works when NFS fails.
- Missing DevKit `rsync` is installed automatically when root/passwordless sudo is available.
- `/nvme/media` devices use NVMe-backed `/workspace-rsync` symlink.
- Devices without `/nvme/media` fall back to rootfs `/workspace-rsync`.
- `dk /workspace/...` syncs only the expected scope and executes from the mapped `/workspace-rsync/...` path.
