### PR TITLE
Use /media/nvme for rsync fallback workspace

### DIFF
--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -269,8 +269,8 @@ if ! command -v rsync >/dev/null 2>&1; then
 fi
 
 physical_root="${remote_root}"
-if [[ "${remote_root}" == "/workspace-rsync" && -d "/nvme/media" ]]; then
-  physical_root="/nvme/media/workspace-rsync"
+if [[ "${remote_root}" == "/workspace-rsync" && -d "/media/nvme" ]]; then
+  physical_root="/media/nvme/workspace-rsync"
 fi
 
 if [[ "${physical_root}" == "${remote_root}" ]]; then

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -9,6 +9,11 @@ fail() {
   exit 1
 }
 
+grep -Fq '/media/nvme/workspace-rsync' "${HELPER}" || fail "rsync helper should use /media/nvme for NVMe workspace storage"
+if grep -Fq '/nvme/media/workspace-rsync' "${HELPER}"; then
+  fail "rsync helper should not use the old /nvme/media workspace path"
+fi
+
 assert_contains() {
   local haystack="$1"
   local needle="$2"


### PR DESCRIPTION
## Summary

Fix the DevKit rsync fallback workspace placement to use the expected NVMe mount at `/media/nvme`.

Closes #88.

## What Changed

- Updated `scripts/devkit-sync-rsync.sh` to detect `/media/nvme` instead of the incorrect `/nvme/media` path.
- When the logical remote root is `/workspace-rsync` and `/media/nvme` exists, the physical workspace becomes `/media/nvme/workspace-rsync`.
- Added a regression check to the SDK rsync helper test to ensure the helper uses `/media/nvme/workspace-rsync` and does not regress to `/nvme/media/workspace-rsync`.

## Validation

- `bash -n scripts/devkit-sync-rsync.sh`
- `bash -n tests/sdk/test-devkit-rsync-helper.sh`
- `bash tests/sdk/test-devkit-rsync-helper.sh`