### PR TITLE
Add PR sanitization workflow

### DIFF
--- a/.github/workflows/pr-sanitization.yml
+++ b/.github/workflows/pr-sanitization.yml
@@ -1,0 +1,13 @@
+name: PR Sanitization
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-sanitization:
+    uses: sima-neat/.github/.github/workflows/pr-sanitization.yml@main


### PR DESCRIPTION
Refs sima-neat/.github#85

## Summary
- Add the standard PR Sanitization workflow wrapper for this repository.
- Delegate the actual policy check to `sima-neat/.github/.github/workflows/pr-sanitization.yml@main`.
- Enforce the shared PR hygiene policy: PRs must target approved branches and must reference a GitHub issue.

## Validation
- Ran `actionlint` against the new workflow wrapper.
- Ran `git diff --check`.
