### PR TITLE
Fixes sima-neat/sdk#78 - On DevKit re-point, keep neat-insight URL updated via a supervisor wrapper.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,7 @@ COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
+COPY scripts/neat-insight-supervised.sh /usr/local/bin/neat-insight-supervised
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 COPY scripts/devkit-sync-rsync.sh /usr/local/bin/devkit-sync-rsync.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
@@ -188,6 +189,7 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/sysroot && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
+    chmod 755 /usr/local/bin/neat-insight-supervised && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
     chmod 755 /usr/local/bin/devkit-sync-rsync.sh && \

--- a/config/supervisor-neat-insight.conf
+++ b/config/supervisor-neat-insight.conf
@@ -1,5 +1,9 @@
 [program:neat-insight]
-command=/opt/neat-insight/venv/bin/neat-insight --port %(ENV_NEAT_INSIGHT_PORT)s
+# Launched via a wrapper that sources ~/.devkit-sync.rc so the service inherits
+# the current CONTAINER_HOST_IP after a DevKit re-point. devkit.sh restarts this
+# program on every (re-)point. Insight stays env-agnostic; the rc knowledge is
+# confined to the wrapper.
+command=/usr/local/bin/neat-insight-supervised
 directory=/workspace
 autostart=true
 autorestart=true

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -828,6 +828,10 @@ export DEVKIT_RSYNC_HELPER="${_RSYNC_HELPER}"
 export DEVKIT_SYNC_HINT="${_SYNC_HINT}"
 export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_DEVKIT_IP="${_DEVKIT_IP}"
+# Host IP neat-insight advertises in its URL / WebRTC iceHost. Refresh from the
+# current NFS host IP (_HOST_IP) so it tracks this (re-)point, and persist it
+# below so the neat-insight supervisor wrapper can export it into the service.
+export CONTAINER_HOST_IP="${_HOST_IP}"
 if [[ -z "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
   export DEVKIT_SYNC_ORIG_PS1="${PS1:-\u@\h:\w\$ }"
 fi
@@ -1327,6 +1331,7 @@ __devkit_persist_export() {
   __devkit_persist_export DEVKIT_SYNC_TARGET
   __devkit_persist_export DEVKIT_SYNC_METHOD
   __devkit_persist_export DEVKIT_SYNC_DEVKIT_IP
+  __devkit_persist_export CONTAINER_HOST_IP
   __devkit_persist_export DEVKIT_SYNC_MOUNT_POINT
   __devkit_persist_export DEVKIT_SYNC_NFS_MOUNT_POINT
   __devkit_persist_export DEVKIT_SYNC_LOCAL_ROOT
@@ -1451,6 +1456,45 @@ fi
 copy_insight_port_map_to_devkit "${DEVKIT_SYNC_DEVKIT_USER}" "${DEVKIT_SYNC_DEVKIT_IP}" "${DEVKIT_SYNC_DEVKIT_PORT}"
 
 echo "Persisted DevKit shell helpers to ${_persist_file} (auto-loaded by ~/.bashrc and ~/.bash_profile)."
+
+# Restart neat-insight so it (and the vf WebRTC viewer it spawns) re-read the
+# refreshed CONTAINER_HOST_IP via the supervisor wrapper, and the Insight URL /
+# iceHost track this (re-)point. Best-effort, and only when the host IP actually
+# changed so we don't tear down active sessions on a no-op re-source. Skipped on
+# images without Insight (insight-admin / supervisord absent).
+__devkit_refresh_neat_insight() {
+  command -v insight-admin >/dev/null 2>&1 || return 0  # no Insight on this image
+  # Need at least one of the IPs neat-insight surfaces.
+  [[ -n "${_HOST_IP:-}" || -n "${_DEVKIT_IP:-}" ]] || return 0
+
+  # Restart only when the advertised host IP (CONTAINER_HOST_IP -- the Insight
+  # URL / WebRTC iceHost) OR the active DevKit IP (DEVKIT_SYNC_DEVKIT_IP -- shown
+  # in the Insight UI and used by the webssh shell) differs from what neat-insight
+  # is *currently* advertising. A re-point can change one without the other (e.g.
+  # a different DevKit on the same subnet keeps the host IP).
+  #
+  # Read the running neat-insight's launch environment -- it holds the values
+  # the wrapper exported at its last start, i.e. exactly what is live now.
+  # If it already matches, skip (don't tear down active sessions). If neat-insight
+  # isn't running, fall through and (re)start.
+  local pid env_file applied_host applied_devkit
+  pid="$(pgrep -f 'neat-insight( |$)' 2>/dev/null | head -1)"
+  if [[ -n "${pid}" ]]; then
+    env_file="/proc/${pid}/environ"
+    if [[ -r "${env_file}" ]]; then
+      applied_host="$(tr '\0' '\n' < "${env_file}" | sed -n 's/^CONTAINER_HOST_IP=//p' | head -1)"
+      applied_devkit="$(tr '\0' '\n' < "${env_file}" | sed -n 's/^DEVKIT_SYNC_DEVKIT_IP=//p' | head -1)"
+      [[ "${applied_host}" == "${_HOST_IP:-}" && "${applied_devkit}" == "${_DEVKIT_IP:-}" ]] && return 0
+    fi
+  fi
+
+  # Best-effort: insight-admin restart fails cleanly if supervisord isn't up. We
+  # do NOT gate on `insight-admin status` -- that checks neat-insight's RUNNING
+  # state (non-zero during STARTING/BACKOFF/FATAL) and would wrongly skip.
+  echo "Refreshing neat-insight (host IP ${_HOST_IP:-<unset>}, DevKit ${_DEVKIT_IP:-<unset>})..."
+  insight-admin restart >/dev/null 2>&1 || true
+}
+__devkit_refresh_neat_insight
 
 _c_ok="" _c_rst=""
 if [[ -t 1 ]]; then

--- a/scripts/neat-insight-supervised.sh
+++ b/scripts/neat-insight-supervised.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Supervisord launch wrapper for neat-insight.
+#
+# Sources ~/.devkit-sync.rc (rewritten by devkit.sh on every DevKit (re-)point)
+# so neat-insight -- and the vf WebRTC viewer it spawns -- inherit the current
+# CONTAINER_HOST_IP. neat-insight itself stays environment-agnostic: it only
+# reads CONTAINER_HOST_IP from its process env. All DevKit-specific knowledge
+# (the .devkit-sync.rc format) lives here in the SDK image, not in Insight.
+#
+# supervisord runs this as root (HOME=/root); devkit.sh also installs the rc
+# into the SDK user homes, but the root copy is sufficient for the service env.
+
+rc="${HOME:-/root}/.devkit-sync.rc"
+[ -f "$rc" ] || rc="/root/.devkit-sync.rc"
+if [ -f "$rc" ]; then
+  # shellcheck disable=SC1090
+  . "$rc" >/dev/null 2>&1 || true
+fi
+
+exec /opt/neat-insight/venv/bin/neat-insight --port "${NEAT_INSIGHT_PORT:-9900}"


### PR DESCRIPTION
# Pull Request Template

## Summary
Explain the motivation and context for this PR.  
- What problem does it solve?  
After a DevKit re-point — or a host network/VPN change — neat-insight kept advertising the old host IP in its URL. CONTAINER_HOST_IP (and DEVKIT_SYNC_DEVKIT_IP) are baked into the Neat container at docker run and are immutable for the container's lifetime. neat-insight and the vf WebRTC viewer it spawns run under supervisord with a frozen environment and never source the per-re-point ~/.devkit-sync.rc, so they never see the refreshed values. 
This PR does the following:-
	- scripts/devkit.sh — persist the live CONTAINER_HOST_IP into ~/.devkit-sync.rc.
	- scripts/neat-insight-supervised.sh — launch wrapper that sources ~/.devkit-sync.rc then execs neat-insight so the service and its child vf process inherit the current CONTAINER_HOST_IP / DEVKIT_SYNC_DEVKIT_IP. Insight needs no SDK knowledge.
	- devkit.sh — on (re-)point, restart neat-insight so the wrapper re-sources the fresh rc. The restart fires when the host IP or the DevKit IP changed (detected by comparing the running neat-insight's /proc/< pid >/environ).

- Which issue does it close (e.g., `Fixes #123`)?  
Fixes sima-neat/sdk#78
Also, fixes sima-neat/insight#38
---

## Type of Change
Please mark the relevant options with an `x`:

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor / code cleanup  
- [ ] Tests / CI improvements  

---

## Testing & Verification
Describe how you tested your changes:  
- [ ] Unit tests added/updated  
- [ ] Built successfully on hardware (e.g., Modalix, Davinci DevKit)  
- [ ] Verified with Yocto/SDK build  
- [x] Manual functional tests (describe below)  
Patched the wrapper supervisor script and reload the supervisord to pick the wrapper (docker cp the scripts/conf + supervisorctl reread && update). So, when the host ip or devkit ip changes, then user can run sima-cli sdk setup --devkit {devkit-ip} which will update CONTAINER_HOST_IP and DEVKIT_SYNC_DEVKIT_IP and neat-insight gets restarted through wrapper to reflect the updated host ip and devkit ip.
---

## Checklist
- [x] Code follows project style guidelines  
- [x] Comments/documentation updated where needed  
- [x] Related issues linked in PR description  
