### PR TITLE
Publish SDK install stub for sima-cli

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -170,90 +170,10 @@ jobs:
           path: image-metadata/image.env
           if-no-files-found: error
 
-  prepare-vulcan-install-stub:
-    name: Prepare SDK install stub package
-    if: github.event_name != 'pull_request'
-    needs: publish-manifest
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v5
-
-      - name: Download image metadata
-        uses: actions/download-artifact@v7
-        with:
-          name: image-promotion-metadata
-          path: .smoke
-
-      - name: Install sima-cli
-        run: |
-          set -euo pipefail
-
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip install sima-cli
-          SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli --version
-
-      - name: Prepare SDK install stub package
-        run: |
-          set -euo pipefail
-
-          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
-          # shellcheck disable=SC1090
-          source "${metadata_file}"
-
-          if [[ -z "${staged_tag:-}" ]]; then
-            echo "SDK install stub skipped: no staged image tag was recorded." >&2
-            exit 1
-          fi
-
-          image_resource="ghcr:${repository#ghcr.io/}:${staged_tag}"
-          if [[ -n "${release_tag}" ]]; then
-            package_version="${release_tag#v}"
-          else
-            package_version="${GITHUB_REF_NAME}"
-          fi
-
-          source .venv/bin/activate
-          tools/prepare_s3_artifacts.sh \
-            --output-dir dist \
-            --image-resource "${image_resource}" \
-            --version "${package_version}" \
-            --release "${GITHUB_SHA}"
-
-      - name: Upload SDK install stub package
-        uses: actions/upload-artifact@v7
-        with:
-          name: sdk-install-stub
-          path: dist/
-          if-no-files-found: error
-
-  publish-vulcan-install-stub:
-    name: Publish SDK install stub to Vulcan
-    if: github.event_name != 'pull_request'
-    needs: prepare-vulcan-install-stub
-    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
-    with:
-      aws_region: us-west-2
-      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
-      artifact_pattern: sdk-install-stub
-      artifact_glob: "**/*"
-      min_artifact_count: 2
-
-  mark-vulcan-install-stub-latest:
-    name: Mark SDK install stub as latest
-    if: github.event_name != 'pull_request'
-    needs: publish-vulcan-install-stub
-    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
-    with:
-      aws_region: us-west-2
-      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
-
   smoke:
     name: Smoke on ${{ matrix.arch }}
     if: github.event_name != 'pull_request'
-    needs: mark-vulcan-install-stub-latest
+    needs: publish-manifest
     runs-on: ${{ matrix.runs_on }}
     env:
       SIMA_CLI_CHECK_FOR_UPDATE: "0"
@@ -579,3 +499,83 @@ jobs:
           docker buildx imagetools create \
             "${tags[@]}" \
             "${source_ref}"
+
+  prepare-vulcan-install-stub:
+    name: Prepare SDK install stub package
+    if: github.event_name != 'pull_request'
+    needs: promote
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+
+      - name: Install sima-cli
+        run: |
+          set -euo pipefail
+
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install sima-cli
+          SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli --version
+
+      - name: Prepare SDK install stub package
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          if [[ "${promote_latest}" == "true" ]]; then
+            canonical_sdk_repository="${repository%/*}/sdk"
+            image_resource="ghcr:${canonical_sdk_repository#ghcr.io/}:${branch_tag}"
+            package_version="${GITHUB_REF_NAME}"
+          elif [[ -n "${release_tag}" ]]; then
+            image_resource="ghcr:${repository#ghcr.io/}:${release_tag}"
+            package_version="${release_tag#v}"
+          else
+            echo "SDK install stub skipped: no promoted branch or release image tag." >&2
+            exit 1
+          fi
+
+          source .venv/bin/activate
+          tools/prepare_s3_artifacts.sh \
+            --output-dir dist \
+            --image-resource "${image_resource}" \
+            --version "${package_version}" \
+            --release "${GITHUB_SHA}"
+
+      - name: Upload SDK install stub package
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-install-stub
+          path: dist/
+          if-no-files-found: error
+
+  publish-vulcan-install-stub:
+    name: Publish SDK install stub to Vulcan
+    if: github.event_name != 'pull_request'
+    needs: prepare-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      artifact_pattern: sdk-install-stub
+      artifact_glob: "**/*"
+      min_artifact_count: 2
+
+  mark-vulcan-install-stub-latest:
+    name: Mark SDK install stub as latest
+    if: github.event_name != 'pull_request'
+    needs: publish-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,8 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
+  id-token: write
   packages: write
 
 concurrency:
@@ -130,6 +131,7 @@ jobs:
 
           release_tag=""
           release_latest_tag=""
+          branch_tag=""
           promote_latest=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             release_tag="${GITHUB_REF_NAME}"
@@ -141,6 +143,11 @@ jobs:
             fi
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             promote_latest=true
+            branch_tag="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')"
+            branch_tag="$(echo "${branch_tag}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            if [[ -z "${branch_tag}" ]]; then
+              branch_tag="branch"
+            fi
           fi
 
           {
@@ -150,6 +157,7 @@ jobs:
             echo "commit_sha=${GITHUB_SHA}"
             echo "release_tag=${release_tag}"
             echo "release_latest_tag=${release_latest_tag}"
+            echo "branch_tag=${branch_tag}"
             echo "promote_latest=${promote_latest}"
           } > image-metadata/image.env
         env:
@@ -162,10 +170,90 @@ jobs:
           path: image-metadata/image.env
           if-no-files-found: error
 
+  prepare-vulcan-install-stub:
+    name: Prepare SDK install stub package
+    if: github.event_name != 'pull_request'
+    needs: publish-manifest
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+
+      - name: Install sima-cli
+        run: |
+          set -euo pipefail
+
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install sima-cli
+          SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli --version
+
+      - name: Prepare SDK install stub package
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          if [[ -z "${staged_tag:-}" ]]; then
+            echo "SDK install stub skipped: no staged image tag was recorded." >&2
+            exit 1
+          fi
+
+          image_resource="ghcr:${repository#ghcr.io/}:${staged_tag}"
+          if [[ -n "${release_tag}" ]]; then
+            package_version="${release_tag#v}"
+          else
+            package_version="${GITHUB_REF_NAME}"
+          fi
+
+          source .venv/bin/activate
+          tools/prepare_s3_artifacts.sh \
+            --output-dir dist \
+            --image-resource "${image_resource}" \
+            --version "${package_version}" \
+            --release "${GITHUB_SHA}"
+
+      - name: Upload SDK install stub package
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-install-stub
+          path: dist/
+          if-no-files-found: error
+
+  publish-vulcan-install-stub:
+    name: Publish SDK install stub to Vulcan
+    if: github.event_name != 'pull_request'
+    needs: prepare-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      artifact_pattern: sdk-install-stub
+      artifact_glob: "**/*"
+      min_artifact_count: 2
+
+  mark-vulcan-install-stub-latest:
+    name: Mark SDK install stub as latest
+    if: github.event_name != 'pull_request'
+    needs: publish-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+
   smoke:
     name: Smoke on ${{ matrix.arch }}
     if: github.event_name != 'pull_request'
-    needs: publish-manifest
+    needs: mark-vulcan-install-stub-latest
     runs-on: ${{ matrix.runs_on }}
     env:
       SIMA_CLI_CHECK_FOR_UPDATE: "0"
@@ -441,6 +529,9 @@ jobs:
     needs: smoke
     runs-on: ubuntu-24.04
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -473,6 +564,10 @@ jobs:
           tags=()
           if [[ "${promote_latest}" == "true" ]]; then
             tags+=(--tag "${repository}:latest")
+            if [[ -n "${branch_tag:-}" ]]; then
+              canonical_sdk_repository="${repository%/*}/sdk"
+              tags+=(--tag "${canonical_sdk_repository}:${branch_tag}")
+            fi
           fi
           if [[ -n "${release_tag}" ]]; then
             tags+=(--tag "${repository}:${release_tag}")

--- a/README.md
+++ b/README.md
@@ -25,16 +25,32 @@ The main user workflow is:
 
 ## Install The SDK
 
-Install the latest published SDK image:
+Install the latest published SDK and run setup:
 
 ```bash
-sima-cli install ghcr:sima-neat/sdk
+sima-cli neat install sdk@developer
+```
+
+Install a released SDK version:
+
+```bash
+sima-cli neat install sdk@{version}
+```
+
+The install command pulls the SDK image and then asks whether to pair the SDK
+with a Modalix DevKit. If you choose to pair, enter the DevKit IP address when
+prompted.
+
+You can still install a container image resource directly when needed:
+
+```bash
+sima-cli install ghcr:sima-neat/sdk:latest
 ```
 
 Install a branch-specific image:
 
 ```bash
-sima-cli install ghcr:sima-neat/sdk-feature-devkit-sync:latest
+sima-cli install ghcr:sima-neat/sdk:feature-devkit-sync
 ```
 
 The published image contains the toolchain, sysroot, headers, libraries, NEAT runtime components, and helper scripts needed to build software for SiMa.ai platforms.

--- a/tools/install_sdk_stub.sh
+++ b/tools/install_sdk_stub.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt_yes_no() {
+  local prompt="$1"
+  local answer
+
+  while true; do
+    read -r -p "${prompt} [y/N]: " answer
+    answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
+    case "${answer}" in
+      y|yes)
+        return 0
+        ;;
+      ""|n|no)
+        return 1
+        ;;
+      *)
+        echo "Please answer y or n."
+        ;;
+    esac
+  done
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "Required command not found: ${name}" >&2
+    exit 1
+  fi
+}
+
+main() {
+  require_command sima-cli
+
+  echo "SiMa.ai Palette Neat SDK image is available locally."
+  echo "Starting SDK setup."
+
+  if prompt_yes_no "Do you want to pair this SDK with a DevKit now?"; then
+    local devkit_ip=""
+    while [[ -z "${devkit_ip}" ]]; do
+      read -r -p "Enter DevKit IP address: " devkit_ip
+      devkit_ip="${devkit_ip//[[:space:]]/}"
+      if [[ -z "${devkit_ip}" ]]; then
+        echo "DevKit IP address cannot be empty."
+      fi
+    done
+    sima-cli sdk setup --devkit "${devkit_ip}"
+  else
+    sima-cli sdk setup
+  fi
+}
+
+main "$@"

--- a/tools/prepare_s3_artifacts.sh
+++ b/tools/prepare_s3_artifacts.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/prepare_s3_artifacts.sh \
+  --output-dir <path> \
+  --image-resource <ghcr:sima-neat/sdk:tag> \
+  [--version <package-version>] \
+  [--release <release-id>]
+
+Builds the Vulcan/sima-cli install stub package for the Neat SDK.
+The SDK image itself remains a GHCR container resource; this script only
+prepares metadata and the installer hook used by `sima-cli neat install`.
+USAGE
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR=""
+IMAGE_RESOURCE=""
+PACKAGE_VERSION=""
+PACKAGE_RELEASE=""
+PACKAGE_NAME="${SDK_PACKAGE_NAME:-sdk}"
+PACKAGE_DOWNLOAD_SIZE="${SDK_PACKAGE_DOWNLOAD_SIZE:-10GB}"
+PACKAGE_INSTALL_SIZE="${SDK_PACKAGE_INSTALL_SIZE:-10GB}"
+INSTALL_SCRIPT_NAME="install_sdk_stub.sh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --image-resource)
+      IMAGE_RESOURCE="${2:-}"
+      shift 2
+      ;;
+    --version)
+      PACKAGE_VERSION="${2:-}"
+      shift 2
+      ;;
+    --release)
+      PACKAGE_RELEASE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${OUTPUT_DIR}" || -z "${IMAGE_RESOURCE}" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ "${IMAGE_RESOURCE}" != ghcr:* ]]; then
+  echo "--image-resource must be a ghcr: resource, got: ${IMAGE_RESOURCE}" >&2
+  exit 1
+fi
+
+if ! command -v sima-cli >/dev/null 2>&1; then
+  echo "sima-cli is required to build SDK package metadata." >&2
+  exit 1
+fi
+
+if [[ -z "${PACKAGE_VERSION}" ]]; then
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+  elif [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_HEAD_REF}"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME}"
+  else
+    PACKAGE_VERSION="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+if [[ -z "${PACKAGE_RELEASE}" ]]; then
+  PACKAGE_RELEASE="${PACKAGE_VERSION}"
+fi
+
+tmp_dir="$(mktemp -d /tmp/sima-sdk-package-XXXXXX)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+artifacts_dir="${tmp_dir}/artifacts"
+mkdir -p "${artifacts_dir}"
+install -m 0755 "${ROOT_DIR}/tools/${INSTALL_SCRIPT_NAME}" "${artifacts_dir}/${INSTALL_SCRIPT_NAME}"
+
+SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
+  --name "${PACKAGE_NAME}" \
+  --version "${PACKAGE_VERSION}" \
+  --description "SiMa.ai Neat SDK install stub" \
+  --install-script "${INSTALL_SCRIPT_NAME}" \
+  --host-platform "ubuntu@22.04,ubuntu@24.04" \
+  --host-platform "windows" \
+  --host-platform "mac"
+
+python3 - "${artifacts_dir}/metadata.json" "${IMAGE_RESOURCE}" "${PACKAGE_RELEASE}" "${PACKAGE_DOWNLOAD_SIZE}" "${PACKAGE_INSTALL_SIZE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+metadata_path = Path(sys.argv[1])
+image_resource = sys.argv[2]
+release = sys.argv[3]
+download_size = sys.argv[4]
+install_size = sys.argv[5]
+
+metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+resources = metadata.setdefault("resources", [])
+if image_resource not in resources:
+    resources.append(image_resource)
+metadata["release"] = release
+metadata["size"] = {
+    "download": download_size,
+    "install": install_size,
+}
+metadata["installation"]["post-message"] = (
+    "[bold green]SDK setup complete.[/bold green]\n"
+    "Run [cyan]sima-cli sdk neat[/cyan] to open the Neat SDK container.\n"
+)
+metadata_path.write_text(json.dumps(metadata, indent=4) + "\n", encoding="utf-8")
+PY
+
+python3 -m json.tool "${artifacts_dir}/metadata.json" >/dev/null
+
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+cp -f "${artifacts_dir}/${INSTALL_SCRIPT_NAME}" "${artifacts_dir}/metadata.json" "${OUTPUT_DIR}/"
+
+echo "Prepared SDK install stub package:"
+ls -lh "${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary
- build a Vulcan-backed SDK install-stub package using `sima-cli packages build`
- publish the package after SDK smoke testing and GHCR image promotion
- mark the Vulcan package latest only after the promoted GHCR tag exists
- add an installer hook that prompts for optional DevKit pairing before running `sima-cli sdk setup`
- document the one-command SDK install flow

Closes #79

## Validation
- `actionlint .github/workflows/docker-build.yml`
- `shellcheck tools/install_sdk_stub.sh tools/prepare_s3_artifacts.sh`
- `bash -n tools/install_sdk_stub.sh tools/prepare_s3_artifacts.sh`
- local stub generation with staged GHCR resource
- generated `metadata.json` validated with `sima_cli.install.metadata_validator`

## Proof
```
scd-vpn-172-16-1-172:~ ()$ sima-cli neat install sdk@sima-cli-package
✅ sima-cli is up-to-date
🔧 Environment: host (mac)
Environment: production
Repository:  sdk
Ref:         sima-cli-package
Spec:        f985c938d9f8
Metadata:    https://artifacts.neat.sima.ai/sdk/sima-cli-package/f985c938d9f8/metadata.json
⬇️  Downloading metadata.json: 1.19kB [00:00, 615kB/s]
⬇️  Downloaded metadata to: /var/folders/rn/rcf6tnks6614ls6ltflkwd_40000gn/T/tmps13sqml6/metadata.json
✅ Metadata validated successfully.

╭──────────────────── 📦 Package Summary ────────────────────╮
│  Name           sdk                                        │
│  Version        sima-cli-package                           │
│  Release        f985c938d9f8c7ef02de7c862e874b651f7ebee8   │
│  Description    SiMa.ai Neat SDK install stub              │
│  Platforms      host (ubuntu); host (windows); host (mac)  │
│  Resources      2 file(s)                                  │
│  Download Size  10GB                                       │
│  Install Size   10GB                                       │
╰────────────────────────────────────────────────────────────╯

💾 Available disk space: 36.55 GB
📦 Required space (base + modules): 9.31 GB
✅ Enough disk space for installation and resources.
📥 Downloading 2 resource(s) to: .

✔  File already exists and is complete: install_sdk_stub.sh
✅ Downloaded: install_sdk_stub.sh
🖥️  Detected platform: Mac
✅ Docker daemon is running.
📦 Pulling container image: ghcr.io/sima-neat/sdk:sima-cli-package
sima-cli-package: Pulling from sima-neat/sdk
eb833c0b909b: Pull complete 
1a42a67bac10: Pull complete 
11f7430e6f3a: Pull complete 
c717a1688a29: Pull complete 
4f4fb700ef54: Pull complete 
afa454299477: Pull complete 
19c831f5554e: Pull complete 
d3ea45fd5f95: Pull complete 
26b297a3c745: Pull complete 
fbd0031654f4: Pull complete 
08656c3533c3: Pull complete 
05838103bd4f: Pull complete 
5ba31621d8b7: Pull complete 
c289b59aaceb: Pull complete 
0bc17c7352ae: Pull complete 
f4c15f4ec0d0: Pull complete 
8d05deb6030a: Pull complete 
77a2510b8715: Pull complete 
63fd2aada7bd: Pull complete 
249e55a7390b: Pull complete 
4777a4e3994e: Pull complete 
3eed74849540: Pull complete 
f88c1073ee65: Pull complete 
82721fab3eea: Pull complete 
3939c0e6faa2: Pull complete 
b8e25f9ea7fd: Pull complete 
ccf1e2524399: Pull complete 
ef03657880ef: Pull complete 
14c6468da672: Pull complete 
1960627d8b9a: Pull complete 
1ca8a649e717: Pull complete 
42eeef25bc7b: Pull complete 
8140443b9182: Pull complete 
266ea3c782f7: Pull complete 
7bb4d2e21c0e: Pull complete 
850077af17c5: Pull complete 
a681a336983b: Pull complete 
f64d1cad83da: Pull complete 
b320ca31d18c: Pull complete 
30e0fa1f381c: Pull complete 
f0f05eea3ebc: Pull complete 
4f5e7a730783: Pull complete 
Digest: sha256:084cc18d970fe46bea1eab15aa8a61a2619772bd5da776a2131bde4f68acdc6e
Status: Downloaded newer image for ghcr.io/sima-neat/sdk:sima-cli-package
ghcr.io/sima-neat/sdk:sima-cli-package
✅ Successfully pulled container: ghcr.io/sima-neat/sdk:sima-cli-package
🚀 Running installation script in: /Users/jimfan
📜 Script: ./install_sdk_stub.sh
SiMa.ai Palette Neat SDK image is available locally.
Starting SDK setup.
Do you want to pair this SDK with a DevKit now? [y/N]: y
Enter DevKit IP address: 10.0.0.244
✅ sima-cli is up-to-date
🔧 Environment: host (mac)
🖥️  Detected platform: Mac
✅ Docker daemon is running.
╭──────────────────────╮
│ 🔧 SiMa.ai SDK Setup │
╰──────────────────────╯
🔍 Checking SiMa SDK Bridge Network...
✅ SiMa SDK Bridge Network found.
✅ Python 3.12.7 (Required ≥ 3.10.0)
✅ Docker 28.3.3 (Required ≥ 20.10.10)
✅ 10 cores / 17.2 GB RAM (Required ≥ 4 cores / 16 GB)
✅ Colima 10 CPUs / 12.0 GB RAM (default) (Required ≥4 CPUs / ≥8 GB RAM)


                          System Requirements Report                           
┌───────────┬─────────────────────┬─────────────────────────────────┬─────────┐
│ Component │ Required            │ Found                           │ Result  │
├───────────┼─────────────────────┼─────────────────────────────────┼─────────┤
│ Python    │ ≥ 3.10.0            │ 3.12.7                          │ ✅ PASS │
├───────────┼─────────────────────┼─────────────────────────────────┼─────────┤
│ Docker    │ ≥ 20.10.10          │ 28.3.3                          │ ✅ PASS │
├───────────┼─────────────────────┼─────────────────────────────────┼─────────┤
│ CPU/RAM   │ ≥4 cores / ≥16 GB   │ 10 / 17.2 GB                    │ ✅ PASS │
├───────────┼─────────────────────┼─────────────────────────────────┼─────────┤
│ Colima    │ ≥4 CPUs / ≥8 GB RAM │ 10 CPUs / 12.0 GB RAM (default) │ ✅ PASS │
└───────────┴─────────────────────┴─────────────────────────────────┴─────────┘

✅ All system requirements met. Ready for installation!
╭───────────────────── 📘 SiMa.ai SDK Image Selection ──────────────────────╮
│ How to use this menu:                                                     │
│                                                                           │
│ • Use ↑/↓ arrows then Space to select one or more images.                 │
│ • Press Enter to confirm your selection.                                  │
│ • These are local Docker SDK images detected across supported registries. │
│ • Containers based on these images will be started automatically.         │
│ • Press CTRL+C to cancel anytime.                                         │
╰───────────────────────────────────────────────────────────────────────────╯
? Multiple SDK versions detected — select one to start: sima-cli-package
ℹ️  Showing images for version sima-cli-package
📦 Select SDK images to start: (Space to toggle, Enter to confirm) 
❯ [x] ✅ Select All
  [ ] ghcr.io-sima-neat-sdk-sima-cli-package
  [ ] 🚫 Cancel
```