### PR TITLE
[codex] Promote main to release-2.1

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -133,10 +133,10 @@ jobs:
           promote_latest=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             release_tag="${GITHUB_REF_NAME}"
-            if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+$ ]]; then
+            if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+([.][0-9]+)?$ ]]; then
               release_latest_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-latest"
             else
-              echo "Release tags must use vX.Y.Z format: ${GITHUB_REF_NAME}" >&2
+              echo "Release tags must use vX.Y.Z or vX.Y.Z.N format: ${GITHUB_REF_NAME}" >&2
               exit 1
             fi
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       tag:
-        description: Patch release version without v prefix, for example 2.1.2.
+        description: SDK release version without v prefix, for example 2.1.2 or 2.1.2.1.
         required: true
         type: string
       source_branch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,13 +203,15 @@ RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
               /etc/profile.d/pkg-config-sysroot.sh
 
 RUN if printf '%s' "${SDK_RELEASE_REF}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+'; then \
-      printf 'SDK Release = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
+      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
         "${SDK_RELEASE_REF}" \
+        "${BASE_SDK_VERSION}" \
         "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}" \
         "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}"; \
     else \
-      printf 'SDK Release = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
+      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
         "${SDK_RELEASE_REF}" \
+        "${BASE_SDK_VERSION}" \
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}"; \
     fi > /etc/sdk-release

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,9 +1,9 @@
 {
   "core": {
-    "ref": "v0.2.0"
+    "ref": "v0.2.1"
   },
   "insight": {
-    "ref": "v0.0.2"
+    "ref": "v0.0.3"
   },
   "platform-version": "2.1.2"
 }

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -18,6 +18,39 @@ check_remote_passwordless_sudo() {
   ssh -tt -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "${user}@${ip}" "sudo -n true" >/dev/null 2>&1
 }
 
+sdk_platform_version_from_release_file() {
+  local sdk_release="$1"
+  local platform_version=""
+
+  platform_version="$(
+    awk -F= '
+      /^[[:space:]]*Platform Version[[:space:]]*=/ {
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2)
+        print $2
+        exit
+      }
+    ' "${sdk_release}"
+  )"
+
+  if [[ -n "${platform_version}" ]]; then
+    printf "%s\n" "${platform_version}"
+    return 0
+  fi
+
+  platform_version="$(
+    grep -E '^[[:space:]]*eLXr Version[[:space:]]*=' "${sdk_release}" \
+      | grep -Eo '[0-9]+([.][0-9]+){2}' \
+      | head -n1 || true
+  )"
+
+  if [[ -n "${platform_version}" ]]; then
+    printf "%s\n" "${platform_version}"
+    return 0
+  fi
+
+  grep -Eo '[0-9]+([.][0-9]+){2}' "${sdk_release}" | head -n1 || true
+}
+
 check_devkit_sdk_version_compatibility() {
   local user="$1"
   local ip="$2"
@@ -61,33 +94,28 @@ EOS
     return 1
   fi
 
-  if grep -Fq "${devkit_distro_version}" "${sdk_release}"; then
-    echo "DevKit DISTRO_VERSION ${devkit_distro_version} is compatible with this SDK."
-    return 0
+  sdk_expected_version="$(sdk_platform_version_from_release_file "${sdk_release}")"
+  if [[ -z "${sdk_expected_version}" ]]; then
+    {
+      printf "%bERROR:%b Could not determine SDK platform compatibility version from %s.\n" "${c_warn}" "${c_reset}" "${sdk_release}"
+      sed 's/^/    /' "${sdk_release}"
+      printf "\nUse an SDK image that includes Platform Version in %s, then reconnect.\n" "${sdk_release}"
+    } >&2
+    return 1
   fi
 
-  sdk_expected_version="$(
-    grep -E '^[[:space:]]*eLXr Version[[:space:]]*=' "${sdk_release}" \
-      | grep -Eo '[0-9]+([.][0-9]+){2}' \
-      | head -n1 || true
-  )"
-  if [[ -z "${sdk_expected_version}" ]]; then
-    sdk_expected_version="$(
-      grep -Eo '[0-9]+([.][0-9]+){2}' "${sdk_release}" \
-        | head -n1 || true
-    )"
+  if [[ "${devkit_distro_version}" == "${sdk_expected_version}" ]]; then
+    echo "DevKit DISTRO_VERSION ${devkit_distro_version} is compatible with SDK platform ${sdk_expected_version}."
+    return 0
   fi
 
   {
     printf "%bERROR: DevKit/SDK version mismatch.\n" "${c_warn}"
     printf "  DevKit DISTRO_VERSION: %s\n" "${devkit_distro_version}"
+    printf "  SDK Platform Version : %s\n" "${sdk_expected_version}"
     printf "  SDK release file     : %s\n" "${sdk_release}"
     sed 's/^/    /' "${sdk_release}"
-    if [[ -n "${sdk_expected_version}" ]]; then
-      printf "\nPlease update your DevKit to %s, then reconnect.%b\n" "${sdk_expected_version}" "${c_reset}"
-    else
-      printf "\nPlease update your DevKit to the matching version listed in %s, then reconnect.%b\n" "${sdk_release}" "${c_reset}"
-    fi
+    printf "\nPlease update your DevKit to %s, then reconnect.%b\n" "${sdk_expected_version}" "${c_reset}"
   } >&2
   return 1
 }

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -156,7 +156,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -184,7 +184,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'sima-neat-*-Linux-dev.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -684,7 +684,13 @@ set -euo pipefail
 mp="${mount_point}"
 src="${src}"
 opts="${mount_opts}"
-timeout 5 stat "\${mp}/." >/dev/null 2>&1 && exit 0
+if findmnt -rn -T "\${mp}" -o SOURCE,FSTYPE | awk -v src="\${src}" '
+  \$1 == src && \$2 ~ /^nfs/ { found=1 }
+  END { exit found ? 0 : 1 }
+'; then
+  timeout 5 stat "\${mp}/." >/dev/null 2>&1 && exit 0
+fi
+
 umount -lf "\${mp}" >/dev/null 2>&1 || true
 mount -t nfs -o "\${opts}" "\${src}" "\${mp}"
 EOF
@@ -847,13 +853,24 @@ devkit-run() {
       ;;
   esac
 
-  local rel remote_path pyneat_activate
+  local rel remote_path remote_cwd pyneat_activate
   rel="${local_path#/workspace/}"
   remote_path="${DEVKIT_SYNC_MOUNT_POINT}/${rel}"
-  pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
   local host_pwd remote_args arg
   host_pwd="$(pwd)"
-  remote_args=("${remote_path}" "${pyneat_activate}")
+  case "${host_pwd}" in
+    /workspace/*)
+      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}/${host_pwd#/workspace/}"
+      ;;
+    /workspace)
+      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}"
+      ;;
+    *)
+      remote_cwd="$(dirname "${remote_path}")"
+      ;;
+  esac
+  pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
+  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}")
 
   normalize_devkit_host_path() {
     local input="$1"
@@ -957,6 +974,7 @@ devkit-run() {
 
   printf "%b[DevKit]%b executing remotely on %s@%s:%s -> %s\n" \
     "${c_out}" "${c_reset}" "${DEVKIT_SYNC_DEVKIT_USER}" "${DEVKIT_SYNC_DEVKIT_IP}" "${DEVKIT_SYNC_DEVKIT_PORT}" "${remote_path}"
+  printf "%b[DevKit]%b cwd: %s\n" "${c_out}" "${c_reset}" "${remote_cwd}"
   printf "%b[DevKit]%b argv:" "${c_out}" "${c_reset}"
   for arg in "${remote_args[@]}"; do
     printf " %q" "${arg}"
@@ -1011,11 +1029,12 @@ __restore_tty() {
 trap __restore_tty EXIT INT TERM HUP
 target="${1:?missing target path}"
 pyneat_activate="${2-}"
+remote_cwd="${3-}"
 if [[ "${pyneat_activate}" == "__NONE__" ]]; then
   pyneat_activate=""
 fi
-if [[ $# -ge 2 ]]; then
-  shift 2
+if [[ $# -ge 3 ]]; then
+  shift 3
 else
   shift 1
 fi
@@ -1041,6 +1060,10 @@ ensure_target_ready() {
 }
 
 ensure_target_ready "${target}"
+if [[ -n "${remote_cwd}" ]]; then
+  ensure_target_ready "${remote_cwd}"
+  cd "${remote_cwd}"
+fi
 
 prepare_command() {
   if [[ "${target}" == *.py ]]; then


### PR DESCRIPTION
## Summary

Promote SDK `main` into the `release-2.1` branch for the next 2.1 patch update.

## Included changes

- Update SDK dependency manifest versions:
  - `core`: `v0.2.0` -> `v0.2.1`
  - `insight`: `v0.0.2` -> `v0.0.3`
- Update DevKit setup packaging so the new Neat development package is copied alongside the runtime package.
- Include recent DevKit package-copy fixes already promoted through `main`.

## Changed files

- `deps/manifest.json`
- `scripts/devkit.sh`

## Validation

The manifest update was validated with `python -m json.tool deps/manifest.json` in the source PR. The changes have already been promoted through `main` before this release-branch promotion.
