### PR TITLE
Enable release issue validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,7 @@ jobs:
       prerelease: ${{ inputs.prerelease }}
       latest: ${{ inputs.latest }}
       dry_run: ${{ inputs.dry_run }}
+      validate_release_issues: true
+    secrets:
+      NEAT_RELEASES_APP_ID: ${{ secrets.NEAT_RELEASES_APP_ID }}
+      NEAT_RELEASES_APP_PRIVATE_KEY: ${{ secrets.NEAT_RELEASES_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Enable the shared Release Engineering pre-release issue validation in the SDK release workflow.
- Pass the Release Engineering GitHub App credentials through to the shared `vulcan-release.yml` workflow.
- Align SDK release behavior with internals, LLiMa, core, sima-cli, and insight.

## Behavior

Before creating release branches, tags, and draft releases, the shared workflow validates that issues targeted for the requested release are ready. If validation fails, the release workflow stops before making release artifacts.

## Testing

- Parsed `.github/workflows/release.yml` successfully with Ruby YAML loader.
