### PR TITLE
[codex] Update core and Insight manifest versions

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,9 +1,9 @@
 {
   "core": {
-    "ref": "v0.2.0"
+    "ref": "v0.2.1"
   },
   "insight": {
-    "ref": "v0.0.2"
+    "ref": "v0.0.3"
   },
   "platform-version": "2.1.2"
 }


### PR DESCRIPTION
## Summary

Update SDK dependency manifest versions for the latest patch releases:

- `core`: `v0.2.0` -> `v0.2.1`
- `insight`: `v0.0.2` -> `v0.0.3`

## Why

The SDK manifest should resolve to the current patched Core and Insight releases so SDK builds pick up the latest package, install, and Insight WebSSH/port-map fixes.

## Validation

- `python -m json.tool deps/manifest.json`
