### PR TITLE
fix(sdk): add OpenCV sysroot runtime libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NEAT_VERSION=latest
 ARG NEAT_CORE_TARGET=
 ARG NEAT_INSIGHT_BRANCH=
 ARG NEAT_INSIGHT_VERSION=
-ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libstdc++6 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
+ARG SDK_SYSROOT_PKG_LIST="libarpack2 libarpack2-dev libblas-dev libblas3 libblkid-dev libbsd0 libcharls2 libcpp-httplib-dev libelf1 libexpat1 libffi-dev libffi8 libgdal32 libgfortran5 libglib2.0-0 libgomp1 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstrtspserver-1.0-0 libgstrtspserver-1.0-dev libjpeg62-turbo libjson-glib-dev liblapack-dev liblapack3 liblzma5 libmount-dev libopencv-dnn406 libopencv-features2d406 libopencv-flann406 libopencv-objdetect406 libopencv-video406 libopenblas-pthread-dev libopenblas0-pthread libopenjp2-7 libpng16-16 libpython3.11-dev libqt5gui5 libsepol-dev libspdlog-dev libssl3 libstdc++6 libsuperlu-dev libsuperlu5 libtiff6 liburcu-dev libwebp7 python3-dev python3.11-dev zlib1g"
 ENV SDK_PKG_LIST="\
 	libgrpc-dev,\
 	protobuf-compiler-grpc,\

--- a/scripts/install-sdk-sysroot-overlay.sh
+++ b/scripts/install-sdk-sysroot-overlay.sh
@@ -13,4 +13,18 @@ for pkg in ${SDK_SYSROOT_PKG_LIST:-}; do
 done
 
 /usr/local/bin/install-sysroot-overlay.sh /opt/toolchain/aarch64/modalix "${overlay_pkgs[@]}"
+
+libdir=/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu
+for lib in \
+  libopencv_dnn.so.406 \
+  libopencv_features2d.so.406 \
+  libopencv_flann.so.406 \
+  libopencv_objdetect.so.406 \
+  libopencv_video.so.406; do
+  if [[ ! -e "${libdir}/${lib}" ]]; then
+    echo "Missing required sysroot OpenCV runtime library: ${libdir}/${lib}" >&2
+    exit 1
+  fi
+done
+
 chmod -R a+rX /opt/toolchain/aarch64/modalix/usr/include

--- a/scripts/install-sdk-sysroot-overlay.sh
+++ b/scripts/install-sdk-sysroot-overlay.sh
@@ -15,16 +15,17 @@ done
 /usr/local/bin/install-sysroot-overlay.sh /opt/toolchain/aarch64/modalix "${overlay_pkgs[@]}"
 
 libdir=/opt/toolchain/aarch64/modalix/usr/lib/aarch64-linux-gnu
-for lib in \
-  libopencv_dnn.so.406 \
-  libopencv_features2d.so.406 \
-  libopencv_flann.so.406 \
-  libopencv_objdetect.so.406 \
-  libopencv_video.so.406; do
-  if [[ ! -e "${libdir}/${lib}" ]]; then
-    echo "Missing required sysroot OpenCV runtime library: ${libdir}/${lib}" >&2
-    exit 1
-  fi
-done
+broken_opencv_links=()
+while IFS= read -r link; do
+  broken_opencv_links+=("${link}")
+done < <(find "${libdir}" -maxdepth 1 -xtype l -name 'libopencv_*.so' -print | sort)
+
+if [[ "${#broken_opencv_links[@]}" -gt 0 ]]; then
+  echo "Broken sysroot OpenCV linker symlinks found:" >&2
+  for link in "${broken_opencv_links[@]}"; do
+    echo "  ${link} -> $(readlink "${link}")" >&2
+  done
+  exit 1
+fi
 
 chmod -R a+rX /opt/toolchain/aarch64/modalix/usr/include


### PR DESCRIPTION
## Summary

- Add OpenCV runtime packages that satisfy existing Modalix sysroot OpenCV development symlinks.
- Fail SDK image setup if any `libopencv_*.so` linker symlink remains broken after the sysroot overlay.

## Why

Internals full plugin builds link OpenCV through `genericboxdecode` and related GStreamer targets. Older SDK sysroots can contain unversioned OpenCV development symlinks such as `libopencv_video.so` without the matching runtime target such as `libopencv_video.so.406`, which breaks the linker.

This change makes the observed runtime packages explicit and adds a generic guard so future OpenCV component gaps fail during SDK image creation instead of later during an Internals build.

Closes #73

## Validation

- `bash -n scripts/install-sdk-sysroot-overlay.sh`
- Verified the five observed OpenCV runtime package names are present in the Dockerfile.
- Verified the packages are available from the SDK apt resolver as `:arm64`.
- Verified the generic guard detects the five broken OpenCV linker symlinks in the older `ghcr.io/sima-neat/sdk:latest` image (`main-8368b0c`).
