### PR TITLE
Promote SDK 2.1 updates to release-2.1

### DIFF
--- a/.github/issue-triage/config.json
+++ b/.github/issue-triage/config.json
@@ -1,0 +1,42 @@
+{
+  "labels": {
+    "allowed": [
+      "bug",
+      "documentation",
+      "enhancement",
+      "question",
+      "help wanted"
+    ]
+  },
+  "automation": {
+    "apply_labels": true,
+    "post_comment": true
+  },
+  "cross_reference_repos": [
+    {
+      "repository": "sima-neat/sima-cli",
+      "ref": "develop",
+      "path": "sima-cli"
+    },
+    {
+      "repository": "sima-neat/core",
+      "ref": "develop",
+      "path": "core"
+    },
+    {
+      "repository": "sima-neat/model-compiler",
+      "ref": "develop",
+      "path": "model-compiler"
+    },
+    {
+      "repository": "sima-neat/insight",
+      "ref": "develop",
+      "path": "insight"
+    }
+  ],
+  "max_extended_repos": 2,
+  "triage_max_files": 20,
+  "triage_file_limit_bytes": 50000,
+  "triage_total_limit_bytes": 200000,
+  "max_comment_chars": 2400
+}

--- a/.github/issue-triage/skills/sdk-triage/SKILL.md
+++ b/.github/issue-triage/skills/sdk-triage/SKILL.md
@@ -1,0 +1,230 @@
+# sdk-triage
+
+Use this skill when triaging GitHub issues in the `sima-neat/sdk` repository.
+
+## Repository Scope
+
+`sdk` packages the SiMa.ai Neat SDK as Docker images for supported host
+architectures. It covers SDK image builds, image publishing, GHCR package
+cleanup, SDK smoke tests, DevKit workspace helper behavior, SDK documentation,
+and scripts/configuration that shape the container environment.
+
+SDK issues may describe `sima-cli sdk setup` or `sima-cli sdk neat` behavior,
+but first decide whether the failure is caused by this repository's image,
+scripts, workflows, or documentation versus the `sima-cli` command
+implementation.
+
+## First Pass
+
+Before classifying the issue, check whether it is likely a duplicate of an
+existing issue from the provided issue context. Compare the title, command,
+error text, image tag, branch/package name, host architecture, DevKit pairing
+mode, and workflow name against existing discussion in the issue thread and any
+available repo context.
+
+If the issue appears to duplicate another issue, do not propose closing it and
+do not use the `duplicate` label. Set `needs_human_review` to true, keep the
+primary category aligned with the underlying problem, and mention in the public
+comment that it may overlap with an existing report if the evidence is strong.
+If the duplicate relationship is uncertain, ask for the missing detail needed to
+confirm whether it is the same failure mode.
+
+## Safety And Sensitivity
+
+If the issue appears security-sensitive, customer-confidential, or likely to
+contain private customer assets, set `needs_human_review` to true, keep the
+public comment conservative, and do not request extended analysis.
+
+Do not ask the reporter to upload credentials, tokens, private package URLs,
+private registry credentials, proprietary logs, customer code, or full DevKit
+images. Ask for redacted terminal output, public image/package references, host
+OS/architecture, and reproducible command sequences instead.
+
+If an issue likely requires private infrastructure, private package feeds,
+private runner configuration, or release credentials, route it to human review.
+
+## Classification
+
+Use `bug` when the issue describes an SDK image build failure, broken published
+image, missing tool/package in the container, smoke test failure, DevKit
+workspace failure, GHCR cleanup regression, install/setup regression caused by
+image contents, or documentation command that no longer works.
+
+Use `enhancement` when the issue requests new SDK image content, host/platform
+support, publishing behavior, setup flow, DevKit helper behavior, cleanup
+policy, smoke coverage, or developer-experience improvement.
+
+Use `documentation` when the issue is primarily about README/docs accuracy,
+installation guidance, supported platform explanation, DevKit workflow
+instructions, or confusing command examples.
+
+Use `question` when the issue asks how SDK installation, image selection,
+DevKit pairing, sysroot management, package publishing, or cleanup works and
+does not yet identify a concrete defect or requested change.
+
+Use `help wanted` only when the issue is suitable for external contribution and
+does not require private package feeds, release credentials, private runners, or
+internal infrastructure.
+
+Do not propose `duplicate`, `invalid`, or `wontfix`. If an issue appears
+duplicate, out of scope, or unsupported, set `needs_human_review` to true and
+explain the evidence neutrally.
+
+## Area Routing
+
+Set `area` to one of these short names when the issue matches:
+
+- `image-build`: Dockerfile/build script behavior, multi-arch image builds,
+  host architecture selection, Buildx, sysroot package installation during
+  build, or local `./build.sh` behavior.
+- `image-publish`: GHCR image names/tags, multi-arch manifests, branch images,
+  release images, staged/latest promotion, or package visibility.
+- `package-cleanup`: GHCR branch package cleanup, deleted branch handling,
+  protected release branches, canonical `sdk` tag cleanup, or cleanup dry-run
+  behavior.
+- `sdk-setup`: SDK setup behavior caused by image contents, container startup
+  assumptions, workspace mount expectations, user/group setup inside the image,
+  or Model Compiler extension availability from the SDK environment.
+- `devkit-workspace`: DevKit pairing, NFS workspace, `dk` helper behavior,
+  `devkit-syncd`, SSH access from the container, or `/workspace` mirroring.
+- `container-runtime`: Docker/Colima runtime behavior that affects SDK
+  containers, port mappings, privileged mode, `/dev` access, PID namespace,
+  container naming, or stopped-container recovery.
+- `sdk-networking`: SDK setup networking, DevKit connectivity, SDK-to-DevKit
+  workspace/network configuration, port forwarding, NFS/rsync fallback, or
+  network troubleshooting during SDK setup.
+- `sysroot-toolchain`: `/opt/toolchain`, `simaai-init-build-env`, cross
+  compiler/sysroot packages, `sysroot install/list/remove`, or target package
+  availability.
+- `docs`: README, `docs/`, installation instructions, DevKit workspace docs,
+  building-software docs, or supported platform statements.
+- `smoke-ci`: GitHub Actions, SDK smoke tests, Docker build workflow, runner
+  architecture issues, or CI-only failures.
+- `sdk-package`: SDK install package metadata, `sima-cli neat install
+  sdk@...`, package resources, one-command SDK installation, or installer
+  script behavior.
+- `insight`: Insight installation or usage from inside the SDK image, Insight
+  version baked into the SDK, or docs for Insight in SDK.
+- `unknown`: not enough information to route.
+
+## Common Missing Information
+
+For SDK install/setup issues, ask for:
+
+- host OS and architecture
+- `sima-cli --version`
+- exact command
+- SDK image/package ref or tag
+- complete redacted terminal output
+- Docker or Colima status
+- whether a DevKit was paired and the pairing mode, without requiring private IP
+  disclosure if the reporter does not want to share it
+
+For image build or CI issues, ask for:
+
+- branch or commit
+- architecture, such as `linux/amd64` or `linux/arm64`
+- workflow/job name if CI-related
+- full failing build step and error output
+- whether the failure reproduces locally with `./build.sh`
+
+For DevKit workspace issues, ask for:
+
+- SDK image tag
+- host OS and architecture
+- DevKit software/platform version if available
+- whether `dk shell` works
+- redacted NFS/SSH/workspace error output
+
+For SDK setup network issues, use the public sima-cli SDK networking
+documentation as the first reference:
+
+- https://developer.sima.ai/software/tools/sima-cli/sdk-networking/
+- https://developer.sima.ai/software/tools/sima-cli/sdk-networking/troubleshooting
+
+If the issue appears to match documented setup or troubleshooting guidance,
+point the reporter to the relevant page and ask for the specific command output
+that differs from the documented flow. Do not ask for private network details
+unless the reporter can redact them.
+
+For package cleanup or publishing issues, ask for:
+
+- branch/tag name
+- expected GHCR image or SDK install package name
+- whether the branch is protected or deleted
+- workflow run URL when available
+- dry-run output when available
+
+## Extended Analysis
+
+Most issues should be triaged from the issue text, command output, and this
+repo's local triage guidance. Do not request extended analysis just because the
+issue mentions sima-cli, core, Model Compiler, or Insight.
+
+Request extended analysis only when the issue includes enough specific detail
+that checking another public repository can materially improve routing or the
+next maintainer action.
+
+Allowed cross-reference repositories:
+
+- `sima-neat/sima-cli`
+- `sima-neat/core`
+- `sima-neat/model-compiler`
+- `sima-neat/insight`
+
+Request `sima-neat/sima-cli` when:
+
+- the issue is primarily about `sima-cli sdk setup`, `sima-cli sdk neat`,
+  `sima-cli neat install`, Docker permission recovery, SDK container selection,
+  update prompts, or package installer orchestration.
+- the report includes a concrete CLI command, CLI version, prompt sequence, or
+  error message that can be checked against sima-cli behavior.
+
+Request `sima-neat/core` when:
+
+- the issue involves NEAT libraries, tutorials, Python bindings, installed core
+  packages, runtime behavior, or SDK-contained artifacts that are produced by
+  the core repo.
+- the issue includes a core package version, tutorial path, NEAT API error, or
+  runtime log that can be checked in core docs/tests/source.
+
+Request `sima-neat/model-compiler` when:
+
+- the issue involves Model Compiler extension installation, model compiler
+  examples, BF16/INT8 behavior, compiled model archives, or compiler tools used
+  inside the SDK.
+- the issue includes compiler output, example path, extension package ref, or
+  model archive details that can be checked against model-compiler docs or
+  workflows.
+
+Request `sima-neat/insight` when:
+
+- the issue involves Insight installed in the SDK image, Insight launch/use from
+  the SDK container, media/source workflows, or SDK docs that route to Insight.
+- the issue includes Insight logs, package refs, workflow names, or docs paths
+  that can be checked in the public Insight repository.
+
+When extended analysis is useful, set:
+
+- `extended_analysis_required`: `true`
+- `extended_analysis_repos`: only the specific repo or repos needed from the
+  allowlist above
+- `extended_analysis_reason`: a concise explanation of what should be checked
+
+If the issue lacks concrete logs, commands, image tags, package refs, workflow
+names, or file paths, do not request extended analysis. Ask for the missing
+information instead.
+
+## Comment Style
+
+Write a public triage comment with 2-4 short paragraphs:
+
+- acknowledge the issue and state the likely area
+- state whether it appears actionable, needs repro details, or needs human
+  review
+- mention specific evidence from the report
+- ask only for missing information that would materially unblock investigation
+
+Do not include a mechanical label list unless it is useful to the reporter. Do
+not claim a root cause unless the issue text or checked public repository
+context provides strong evidence.

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -1,0 +1,233 @@
+name: Cleanup GHCR Packages
+
+on:
+  schedule:
+    - cron: "23 9 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Show what would be deleted without deleting packages"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Cleanup branch SDK packages
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Cleanup GHCR package versions
+        uses: actions/github-script@v8
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repoFullName = `${owner}/${repo}`;
+            const dryRun = String(process.env.DRY_RUN).toLowerCase() === 'true';
+
+            const protectedBranchNames = new Set(['develop', 'main']);
+
+            function branchSlug(branchName) {
+              let branch = branchName.toLowerCase();
+              branch = branch
+                .replace(/[^a-z0-9._-]+/g, '-')
+                .replace(/^-+/, '')
+                .replace(/-+$/, '')
+                .replace(/-{2,}/g, '-');
+              if (!branch) {
+                branch = 'branch';
+              }
+              return branch;
+            }
+
+            function sdkPackageForBranch(branchName) {
+              const branch = branchSlug(branchName);
+              return `sdk-${branch}`;
+            }
+
+            function isReleaseOrInfrastructureTag(tag) {
+              return (
+                tag === 'latest' ||
+                tag === 'staged-latest' ||
+                /^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$/.test(tag) ||
+                /^v[0-9]+[.][0-9]+-latest$/.test(tag) ||
+                /^[0-9a-f]{40}$/.test(tag) ||
+                /^staged-[0-9a-f]{40}$/.test(tag) ||
+                /^[0-9a-f]{40}-(x86_64|aarch64)$/.test(tag)
+              );
+            }
+
+            function isBranchTag(tag, liveBranchSlugs) {
+              if (isReleaseOrInfrastructureTag(tag)) {
+                return false;
+              }
+              return !liveBranchSlugs.has(tag);
+            }
+
+            function packageRepositoryFullName(pkg) {
+              if (pkg.repository?.full_name) {
+                return pkg.repository.full_name;
+              }
+              const repoOwner = pkg.repository?.owner?.login;
+              const repoName = pkg.repository?.name;
+              if (repoOwner && repoName) {
+                return `${repoOwner}/${repoName}`;
+              }
+              return '';
+            }
+
+            async function paginate(route, parameters) {
+              return github.paginate(route, {
+                per_page: 100,
+                ...parameters,
+              });
+            }
+
+            async function deletePackage(packageName) {
+              if (dryRun) {
+                core.info(`[dry-run] would delete package ${packageName}`);
+                return;
+              }
+              await github.request('DELETE /orgs/{org}/packages/{package_type}/{package_name}', {
+                org: owner,
+                package_type: 'container',
+                package_name: packageName,
+              });
+              core.info(`Deleted package ${packageName}`);
+            }
+
+            async function deletePackageVersion(packageName, version) {
+              const tags = version.metadata?.container?.tags ?? [];
+              if (dryRun) {
+                core.info(`[dry-run] would delete ${packageName} version ${version.id} tags=[${tags.join(', ')}]`);
+                return;
+              }
+              await github.request('DELETE /orgs/{org}/packages/{package_type}/{package_name}/versions/{package_version_id}', {
+                org: owner,
+                package_type: 'container',
+                package_name: packageName,
+                package_version_id: version.id,
+              });
+              core.info(`Deleted ${packageName} version ${version.id} tags=[${tags.join(', ')}]`);
+            }
+
+            async function packageExists(packageName) {
+              try {
+                await github.request('GET /orgs/{org}/packages/{package_type}/{package_name}', {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: packageName,
+                });
+                return true;
+              } catch (error) {
+                if (error.status === 404) {
+                  return false;
+                }
+                throw error;
+              }
+            }
+
+            const branches = await paginate('GET /repos/{owner}/{repo}/branches', {
+              owner,
+              repo,
+            });
+            const branchPackages = new Set();
+            const protectedBranchPackages = new Set();
+            const branchSlugs = new Set();
+
+            for (const branch of branches) {
+              const slug = branchSlug(branch.name);
+              const packageName = sdkPackageForBranch(branch.name);
+              branchSlugs.add(slug);
+              branchPackages.add(packageName);
+              if (branch.protected || protectedBranchNames.has(branch.name)) {
+                protectedBranchPackages.add(packageName);
+              }
+            }
+
+            core.info(`Found ${branches.length} branch(es).`);
+            core.info(`Found ${protectedBranchPackages.size} protected branch package name(s).`);
+
+            const packages = await paginate('GET /orgs/{org}/packages', {
+              org: owner,
+              package_type: 'container',
+            });
+            const sdkBranchPackages = packages
+              .filter((pkg) => pkg.name.startsWith('sdk-'))
+              .filter((pkg) => {
+                const packageRepo = packageRepositoryFullName(pkg);
+                if (packageRepo === repoFullName) {
+                  return true;
+                }
+                core.info(`${pkg.name}: skipping package associated with ${packageRepo || 'unknown repository'}.`);
+                return false;
+              })
+              .map((pkg) => pkg.name);
+
+            core.info(`Found ${sdkBranchPackages.length} sdk-* GHCR package(s).`);
+
+            for (const packageName of sdkBranchPackages) {
+              if (!branchPackages.has(packageName)) {
+                core.info(`${packageName}: no matching branch; deleting entire package.`);
+                await deletePackage(packageName);
+                continue;
+              }
+
+              if (protectedBranchPackages.has(packageName)) {
+                core.info(`${packageName}: matching branch is protected; keeping all versions.`);
+                continue;
+              }
+
+              core.info(`${packageName}: matching branch still exists; keeping package and all versions.`);
+            }
+
+            if (!(await packageExists('sdk'))) {
+              core.info('sdk: canonical package does not exist; skipping canonical branch-tag cleanup.');
+            } else {
+              const versions = await paginate(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: 'sdk',
+                },
+              );
+              let deletedCanonical = 0;
+              let keptCanonical = 0;
+              let skippedCanonical = 0;
+              for (const version of versions) {
+                const tags = version.metadata?.container?.tags ?? [];
+                const deletedBranchTags = tags.filter((tag) => isBranchTag(tag, branchSlugs));
+                if (deletedBranchTags.length === 0) {
+                  keptCanonical += 1;
+                  continue;
+                }
+
+                const retainedTags = tags.filter((tag) => !deletedBranchTags.includes(tag));
+                if (retainedTags.length > 0) {
+                  skippedCanonical += 1;
+                  core.warning(
+                    `sdk: version ${version.id} has deleted-branch tag(s) [${deletedBranchTags.join(', ')}] ` +
+                    `but also retained tag(s) [${retainedTags.join(', ')}]; keeping the version because GHCR deletes versions, not individual tags.`,
+                  );
+                  continue;
+                }
+
+                await deletePackageVersion('sdk', version);
+                deletedCanonical += 1;
+              }
+              core.info(
+                `sdk: deleted ${deletedCanonical} deleted-branch-only version(s), ` +
+                `kept ${keptCanonical} version(s), skipped ${skippedCanonical} mixed-tag version(s).`,
+              );
+            }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,8 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
+  id-token: write
   packages: write
 
 concurrency:
@@ -130,6 +131,7 @@ jobs:
 
           release_tag=""
           release_latest_tag=""
+          branch_tag=""
           promote_latest=false
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             release_tag="${GITHUB_REF_NAME}"
@@ -141,6 +143,11 @@ jobs:
             fi
           elif [[ "${GITHUB_REF}" == refs/heads/* ]]; then
             promote_latest=true
+            branch_tag="$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')"
+            branch_tag="$(echo "${branch_tag}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            if [[ -z "${branch_tag}" ]]; then
+              branch_tag="branch"
+            fi
           fi
 
           {
@@ -150,6 +157,7 @@ jobs:
             echo "commit_sha=${GITHUB_SHA}"
             echo "release_tag=${release_tag}"
             echo "release_latest_tag=${release_latest_tag}"
+            echo "branch_tag=${branch_tag}"
             echo "promote_latest=${promote_latest}"
           } > image-metadata/image.env
         env:
@@ -441,6 +449,9 @@ jobs:
     needs: smoke
     runs-on: ubuntu-24.04
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -473,6 +484,10 @@ jobs:
           tags=()
           if [[ "${promote_latest}" == "true" ]]; then
             tags+=(--tag "${repository}:latest")
+            if [[ -n "${branch_tag:-}" ]]; then
+              canonical_sdk_repository="${repository%/*}/sdk"
+              tags+=(--tag "${canonical_sdk_repository}:${branch_tag}")
+            fi
           fi
           if [[ -n "${release_tag}" ]]; then
             tags+=(--tag "${repository}:${release_tag}")
@@ -484,3 +499,83 @@ jobs:
           docker buildx imagetools create \
             "${tags[@]}" \
             "${source_ref}"
+
+  prepare-vulcan-install-stub:
+    name: Prepare SDK install stub package
+    if: github.event_name != 'pull_request'
+    needs: promote
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+
+      - name: Install sima-cli
+        run: |
+          set -euo pipefail
+
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install sima-cli
+          SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli --version
+
+      - name: Prepare SDK install stub package
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          if [[ "${promote_latest}" == "true" ]]; then
+            canonical_sdk_repository="${repository%/*}/sdk"
+            image_resource="ghcr:${canonical_sdk_repository#ghcr.io/}:${branch_tag}"
+            package_version="${GITHUB_REF_NAME}"
+          elif [[ -n "${release_tag}" ]]; then
+            image_resource="ghcr:${repository#ghcr.io/}:${release_tag}"
+            package_version="${release_tag#v}"
+          else
+            echo "SDK install stub skipped: no promoted branch or release image tag." >&2
+            exit 1
+          fi
+
+          source .venv/bin/activate
+          tools/prepare_s3_artifacts.sh \
+            --output-dir dist \
+            --image-resource "${image_resource}" \
+            --version "${package_version}" \
+            --release "${GITHUB_SHA}"
+
+      - name: Upload SDK install stub package
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-install-stub
+          path: dist/
+          if-no-files-found: error
+
+  publish-vulcan-install-stub:
+    name: Publish SDK install stub to Vulcan
+    if: github.event_name != 'pull_request'
+    needs: prepare-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      artifact_pattern: sdk-install-stub
+      artifact_glob: "**/*"
+      min_artifact_count: 2
+
+  mark-vulcan-install-stub-latest:
+    name: Mark SDK install stub as latest
+    if: github.event_name != 'pull_request'
+    needs: publish-vulcan-install-stub
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -573,7 +573,7 @@ jobs:
 
   mark-vulcan-install-stub-latest:
     name: Mark SDK install stub as latest
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     needs: publish-vulcan-install-stub
     uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
     with:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,38 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage.
+        required: true
+        type: number
+      dry_run:
+        description: Propose actions without mutating the issue.
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          !contains(github.event.issue.labels.*.name, 'no-ai-triage') &&
+          !contains(github.event.issue.labels.*.name, 'customer-confidential') &&
+          !contains(github.event.issue.labels.*.name, 'security') &&
+          !contains(github.event.issue.labels.*.name, 'manual-triage')
+        )
+      }}
+    uses: sima-neat/.github/.github/workflows/reusable-issue-triage.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number || inputs.issue_number }}
+      dry_run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      repo_triage_path: .github/issue-triage

--- a/.github/workflows/pr-sanitization.yml
+++ b/.github/workflows/pr-sanitization.yml
@@ -1,0 +1,13 @@
+name: PR Sanitization
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-sanitization:
+    uses: sima-neat/.github/.github/workflows/pr-sanitization.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,7 @@ jobs:
       prerelease: ${{ inputs.prerelease }}
       latest: ${{ inputs.latest }}
       dry_run: ${{ inputs.dry_run }}
+      validate_release_issues: true
+    secrets:
+      NEAT_RELEASES_APP_ID: ${{ secrets.NEAT_RELEASES_APP_ID }}
+      NEAT_RELEASES_APP_PRIVATE_KEY: ${{ secrets.NEAT_RELEASES_APP_PRIVATE_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,7 @@ COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.conf
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
+COPY scripts/neat-insight-supervised.sh /usr/local/bin/neat-insight-supervised
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
 COPY scripts/devkit-sync-rsync.sh /usr/local/bin/devkit-sync-rsync.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
@@ -188,6 +189,7 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/sysroot && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
+    chmod 755 /usr/local/bin/neat-insight-supervised && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
     chmod 755 /usr/local/bin/devkit-sync-rsync.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,6 +182,7 @@ COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.d/neat-insight.con
 COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY scripts/insight-admin.sh /usr/local/bin/insight-admin
 COPY scripts/devkit.sh /usr/local/bin/devkit.sh
+COPY scripts/devkit-sync-rsync.sh /usr/local/bin/devkit-sync-rsync.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/install-sdk-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/sysroot && \
@@ -189,6 +190,7 @@ RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
     ln -sf /usr/local/bin/insight-admin /usr/local/bin/install-neat-insight && \
     chmod 755 /usr/local/bin/devkit.sh && \
+    chmod 755 /usr/local/bin/devkit-sync-rsync.sh && \
     install-sdk-sysroot-overlay.sh
 
 RUN if [ -n "${NEAT_INSIGHT_BRANCH}${NEAT_INSIGHT_VERSION}" ]; then \

--- a/README.md
+++ b/README.md
@@ -25,16 +25,32 @@ The main user workflow is:
 
 ## Install The SDK
 
-Install the latest published SDK image:
+Install the latest published SDK and run setup:
 
 ```bash
-sima-cli install ghcr:sima-neat/sdk
+sima-cli neat install sdk@developer
+```
+
+Install a released SDK version:
+
+```bash
+sima-cli neat install sdk@{version}
+```
+
+The install command pulls the SDK image and then asks whether to pair the SDK
+with a Modalix DevKit. If you choose to pair, enter the DevKit IP address when
+prompted.
+
+You can still install a container image resource directly when needed:
+
+```bash
+sima-cli install ghcr:sima-neat/sdk:latest
 ```
 
 Install a branch-specific image:
 
 ```bash
-sima-cli install ghcr:sima-neat/sdk-feature-devkit-sync:latest
+sima-cli install ghcr:sima-neat/sdk:feature-devkit-sync
 ```
 
 The published image contains the toolchain, sysroot, headers, libraries, NEAT runtime components, and helper scripts needed to build software for SiMa.ai platforms.

--- a/config/supervisor-neat-insight.conf
+++ b/config/supervisor-neat-insight.conf
@@ -1,5 +1,9 @@
 [program:neat-insight]
-command=/opt/neat-insight/venv/bin/neat-insight --port %(ENV_NEAT_INSIGHT_PORT)s
+# Launched via a wrapper that sources ~/.devkit-sync.rc so the service inherits
+# the current CONTAINER_HOST_IP after a DevKit re-point. devkit.sh restarts this
+# program on every (re-)point. Insight stays env-agnostic; the rc knowledge is
+# confined to the wrapper.
+command=/usr/local/bin/neat-insight-supervised
 directory=/workspace
 autostart=true
 autorestart=true

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,9 +1,9 @@
 {
   "core": {
-    "ref": "v0.2.1"
+    "ref": "v0.2.2"
   },
   "insight": {
-    "ref": "v0.0.3"
+    "ref": "v0.0.4"
   },
   "platform-version": "2.1.2"
 }

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -269,8 +269,8 @@ if ! command -v rsync >/dev/null 2>&1; then
 fi
 
 physical_root="${remote_root}"
-if [[ "${remote_root}" == "/workspace-rsync" && -d "/nvme/media" ]]; then
-  physical_root="/nvme/media/workspace-rsync"
+if [[ "${remote_root}" == "/workspace-rsync" && -d "/media/nvme" ]]; then
+  physical_root="/media/nvme/workspace-rsync"
 fi
 
 if [[ "${physical_root}" == "${remote_root}" ]]; then

--- a/scripts/devkit-sync-rsync.sh
+++ b/scripts/devkit-sync-rsync.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  devkit-sync-rsync.sh setup --devkit IP --user USER --port PORT --local PATH --remote PATH
+  devkit-sync-rsync.sh sync --devkit IP --user USER --port PORT --local PATH --remote PATH [--scope PATH] [--status-file PATH]
+  devkit-sync-rsync.sh status --devkit IP --user USER --port PORT --remote PATH [--status-file PATH]
+  devkit-sync-rsync.sh map-path --local-root PATH --remote-root PATH --path PATH
+  devkit-sync-rsync.sh scope-for-path --local-root PATH --path PATH
+  devkit-sync-rsync.sh print-excludes --local PATH
+EOF
+}
+
+cmd="${1:-}"
+if [[ -z "${cmd}" ]]; then
+  usage
+  exit 2
+fi
+shift
+
+devkit=""
+user="sima"
+port="22"
+local_root="/workspace"
+remote_root="/workspace-rsync"
+path=""
+scope=""
+status_file="${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --devkit)
+      devkit="${2:-}"; shift 2 ;;
+    --user)
+      user="${2:-}"; shift 2 ;;
+    --port)
+      port="${2:-}"; shift 2 ;;
+    --local)
+      local_root="${2:-}"; shift 2 ;;
+    --remote)
+      remote_root="${2:-}"; shift 2 ;;
+    --local-root)
+      local_root="${2:-}"; shift 2 ;;
+    --remote-root)
+      remote_root="${2:-}"; shift 2 ;;
+    --path)
+      path="${2:-}"; shift 2 ;;
+    --scope)
+      scope="${2:-}"; shift 2 ;;
+    --status-file)
+      status_file="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+ssh_target() {
+  printf '%s@%s' "${user}" "${devkit}"
+}
+
+require_connection_args() {
+  if [[ -z "${devkit}" || -z "${user}" || -z "${port}" ]]; then
+    echo "--devkit, --user, and --port are required." >&2
+    exit 2
+  fi
+  if [[ ! "${port}" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo "Invalid SSH port: ${port}" >&2
+    exit 2
+  fi
+}
+
+ssh_base() {
+  ssh -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "$(ssh_target)" "$@"
+}
+
+ssh_bash() {
+  ssh -T -p "${port}" -o BatchMode=yes -o ConnectTimeout=8 "$(ssh_target)" bash -s -- "$@"
+}
+
+default_excludes() {
+  cat <<'EOF'
+.git/
+.gitmodules
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.cache/
+.venv/
+venv/
+node_modules/
+*.log
+.DS_Store
+EOF
+}
+
+write_status() {
+  local state="$1"
+  local detail="$2"
+  local sync_scope="${3:-}"
+  local status_dir tmp_status
+  status_dir="$(dirname "${status_file}")"
+  if ! mkdir -p "${status_dir}" >/dev/null 2>&1; then
+    return 0
+  fi
+  tmp_status="$(mktemp "${status_dir}/.devkit-rsync-status.XXXXXX" 2>/dev/null)" || return 0
+  {
+    printf 'timestamp=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'state=%s\n' "${state}"
+    if [[ -n "${sync_scope}" ]]; then
+      printf 'scope=%q\n' "${sync_scope}"
+    fi
+    printf 'detail=%q\n' "${detail}"
+  } > "${tmp_status}" || {
+    rm -f "${tmp_status}"
+    return 0
+  }
+  mv -f "${tmp_status}" "${status_file}" >/dev/null 2>&1 || rm -f "${tmp_status}"
+}
+
+normalize_local_path() {
+  local input="$1"
+  local part
+  local -a parts=()
+  local -a normalized_parts=()
+
+  if [[ "${input}" != /* ]]; then
+    input="${PWD}/${input}"
+  fi
+
+  IFS='/' read -r -a parts <<< "${input#/}"
+  for part in "${parts[@]}"; do
+    case "${part}" in
+      ""|".")
+        continue
+        ;;
+      "..")
+        if (( ${#normalized_parts[@]} > 0 )); then
+          unset 'normalized_parts[${#normalized_parts[@]}-1]'
+        fi
+        ;;
+      *)
+        normalized_parts+=("${part}")
+        ;;
+    esac
+  done
+
+  if (( ${#normalized_parts[@]} == 0 )); then
+    printf '/\n'
+    return 0
+  fi
+
+  local joined
+  printf -v joined '%s/' "${normalized_parts[@]}"
+  printf '/%s\n' "${joined%/}"
+}
+
+scope_for_path() {
+  local input="$1"
+  local normalized
+
+  if [[ -z "${input}" ]]; then
+    input="${local_root}"
+  fi
+  normalized="$(normalize_local_path "${input}")"
+
+  case "${normalized}" in
+    "${local_root}")
+      printf '%s\n' "${local_root}"
+      ;;
+    "${local_root}"/*)
+      local rel first
+      rel="${normalized#"${local_root%/}/"}"
+      first="${rel%%/*}"
+      if [[ -n "${first}" ]]; then
+        printf '%s/%s\n' "${local_root%/}" "${first}"
+      else
+        printf '%s\n' "${local_root}"
+      fi
+      ;;
+    *)
+      echo "Scope must be inside ${local_root}: ${input}" >&2
+      return 2
+      ;;
+  esac
+}
+
+remote_for_local_path() {
+  local input="$1"
+  local normalized
+  normalized="$(normalize_local_path "${input}")"
+  case "${normalized}" in
+    "${local_root}")
+      printf '%s\n' "${remote_root%/}"
+      ;;
+    "${local_root}"/*)
+      printf '%s/%s\n' "${remote_root%/}" "${normalized#"${local_root%/}/"}"
+      ;;
+    *)
+      echo "Path must be inside ${local_root}: ${input}" >&2
+      return 2
+      ;;
+  esac
+}
+
+build_exclude_args() {
+  local tmp="$1"
+  local exclude_base="${2:-${local_root}}"
+  default_excludes > "${tmp}"
+  if [[ -f "${exclude_base}/.devkit-rsync-exclude" ]]; then
+    cat "${exclude_base}/.devkit-rsync-exclude" >> "${tmp}"
+  elif [[ "${exclude_base}" != "${local_root}" && -f "${local_root}/.devkit-rsync-exclude" ]]; then
+    cat "${local_root}/.devkit-rsync-exclude" >> "${tmp}"
+  fi
+  if [[ -n "${DEVKIT_RSYNC_EXCLUDES_FILE:-}" && -f "${DEVKIT_RSYNC_EXCLUDES_FILE}" ]]; then
+    cat "${DEVKIT_RSYNC_EXCLUDES_FILE}" >> "${tmp}"
+  fi
+  if [[ -n "${DEVKIT_RSYNC_EXTRA_EXCLUDES:-}" ]]; then
+    printf '%s\n' "${DEVKIT_RSYNC_EXTRA_EXCLUDES}" >> "${tmp}"
+  fi
+}
+
+case "${cmd}" in
+  setup)
+    require_connection_args
+    if ! command -v rsync >/dev/null 2>&1; then
+      echo "rsync is not installed in the SDK container." >&2
+      exit 1
+    fi
+    ssh_bash "${remote_root}" <<'EOS' || {
+set -euo pipefail
+remote_root="$1"
+if [[ "$(id -u)" -eq 0 ]]; then
+  SUDO=""
+elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO="__missing_sudo__"
+fi
+
+as_root() {
+  if [[ -z "${SUDO}" ]]; then
+    "$@"
+  elif [[ "${SUDO}" == "__missing_sudo__" ]]; then
+    echo "Passwordless sudo is required on the DevKit for rsync fallback setup." >&2
+    return 1
+  else
+    sudo "$@"
+  fi
+}
+
+if ! command -v rsync >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    as_root apt-get update --allow-releaseinfo-change
+    as_root apt-get install -y --no-install-recommends rsync
+  fi
+fi
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "rsync is not installed on the DevKit and could not be installed automatically." >&2
+  exit 1
+fi
+
+physical_root="${remote_root}"
+if [[ "${remote_root}" == "/workspace-rsync" && -d "/nvme/media" ]]; then
+  physical_root="/nvme/media/workspace-rsync"
+fi
+
+if [[ "${physical_root}" == "${remote_root}" ]]; then
+  if [[ "$(id -u)" -eq 0 ]]; then
+    mkdir -p "${remote_root}"
+    chmod 0755 "${remote_root}"
+  elif mkdir -p "${remote_root}" >/dev/null 2>&1; then
+    chmod 0755 "${remote_root}" || true
+  elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
+    as_root mkdir -p "${remote_root}"
+    as_root chown "$(id -u):$(id -g)" "${remote_root}"
+    as_root chmod 0755 "${remote_root}"
+  else
+    echo "Cannot create ${remote_root}; passwordless sudo is required." >&2
+    exit 1
+  fi
+else
+  if [[ "$(id -u)" -eq 0 ]]; then
+    mkdir -p "${physical_root}"
+    chown "$(id -u):$(id -g)" "${physical_root}"
+    chmod 0755 "${physical_root}"
+  elif mkdir -p "${physical_root}" >/dev/null 2>&1; then
+    chmod 0755 "${physical_root}" || true
+  elif [[ "${SUDO}" != "__missing_sudo__" ]]; then
+    as_root mkdir -p "${physical_root}"
+    as_root chown "$(id -u):$(id -g)" "${physical_root}"
+    as_root chmod 0755 "${physical_root}"
+  else
+    echo "Cannot create ${physical_root}; passwordless sudo is required." >&2
+    exit 1
+  fi
+
+  if [[ -L "${remote_root}" ]]; then
+    as_root ln -sfn "${physical_root}" "${remote_root}"
+  elif [[ -e "${remote_root}" ]]; then
+    if rmdir "${remote_root}" >/dev/null 2>&1 || as_root rmdir "${remote_root}"; then
+      as_root ln -sfn "${physical_root}" "${remote_root}"
+    else
+      echo "WARNING: ${remote_root} already exists and is not empty; using existing root filesystem path." >&2
+      physical_root="${remote_root}"
+    fi
+  else
+    as_root ln -sfn "${physical_root}" "${remote_root}"
+  fi
+fi
+
+df -h "${physical_root}" 2>/dev/null | tail -n 1 | awk -v logical="${remote_root}" -v physical="${physical_root}" '
+  { printf "rsync remote workspace: logical=%s physical=%s available=%s filesystem=%s\n", logical, physical, $4, $1 }
+'
+EOS
+      echo "DevKit rsync setup failed. Ensure rsync can be installed and ${remote_root} is writable." >&2
+      exit 1
+    }
+    ;;
+  sync)
+    require_connection_args
+    local_sync_root="$(scope_for_path "${scope:-${PWD}}")"
+    remote_sync_root="$(remote_for_local_path "${local_sync_root}")"
+    if [[ ! -d "${local_sync_root}" ]]; then
+      echo "Local sync root not found: ${local_sync_root}" >&2
+      write_status failed "local root not found: ${local_sync_root}" "${local_sync_root}" || true
+      exit 1
+    fi
+    tmp_excludes="$(mktemp)"
+    trap 'rm -f "${tmp_excludes}"' EXIT
+    build_exclude_args "${tmp_excludes}" "${local_sync_root}"
+    rsync_args=(-az --delete "--exclude-from=${tmp_excludes}")
+    case "${DEVKIT_RSYNC_PROGRESS:-AUTO}" in
+      OFF|off|0|false|FALSE|no|NO)
+        ;;
+      AUTO|auto|"")
+        if [[ -t 1 ]]; then
+          rsync_args+=("--info=progress2,stats2" --human-readable)
+        fi
+        ;;
+      *)
+        rsync_args+=("--info=progress2,stats2" --human-readable)
+        ;;
+    esac
+    echo "Syncing ${local_sync_root} -> $(ssh_target):${remote_sync_root}"
+    if rsync "${rsync_args[@]}" -e "ssh -p ${port} -o BatchMode=yes -o ConnectTimeout=8" "${local_sync_root%/}/" "$(ssh_target):${remote_sync_root%/}/"; then
+      write_status ok "synced ${local_sync_root} to ${remote_sync_root}" "${local_sync_root}" || true
+    else
+      rc=$?
+      write_status failed "rsync exited ${rc}" "${local_sync_root}" || true
+      exit "${rc}"
+    fi
+    ;;
+  status)
+    require_connection_args
+    echo "rsync remote root: ${remote_root}"
+    if ssh_base "test -d '${remote_root}'"; then
+      echo "remote root: present"
+      ssh_base "if [ -L '${remote_root}' ]; then printf 'physical root: '; readlink -f '${remote_root}'; else echo 'physical root: ${remote_root}'; fi; df -h '${remote_root}' 2>/dev/null | tail -n 1 | awk '{print \"available space: \" \$4 \" on \" \$1}'" || true
+    else
+      echo "remote root: missing"
+    fi
+    if [[ -f "${status_file}" ]]; then
+      echo "last sync:"
+      sed 's/^/  /' "${status_file}"
+    else
+      echo "last sync: never"
+    fi
+    ;;
+  print-excludes)
+    tmp_excludes="$(mktemp)"
+    trap 'rm -f "${tmp_excludes}"' EXIT
+    build_exclude_args "${tmp_excludes}"
+    cat "${tmp_excludes}"
+    ;;
+  map-path)
+    if [[ -z "${path}" ]]; then
+      echo "--path is required for map-path." >&2
+      exit 2
+    fi
+    case "${path}" in
+      "${local_root}"/*)
+        printf '%s/%s\n' "${remote_root%/}" "${path#"${local_root%/}/"}"
+        ;;
+      "${local_root}")
+        printf '%s\n' "${remote_root%/}"
+        ;;
+      *)
+        printf '%s\n' "${path}"
+        ;;
+    esac
+    ;;
+  scope-for-path)
+    if [[ -z "${path}" ]]; then
+      echo "--path is required for scope-for-path." >&2
+      exit 2
+    fi
+    scope_for_path "${path}"
+    ;;
+  *)
+    echo "Unknown command: ${cmd}" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -1018,7 +1018,7 @@ devkit-run() {
   rel="${local_path#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
   remote_path="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${rel}"
   remote_path="${remote_path//\/\//\/}"
-  local host_pwd remote_args arg
+  local host_pwd remote_args arg local_sync_scope
   host_pwd="$(pwd)"
   case "${host_pwd}" in
     "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
@@ -1034,6 +1034,30 @@ devkit-run() {
   esac
   pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
   remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}" "${DEVKIT_SYNC_METHOD:-nfs}")
+
+  devkit_local_sync_scope() {
+    local path="$1"
+    local root="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+    local rel_path
+
+    case "${path}" in
+      "${root}") ;;
+      "${root}"/*) ;;
+      *)
+        printf '%s\n' "${path}"
+        return 0
+        ;;
+    esac
+
+    rel_path="${path#"${root}"}"
+    rel_path="${rel_path#/}"
+    if [[ -z "${rel_path}" || "${rel_path}" != */* ]]; then
+      printf '%s\n' "${root}"
+    else
+      printf '%s/%s\n' "${root}" "${rel_path%%/*}"
+    fi
+  }
+  local_sync_scope="$(devkit_local_sync_scope "${local_path}")"
 
   normalize_devkit_host_path() {
     local input="$1"
@@ -1116,6 +1140,13 @@ devkit-run() {
     case "${normalized}" in
       "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
         local mapped
+        local arg_sync_scope
+        arg_sync_scope="$(devkit_local_sync_scope "${normalized}")"
+        if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" && "${arg_sync_scope}" != "${local_sync_scope}" ]]; then
+          echo "Mapped argument ${normalized} is outside the synced root ${local_sync_scope}." >&2
+          echo "When rsync fallback is active, keep files needed by dk under the same top-level workspace folder as ${local_path}." >&2
+          return 2
+        fi
         mapped="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${normalized#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
         mapped="${mapped//\/\//\/}"
         printf '%s%s\n' "${prefix}" "${mapped}"
@@ -1126,8 +1157,10 @@ devkit-run() {
     esac
   }
 
+  local mapped_arg
   for arg in "$@"; do
-    remote_args+=("$(map_devkit_arg_path "${arg}")")
+    mapped_arg="$(map_devkit_arg_path "${arg}")" || return $?
+    remote_args+=("${mapped_arg}")
   done
 
   if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" ]]; then

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -446,6 +446,9 @@ _HOST_IP="${NFS_SERVER_HOST_IP:-}"
 _HOST_EXPORT_PATH="${DEVKIT_HOST_EXPORT_PATH:-}"
 _HOST_PLATFORM="${DEVKIT_HOST_PLATFORM:-linux}"
 _DEFAULT_MOUNT_PATH="${DEVKIT_SYNC_MOUNT_PATH:-/workspace}"
+_LOCAL_WORKSPACE_ROOT="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+_RSYNC_REMOTE_ROOT="${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}"
+_RSYNC_HELPER="${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}"
 
 devkit_sync_noninteractive() {
   case "${DEVKIT_SYNC_NONINTERACTIVE:-}" in
@@ -486,9 +489,11 @@ if [[ ! "${_DEVKIT_PORT}" =~ ^[0-9]+$ ]] || (( _DEVKIT_PORT < 1 || _DEVKIT_PORT 
   return 2
 fi
 
-_c_info="" _c_reset=""
+_c_info="" _c_error="" _c_warn="" _c_reset=""
 if [[ -t 1 ]]; then
   _c_info=$'\033[1;34m'
+  _c_error=$'\033[1;31m'
+  _c_warn=$'\033[1;33m'
   _c_reset=$'\033[0m'
 fi
 cat <<EOF
@@ -638,6 +643,7 @@ if ! sync_neat_framework_to_devkit "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_DEVKIT_
 fi
 
 echo "Configuring remote NFS mount..."
+_NFS_CONFIGURED=0
 if ! ssh -T -p "${_DEVKIT_PORT}" -o BatchMode=yes -o ConnectTimeout=8 "${_DEVKIT_USER}@${_DEVKIT_IP}" bash -s -- "${_HOST_IP}" "${_HOST_EXPORT_PATH}" "${_MOUNT_POINT}" "${_NFS_OPTS}" "${_DEVKIT_USER}" <<'EOS'
 set -euo pipefail
 host_ip="$1"
@@ -775,12 +781,52 @@ if command -v git >/dev/null 2>&1; then
 fi
 EOS
 then
+  printf "%bERROR: DevKit NFS workspace setup was not successful.%b\n" "${_c_error}" "${_c_reset}" >&2
   echo "Failed to configure NFS mount on ${_DEVKIT_USER}@${_DEVKIT_IP}." >&2
+  echo "SSH is configured, so the SDK will continue and keep dk shell available." >&2
   echo "Hint: ensure ${_DEVKIT_USER} has passwordless sudo, or rerun as root: source devkit.sh ${_DEVKIT_IP} root ${_DEVKIT_PORT}" >&2
-  return 1
+else
+  _NFS_CONFIGURED=1
 fi
 
-export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_MOUNT_POINT}"
+_SYNC_METHOD="none"
+_ACTIVE_REMOTE_ROOT="${_MOUNT_POINT}"
+_SYNC_HINT=""
+if [[ "${_NFS_CONFIGURED}" == "1" ]]; then
+  _SYNC_METHOD="nfs"
+  _ACTIVE_REMOTE_ROOT="${_MOUNT_POINT}"
+else
+  case "${DEVKIT_RSYNC_FALLBACK:-ON}" in
+    OFF|off|0|false|FALSE|no|NO)
+      _SYNC_METHOD="none"
+      _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+      _SYNC_HINT="NFS failed and rsync fallback is disabled by DEVKIT_RSYNC_FALLBACK=${DEVKIT_RSYNC_FALLBACK}."
+      printf "%bWARNING:%b rsync fallback disabled; only dk shell will be available.\n" "${_c_warn}" "${_c_reset}" >&2
+      ;;
+    *)
+      if [[ -x "${_RSYNC_HELPER}" ]] && "${_RSYNC_HELPER}" setup --devkit "${_DEVKIT_IP}" --user "${_DEVKIT_USER}" --port "${_DEVKIT_PORT}" --local "${_LOCAL_WORKSPACE_ROOT}" --remote "${_RSYNC_REMOTE_ROOT}"; then
+        _SYNC_METHOD="rsync"
+        _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+        _SYNC_HINT="NFS failed; using rsync-over-SSH fallback."
+        printf "%bWARNING:%b using rsync fallback: %s -> %s@%s:%s\n" "${_c_warn}" "${_c_reset}" "${_LOCAL_WORKSPACE_ROOT}" "${_DEVKIT_USER}" "${_DEVKIT_IP}" "${_RSYNC_REMOTE_ROOT}" >&2
+      else
+        _SYNC_METHOD="none"
+        _ACTIVE_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+        _SYNC_HINT="NFS failed and rsync fallback setup was not available."
+        printf "%bWARNING:%b rsync fallback setup failed; only dk shell will be available.\n" "${_c_warn}" "${_c_reset}" >&2
+      fi
+      ;;
+  esac
+fi
+
+export DEVKIT_SYNC_METHOD="${_SYNC_METHOD}"
+export DEVKIT_SYNC_LOCAL_ROOT="${_LOCAL_WORKSPACE_ROOT}"
+export DEVKIT_SYNC_REMOTE_ROOT="${_ACTIVE_REMOTE_ROOT}"
+export DEVKIT_SYNC_NFS_MOUNT_POINT="${_MOUNT_POINT}"
+export DEVKIT_RSYNC_REMOTE_ROOT="${_RSYNC_REMOTE_ROOT}"
+export DEVKIT_RSYNC_HELPER="${_RSYNC_HELPER}"
+export DEVKIT_SYNC_HINT="${_SYNC_HINT}"
+export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_DEVKIT_IP="${_DEVKIT_IP}"
 if [[ -z "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
   export DEVKIT_SYNC_ORIG_PS1="${PS1:-\u@\h:\w\$ }"
@@ -821,8 +867,89 @@ fi
 export PS1="$(__devkit_rewrite_prompt_hostname "${PS1:-${DEVKIT_SYNC_ORIG_PS1}}")"
 
 echo ""
-echo "NFS client mount configured."
+case "${DEVKIT_SYNC_METHOD}" in
+  nfs)
+    echo "NFS client mount configured."
+    ;;
+  rsync)
+    echo "NFS client mount was not configured; rsync fallback is active."
+    ;;
+  *)
+    echo "NFS client mount was not configured; no workspace sync method is active."
+    ;;
+esac
 echo "Target: ${DEVKIT_SYNC_TARGET}"
+
+devkit-sync() {
+  local sync_scope="${1:-${PWD}}"
+  if [[ "${sync_scope}" == "--all" ]]; then
+    sync_scope="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+  fi
+  case "${DEVKIT_SYNC_METHOD:-nfs}" in
+    nfs)
+      echo "Sync method: nfs"
+      echo "No rsync is needed because the DevKit workspace is mounted from the host."
+      return 0
+      ;;
+    rsync)
+      if [[ ! -x "${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" ]]; then
+        echo "rsync helper not found: ${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" >&2
+        return 1
+      fi
+      "${DEVKIT_RSYNC_HELPER}" sync \
+        --devkit "${DEVKIT_SYNC_DEVKIT_IP}" \
+        --user "${DEVKIT_SYNC_DEVKIT_USER:-sima}" \
+        --port "${DEVKIT_SYNC_DEVKIT_PORT:-22}" \
+        --local "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}" \
+        --remote "${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}" \
+        --scope "${sync_scope}" \
+        --status-file "${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}"
+      ;;
+    *)
+      echo "No workspace sync method is active."
+      echo "Use 'dk shell' to connect to the DevKit, then copy files manually or rerun DevKit setup."
+      return 1
+      ;;
+  esac
+}
+
+devkit-status() {
+  local ssh_status="unknown"
+  if ssh -p "${DEVKIT_SYNC_DEVKIT_PORT:-22}" -o BatchMode=yes -o ConnectTimeout=5 "${DEVKIT_SYNC_DEVKIT_USER:-sima}@${DEVKIT_SYNC_DEVKIT_IP}" true >/dev/null 2>&1; then
+    ssh_status="reachable"
+  else
+    ssh_status="not reachable"
+  fi
+
+  cat <<EOF
+DevKit target       : ${DEVKIT_SYNC_DEVKIT_USER:-sima}@${DEVKIT_SYNC_DEVKIT_IP}:${DEVKIT_SYNC_DEVKIT_PORT:-22}
+SSH status          : ${ssh_status}
+Sync method         : ${DEVKIT_SYNC_METHOD:-unknown}
+Local workspace     : ${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}
+Remote workspace    : ${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT:-/workspace}}
+NFS mount path      : ${DEVKIT_SYNC_NFS_MOUNT_POINT:-${DEVKIT_SYNC_MOUNT_POINT:-/workspace}}
+EOF
+
+  if [[ -n "${DEVKIT_SYNC_HINT:-}" ]]; then
+    echo "Status hint         : ${DEVKIT_SYNC_HINT}"
+  fi
+
+  case "${DEVKIT_SYNC_METHOD:-}" in
+    rsync)
+      if [[ -x "${DEVKIT_RSYNC_HELPER:-/usr/local/bin/devkit-sync-rsync.sh}" ]]; then
+        "${DEVKIT_RSYNC_HELPER}" status \
+          --devkit "${DEVKIT_SYNC_DEVKIT_IP}" \
+          --user "${DEVKIT_SYNC_DEVKIT_USER:-sima}" \
+          --port "${DEVKIT_SYNC_DEVKIT_PORT:-22}" \
+          --remote "${DEVKIT_RSYNC_REMOTE_ROOT:-/workspace-rsync}" \
+          --status-file "${DEVKIT_RSYNC_STATUS_FILE:-${HOME}/.devkit-rsync-status}" || true
+      fi
+      ;;
+    none)
+      echo "Workspace sync is not active. 'dk shell' can still be used over SSH."
+      ;;
+  esac
+}
 
 # Run a local /workspace binary or Python script on the paired DevKit.
 devkit-run() {
@@ -847,6 +974,12 @@ devkit-run() {
     ssh_args+=("$@")
     "${ssh_args[@]}"
     return $?
+  fi
+
+  if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "none" ]]; then
+    echo "No workspace sync method is active; cannot map ${local_path} to the DevKit." >&2
+    echo "Use 'dk shell' to connect, or manually copy files to the DevKit." >&2
+    return 2
   fi
 
   if [[ "${local_path}" != /* ]]; then
@@ -874,31 +1007,33 @@ devkit-run() {
   fi
 
   case "${local_path}" in
-    /workspace/*) ;;
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*) ;;
     *)
-      echo "Path must be inside /workspace so DevKit can access it via NFS." >&2
+      echo "Path must be inside ${DEVKIT_SYNC_LOCAL_ROOT:-/workspace} so DevKit can access it via ${DEVKIT_SYNC_METHOD:-nfs}." >&2
       return 2
       ;;
   esac
 
   local rel remote_path remote_cwd pyneat_activate
-  rel="${local_path#/workspace/}"
-  remote_path="${DEVKIT_SYNC_MOUNT_POINT}/${rel}"
+  rel="${local_path#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+  remote_path="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${rel}"
+  remote_path="${remote_path//\/\//\/}"
   local host_pwd remote_args arg
   host_pwd="$(pwd)"
   case "${host_pwd}" in
-    /workspace/*)
-      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}/${host_pwd#/workspace/}"
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
+      remote_cwd="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${host_pwd#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+      remote_cwd="${remote_cwd//\/\//\/}"
       ;;
-    /workspace)
-      remote_cwd="${DEVKIT_SYNC_MOUNT_POINT}"
+    "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}")
+      remote_cwd="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}"
       ;;
     *)
       remote_cwd="$(dirname "${remote_path}")"
       ;;
   esac
   pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
-  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}")
+  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}" "${DEVKIT_SYNC_METHOD:-nfs}")
 
   normalize_devkit_host_path() {
     local input="$1"
@@ -941,7 +1076,6 @@ devkit-run() {
     local raw="$1"
     local prefix=""
     local value="${raw}"
-    local candidate=""
     local normalized=""
     local looks_like_path="0"
 
@@ -980,8 +1114,11 @@ devkit-run() {
     fi
 
     case "${normalized}" in
-      /workspace/*)
-        printf '%s%s\n' "${prefix}" "${DEVKIT_SYNC_MOUNT_POINT}/${normalized#/workspace/}"
+      "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
+        local mapped
+        mapped="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}/${normalized#"${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}/"}"
+        mapped="${mapped//\/\//\/}"
+        printf '%s%s\n' "${prefix}" "${mapped}"
         ;;
       *)
         printf '%s\n' "${raw}"
@@ -992,6 +1129,19 @@ devkit-run() {
   for arg in "$@"; do
     remote_args+=("$(map_devkit_arg_path "${arg}")")
   done
+
+  if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" ]]; then
+    case "${DEVKIT_RSYNC_AUTO_SYNC:-ON}" in
+      OFF|off|0|false|FALSE|no|NO)
+        ;;
+      *)
+        if ! devkit-sync "${local_path}"; then
+          echo "rsync fallback sync failed; not running remote command." >&2
+          return 1
+        fi
+        ;;
+    esac
+  fi
 
   local c_out="" c_stderr="" c_reset=""
   if [[ -t 1 ]]; then
@@ -1058,11 +1208,12 @@ trap __restore_tty EXIT INT TERM HUP
 target="${1:?missing target path}"
 pyneat_activate="${2-}"
 remote_cwd="${3-}"
+sync_method="${4:-nfs}"
 if [[ "${pyneat_activate}" == "__NONE__" ]]; then
   pyneat_activate=""
 fi
-if [[ $# -ge 3 ]]; then
-  shift 3
+if [[ $# -ge 4 ]]; then
+  shift 4
 else
   shift 1
 fi
@@ -1076,7 +1227,7 @@ ensure_target_ready() {
   mount_root="/${seg}"
 
   # Best effort: ask watchdog to recover stale NFS mount.
-  if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  if [[ "${sync_method}" == "nfs" ]] && command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
     sudo systemctl start devkit-nfs-watchdog.service >/dev/null 2>&1 || true
   fi
   sleep 1
@@ -1147,26 +1298,50 @@ EOS
 unalias dk >/dev/null 2>&1 || true
 dk() {
   if [[ $# -lt 1 ]]; then
-    echo "Usage: dk <local-executable-path|shell> [args...]" >&2
+    echo "Usage: dk <local-executable-path|shell|sync|status> [args...]" >&2
     return 0
   fi
+  case "$1" in
+    sync)
+      shift
+      devkit-sync "$@"
+      return $?
+      ;;
+    status)
+      shift
+      devkit-status "$@"
+      return $?
+      ;;
+  esac
   devkit-run "$@"
 }
 
 # Persist session helpers for future container shells.
 _persist_file="${HOME}/.devkit-sync.rc"
+__devkit_persist_export() {
+  local name="$1"
+  local value="${!name-}"
+  printf 'export %s=%q\n' "${name}" "${value}"
+}
 {
-  echo "export DEVKIT_SYNC_TARGET='${DEVKIT_SYNC_TARGET}'"
-  echo "export DEVKIT_SYNC_DEVKIT_IP='${DEVKIT_SYNC_DEVKIT_IP}'"
-  echo "export DEVKIT_SYNC_MOUNT_POINT='${DEVKIT_SYNC_MOUNT_POINT}'"
-  echo "export DEVKIT_SYNC_DEVKIT_USER='${DEVKIT_SYNC_DEVKIT_USER}'"
-  echo "export DEVKIT_SYNC_DEVKIT_PORT='${DEVKIT_SYNC_DEVKIT_PORT}'"
-  echo "export SDK_RELEASE_REF='${SDK_RELEASE_REF:-}'"
-  echo "export SDK_PROMPT_REF='${SDK_PROMPT_REF}'"
-  echo "export SDK_IMAGE_BRANCH='${SDK_IMAGE_BRANCH}'"
-  echo "export SDK_IMAGE_TAG='${SDK_IMAGE_TAG}'"
-  echo "export SDK_PROMPT_HOSTNAME='${SDK_PROMPT_HOSTNAME}'"
-  echo "export DEVKIT_PROMPT_DIRTRIM='${DEVKIT_PROMPT_DIRTRIM}'"
+  __devkit_persist_export DEVKIT_SYNC_TARGET
+  __devkit_persist_export DEVKIT_SYNC_METHOD
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_IP
+  __devkit_persist_export DEVKIT_SYNC_MOUNT_POINT
+  __devkit_persist_export DEVKIT_SYNC_NFS_MOUNT_POINT
+  __devkit_persist_export DEVKIT_SYNC_LOCAL_ROOT
+  __devkit_persist_export DEVKIT_SYNC_REMOTE_ROOT
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_USER
+  __devkit_persist_export DEVKIT_SYNC_DEVKIT_PORT
+  __devkit_persist_export DEVKIT_RSYNC_REMOTE_ROOT
+  __devkit_persist_export DEVKIT_RSYNC_HELPER
+  __devkit_persist_export DEVKIT_SYNC_HINT
+  __devkit_persist_export SDK_RELEASE_REF
+  __devkit_persist_export SDK_PROMPT_REF
+  __devkit_persist_export SDK_IMAGE_BRANCH
+  __devkit_persist_export SDK_IMAGE_TAG
+  __devkit_persist_export SDK_PROMPT_HOSTNAME
+  __devkit_persist_export DEVKIT_PROMPT_DIRTRIM
   echo 'export PROMPT_DIRTRIM="${DEVKIT_PROMPT_DIRTRIM}"'
   echo 'export DEVKIT_SYNC_PROMPT_PREFIX="\[\e[1;32m\][DevKit ${DEVKIT_SYNC_TARGET}]\[\e[0m\] "'
   echo '__devkit_rewrite_prompt_hostname() {'
@@ -1193,6 +1368,8 @@ _persist_file="${HOME}/.devkit-sync.rc"
   echo '  fi'
   echo '}'
   echo '__devkit_apply_prompt'
+  declare -f devkit-sync
+  declare -f devkit-status
   declare -f devkit-run
   echo 'unalias dk >/dev/null 2>&1 || true'
   declare -f dk
@@ -1286,13 +1463,31 @@ ${_c_ok}
   DevKit Connected
 ============================================================
   DevKit target : ${DEVKIT_SYNC_DEVKIT_USER}@${DEVKIT_SYNC_DEVKIT_IP}:${DEVKIT_SYNC_DEVKIT_PORT}
-  Mounted path  : ${DEVKIT_SYNC_MOUNT_POINT}
+  Sync method   : ${DEVKIT_SYNC_METHOD}
+  Remote path   : ${DEVKIT_SYNC_REMOTE_ROOT}
   Host export   : ${_HOST_IP}:${_HOST_EXPORT_PATH}
-
+EOF
+case "${DEVKIT_SYNC_METHOD}" in
+  nfs|rsync)
+    cat <<EOF
   You can now run DevKit binaries from this SDK shell:
     dk /workspace/<path-to-arm64-binary> [args...]
   Or connect to a DevKit shell directly:
     dk shell
+  Check sync status:
+    dk status
+EOF
+    ;;
+  *)
+    cat <<EOF
+  Workspace sync is not active. You can still connect to a DevKit shell:
+    dk shell
+  Check sync status:
+    dk status
+EOF
+    ;;
+esac
+cat <<EOF
 ============================================================
 ${_c_rst}
 EOF

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -828,6 +828,10 @@ export DEVKIT_RSYNC_HELPER="${_RSYNC_HELPER}"
 export DEVKIT_SYNC_HINT="${_SYNC_HINT}"
 export DEVKIT_SYNC_TARGET="${_DEVKIT_IP}:${_ACTIVE_REMOTE_ROOT}"
 export DEVKIT_SYNC_DEVKIT_IP="${_DEVKIT_IP}"
+# Host IP neat-insight advertises in its URL / WebRTC iceHost. Refresh from the
+# current NFS host IP (_HOST_IP) so it tracks this (re-)point, and persist it
+# below so the neat-insight supervisor wrapper can export it into the service.
+export CONTAINER_HOST_IP="${_HOST_IP}"
 if [[ -z "${DEVKIT_SYNC_ORIG_PS1:-}" ]]; then
   export DEVKIT_SYNC_ORIG_PS1="${PS1:-\u@\h:\w\$ }"
 fi
@@ -1367,6 +1371,7 @@ __devkit_persist_export() {
   __devkit_persist_export DEVKIT_SYNC_TARGET
   __devkit_persist_export DEVKIT_SYNC_METHOD
   __devkit_persist_export DEVKIT_SYNC_DEVKIT_IP
+  __devkit_persist_export CONTAINER_HOST_IP
   __devkit_persist_export DEVKIT_SYNC_MOUNT_POINT
   __devkit_persist_export DEVKIT_SYNC_NFS_MOUNT_POINT
   __devkit_persist_export DEVKIT_SYNC_LOCAL_ROOT
@@ -1491,6 +1496,45 @@ fi
 copy_insight_port_map_to_devkit "${DEVKIT_SYNC_DEVKIT_USER}" "${DEVKIT_SYNC_DEVKIT_IP}" "${DEVKIT_SYNC_DEVKIT_PORT}"
 
 echo "Persisted DevKit shell helpers to ${_persist_file} (auto-loaded by ~/.bashrc and ~/.bash_profile)."
+
+# Restart neat-insight so it (and the vf WebRTC viewer it spawns) re-read the
+# refreshed CONTAINER_HOST_IP via the supervisor wrapper, and the Insight URL /
+# iceHost track this (re-)point. Best-effort, and only when the host IP actually
+# changed so we don't tear down active sessions on a no-op re-source. Skipped on
+# images without Insight (insight-admin / supervisord absent).
+__devkit_refresh_neat_insight() {
+  command -v insight-admin >/dev/null 2>&1 || return 0  # no Insight on this image
+  # Need at least one of the IPs neat-insight surfaces.
+  [[ -n "${_HOST_IP:-}" || -n "${_DEVKIT_IP:-}" ]] || return 0
+
+  # Restart only when the advertised host IP (CONTAINER_HOST_IP -- the Insight
+  # URL / WebRTC iceHost) OR the active DevKit IP (DEVKIT_SYNC_DEVKIT_IP -- shown
+  # in the Insight UI and used by the webssh shell) differs from what neat-insight
+  # is *currently* advertising. A re-point can change one without the other (e.g.
+  # a different DevKit on the same subnet keeps the host IP).
+  #
+  # Read the running neat-insight's launch environment -- it holds the values
+  # the wrapper exported at its last start, i.e. exactly what is live now.
+  # If it already matches, skip (don't tear down active sessions). If neat-insight
+  # isn't running, fall through and (re)start.
+  local pid env_file applied_host applied_devkit
+  pid="$(pgrep -f 'neat-insight( |$)' 2>/dev/null | head -1)"
+  if [[ -n "${pid}" ]]; then
+    env_file="/proc/${pid}/environ"
+    if [[ -r "${env_file}" ]]; then
+      applied_host="$(tr '\0' '\n' < "${env_file}" | sed -n 's/^CONTAINER_HOST_IP=//p' | head -1)"
+      applied_devkit="$(tr '\0' '\n' < "${env_file}" | sed -n 's/^DEVKIT_SYNC_DEVKIT_IP=//p' | head -1)"
+      [[ "${applied_host}" == "${_HOST_IP:-}" && "${applied_devkit}" == "${_DEVKIT_IP:-}" ]] && return 0
+    fi
+  fi
+
+  # Best-effort: insight-admin restart fails cleanly if supervisord isn't up. We
+  # do NOT gate on `insight-admin status` -- that checks neat-insight's RUNNING
+  # state (non-zero during STARTING/BACKOFF/FATAL) and would wrongly skip.
+  echo "Refreshing neat-insight (host IP ${_HOST_IP:-<unset>}, DevKit ${_DEVKIT_IP:-<unset>})..."
+  insight-admin restart >/dev/null 2>&1 || true
+}
+__devkit_refresh_neat_insight
 
 _c_ok="" _c_rst=""
 if [[ -t 1 ]]; then

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -955,6 +955,29 @@ EOF
   esac
 }
 
+devkit-local-sync-scope() {
+  local path="$1"
+  local root="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
+  local rel_path
+
+  case "${path}" in
+    "${root}") ;;
+    "${root}"/*) ;;
+    *)
+      printf '%s\n' "${path}"
+      return 0
+      ;;
+  esac
+
+  rel_path="${path#"${root}"}"
+  rel_path="${rel_path#/}"
+  if [[ -z "${rel_path}" ]]; then
+    printf '%s\n' "${root}"
+  else
+    printf '%s/%s\n' "${root}" "${rel_path%%/*}"
+  fi
+}
+
 # Run a local /workspace binary or Python script on the paired DevKit.
 devkit-run() {
   if [[ $# -lt 1 ]]; then
@@ -1038,32 +1061,10 @@ devkit-run() {
   esac
   pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
 
-  devkit_local_sync_scope() {
-    local path="$1"
-    local root="${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"
-    local rel_path
-
-    case "${path}" in
-      "${root}") ;;
-      "${root}"/*) ;;
-      *)
-        printf '%s\n' "${path}"
-        return 0
-        ;;
-    esac
-
-    rel_path="${path#"${root}"}"
-    rel_path="${rel_path#/}"
-    if [[ -z "${rel_path}" || "${rel_path}" != */* ]]; then
-      printf '%s\n' "${root}"
-    else
-      printf '%s/%s\n' "${root}" "${rel_path%%/*}"
-    fi
-  }
-  local_sync_scope="$(devkit_local_sync_scope "${local_path}")"
+  local_sync_scope="$(devkit-local-sync-scope "${local_path}")"
   if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" ]]; then
     local cwd_sync_scope
-    cwd_sync_scope="$(devkit_local_sync_scope "${host_pwd}")"
+    cwd_sync_scope="$(devkit-local-sync-scope "${host_pwd}")"
     if [[ "${cwd_sync_scope}" != "${local_sync_scope}" ]]; then
       remote_cwd="$(dirname "${remote_path}")"
     fi
@@ -1149,10 +1150,23 @@ devkit-run() {
     fi
 
     case "${normalized}" in
+      "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}")
+        local mapped
+        local arg_sync_scope
+        arg_sync_scope="$(devkit-local-sync-scope "${normalized}")"
+        if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" && "${arg_sync_scope}" != "${local_sync_scope}" ]]; then
+          echo "Mapped argument ${normalized} is outside the synced root ${local_sync_scope}." >&2
+          echo "When rsync fallback is active, keep files needed by dk under the same top-level workspace folder as ${local_path}." >&2
+          return 2
+        fi
+        mapped="${DEVKIT_SYNC_REMOTE_ROOT:-${DEVKIT_SYNC_MOUNT_POINT}}"
+        mapped="${mapped//\/\//\/}"
+        printf '%s%s\n' "${prefix}" "${mapped}"
+        ;;
       "${DEVKIT_SYNC_LOCAL_ROOT:-/workspace}"/*)
         local mapped
         local arg_sync_scope
-        arg_sync_scope="$(devkit_local_sync_scope "${normalized}")"
+        arg_sync_scope="$(devkit-local-sync-scope "${normalized}")"
         if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" && "${arg_sync_scope}" != "${local_sync_scope}" ]]; then
           echo "Mapped argument ${normalized} is outside the synced root ${local_sync_scope}." >&2
           echo "When rsync fallback is active, keep files needed by dk under the same top-level workspace folder as ${local_path}." >&2
@@ -1415,6 +1429,7 @@ __devkit_persist_export() {
   echo '__devkit_apply_prompt'
   declare -f devkit-sync
   declare -f devkit-status
+  declare -f devkit-local-sync-scope
   declare -f devkit-run
   echo 'unalias dk >/dev/null 2>&1 || true'
   declare -f dk

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -1033,7 +1033,6 @@ devkit-run() {
       ;;
   esac
   pyneat_activate="${DEVKIT_PYNEAT_ACTIVATE:-__NONE__}"
-  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}" "${DEVKIT_SYNC_METHOD:-nfs}")
 
   devkit_local_sync_scope() {
     local path="$1"
@@ -1058,6 +1057,14 @@ devkit-run() {
     fi
   }
   local_sync_scope="$(devkit_local_sync_scope "${local_path}")"
+  if [[ "${DEVKIT_SYNC_METHOD:-nfs}" == "rsync" ]]; then
+    local cwd_sync_scope
+    cwd_sync_scope="$(devkit_local_sync_scope "${host_pwd}")"
+    if [[ "${cwd_sync_scope}" != "${local_sync_scope}" ]]; then
+      remote_cwd="$(dirname "${remote_path}")"
+    fi
+  fi
+  remote_args=("${remote_path}" "${pyneat_activate}" "${remote_cwd}" "${DEVKIT_SYNC_METHOD:-nfs}")
 
   normalize_devkit_host_path() {
     local input="$1"

--- a/scripts/neat-insight-supervised.sh
+++ b/scripts/neat-insight-supervised.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Supervisord launch wrapper for neat-insight.
+#
+# Sources ~/.devkit-sync.rc (rewritten by devkit.sh on every DevKit (re-)point)
+# so neat-insight -- and the vf WebRTC viewer it spawns -- inherit the current
+# CONTAINER_HOST_IP. neat-insight itself stays environment-agnostic: it only
+# reads CONTAINER_HOST_IP from its process env. All DevKit-specific knowledge
+# (the .devkit-sync.rc format) lives here in the SDK image, not in Insight.
+#
+# supervisord runs this as root (HOME=/root); devkit.sh also installs the rc
+# into the SDK user homes, but the root copy is sufficient for the service env.
+
+rc="${HOME:-/root}/.devkit-sync.rc"
+[ -f "$rc" ] || rc="/root/.devkit-sync.rc"
+if [ -f "$rc" ]; then
+  # shellcheck disable=SC1090
+  . "$rc" >/dev/null 2>&1 || true
+fi
+
+exec /opt/neat-insight/venv/bin/neat-insight --port "${NEAT_INSIGHT_PORT:-9900}"

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="${ROOT_DIR}/scripts/devkit-sync-rsync.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  grep -Fxq "${needle}" <<< "${haystack}" || fail "expected exclude '${needle}'"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if grep -Fxq "${needle}" <<< "${haystack}"; then
+    fail "unexpected exclude '${needle}'"
+  fi
+}
+
+mapped="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-rsync --path /workspace/apps/demo.py)"
+[[ "${mapped}" == "/workspace-rsync/apps/demo.py" ]] || fail "unexpected mapped path: ${mapped}"
+
+unchanged="$("${HELPER}" map-path --local-root /workspace --remote-root /workspace-rsync --path /tmp/demo.py)"
+[[ "${unchanged}" == "/tmp/demo.py" ]] || fail "unexpected unchanged path: ${unchanged}"
+
+scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace/apps/examples/demo.py)"
+[[ "${scope}" == "/workspace/apps" ]] || fail "unexpected scope: ${scope}"
+
+root_scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace)"
+[[ "${root_scope}" == "/workspace" ]] || fail "unexpected root scope: ${root_scope}"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+mkdir -p "${tmpdir}/workspace"
+printf 'project-cache/\n' > "${tmpdir}/workspace/.devkit-rsync-exclude"
+printf 'external-cache/\n' > "${tmpdir}/external-excludes"
+
+excludes="$(
+  DEVKIT_RSYNC_EXCLUDES_FILE="${tmpdir}/external-excludes" \
+  DEVKIT_RSYNC_EXTRA_EXCLUDES=$'scratch/\ntmp-artifacts/' \
+    "${HELPER}" print-excludes --local "${tmpdir}/workspace"
+)"
+
+assert_contains "${excludes}" ".git/"
+assert_contains "${excludes}" "__pycache__/"
+assert_contains "${excludes}" "project-cache/"
+assert_contains "${excludes}" "external-cache/"
+assert_contains "${excludes}" "scratch/"
+assert_contains "${excludes}" "tmp-artifacts/"
+
+assert_not_contains "${excludes}" "dist/"
+assert_not_contains "${excludes}" "build/"
+assert_not_contains "${excludes}" "build-*/"
+assert_not_contains "${excludes}" "cmake-build-*/"
+assert_not_contains "${excludes}" "CMakeFiles/"
+assert_not_contains "${excludes}" "CMakeCache.txt"
+assert_not_contains "${excludes}" "*.o"
+assert_not_contains "${excludes}" "*.a"
+assert_not_contains "${excludes}" "*.so"
+assert_not_contains "${excludes}" "*.dylib"
+
+echo "devkit rsync helper tests passed"

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -9,6 +9,11 @@ fail() {
   exit 1
 }
 
+grep -Fq '/media/nvme/workspace-rsync' "${HELPER}" || fail "rsync helper should use /media/nvme for NVMe workspace storage"
+if grep -Fq '/nvme/media/workspace-rsync' "${HELPER}"; then
+  fail "rsync helper should not use the old /nvme/media workspace path"
+fi
+
 assert_contains() {
   local haystack="$1"
   local needle="$2"

--- a/tests/sdk/test-devkit-rsync-helper.sh
+++ b/tests/sdk/test-devkit-rsync-helper.sh
@@ -37,6 +37,9 @@ unchanged="$("${HELPER}" map-path --local-root /workspace --remote-root /workspa
 scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace/apps/examples/demo.py)"
 [[ "${scope}" == "/workspace/apps" ]] || fail "unexpected scope: ${scope}"
 
+top_level_scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace/apps)"
+[[ "${top_level_scope}" == "/workspace/apps" ]] || fail "unexpected top-level scope: ${top_level_scope}"
+
 root_scope="$("${HELPER}" scope-for-path --local-root /workspace --path /workspace)"
 [[ "${root_scope}" == "/workspace" ]] || fail "unexpected root scope: ${root_scope}"
 

--- a/tests/sdk/test-devkit-rsync-scope.sh
+++ b/tests/sdk/test-devkit-rsync-scope.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEVKIT_SH="${ROOT_DIR}/scripts/devkit.sh"
+HELPER="${ROOT_DIR}/scripts/devkit-sync-rsync.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Load only the sourceable scope helper from devkit.sh. Sourcing the full file
+# would attempt to configure a live DevKit connection.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+sed -n '/^devkit-local-sync-scope()/,/^}/p' "${DEVKIT_SH}" > "${tmpdir}/devkit-scope.sh"
+# shellcheck source=/dev/null
+source "${tmpdir}/devkit-scope.sh"
+
+assert_scope() {
+  local path="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(DEVKIT_SYNC_LOCAL_ROOT=/workspace devkit-local-sync-scope "${path}")"
+  [[ "${actual}" == "${expected}" ]] || fail "unexpected devkit.sh scope for ${path}: ${actual}"
+
+  if [[ "${path}" == /workspace* ]]; then
+    local helper_actual
+    helper_actual="$("${HELPER}" scope-for-path --local-root /workspace --path "${path}")"
+    [[ "${helper_actual}" == "${expected}" ]] || fail "unexpected helper scope for ${path}: ${helper_actual}"
+  fi
+}
+
+assert_scope "/workspace" "/workspace"
+assert_scope "/workspace/apps" "/workspace/apps"
+assert_scope "/workspace/apps/examples/demo.py" "/workspace/apps"
+assert_scope "/workspace/core" "/workspace/core"
+assert_scope "/tmp/demo.py" "/tmp/demo.py"
+
+echo "devkit rsync scope tests passed"

--- a/tools/install_sdk_stub.sh
+++ b/tools/install_sdk_stub.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt_yes_no() {
+  local prompt="$1"
+  local answer
+
+  while true; do
+    read -r -p "${prompt} [y/N]: " answer
+    answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
+    case "${answer}" in
+      y|yes)
+        return 0
+        ;;
+      ""|n|no)
+        return 1
+        ;;
+      *)
+        echo "Please answer y or n."
+        ;;
+    esac
+  done
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "Required command not found: ${name}" >&2
+    exit 1
+  fi
+}
+
+main() {
+  require_command sima-cli
+
+  echo "SiMa.ai Palette Neat SDK image is available locally."
+  echo "Starting SDK setup."
+
+  if prompt_yes_no "Do you want to pair this SDK with a DevKit now?"; then
+    local devkit_ip=""
+    while [[ -z "${devkit_ip}" ]]; do
+      read -r -p "Enter DevKit IP address: " devkit_ip
+      devkit_ip="${devkit_ip//[[:space:]]/}"
+      if [[ -z "${devkit_ip}" ]]; then
+        echo "DevKit IP address cannot be empty."
+      fi
+    done
+    sima-cli sdk setup --devkit "${devkit_ip}"
+  else
+    sima-cli sdk setup
+  fi
+}
+
+main "$@"

--- a/tools/prepare_s3_artifacts.sh
+++ b/tools/prepare_s3_artifacts.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/prepare_s3_artifacts.sh \
+  --output-dir <path> \
+  --image-resource <ghcr:sima-neat/sdk:tag> \
+  [--version <package-version>] \
+  [--release <release-id>]
+
+Builds the Vulcan/sima-cli install stub package for the Neat SDK.
+The SDK image itself remains a GHCR container resource; this script only
+prepares metadata and the installer hook used by `sima-cli neat install`.
+USAGE
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR=""
+IMAGE_RESOURCE=""
+PACKAGE_VERSION=""
+PACKAGE_RELEASE=""
+PACKAGE_NAME="${SDK_PACKAGE_NAME:-sdk}"
+PACKAGE_DOWNLOAD_SIZE="${SDK_PACKAGE_DOWNLOAD_SIZE:-10GB}"
+PACKAGE_INSTALL_SIZE="${SDK_PACKAGE_INSTALL_SIZE:-10GB}"
+INSTALL_SCRIPT_NAME="install_sdk_stub.sh"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --image-resource)
+      IMAGE_RESOURCE="${2:-}"
+      shift 2
+      ;;
+    --version)
+      PACKAGE_VERSION="${2:-}"
+      shift 2
+      ;;
+    --release)
+      PACKAGE_RELEASE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${OUTPUT_DIR}" || -z "${IMAGE_RESOURCE}" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 1
+fi
+
+if [[ "${IMAGE_RESOURCE}" != ghcr:* ]]; then
+  echo "--image-resource must be a ghcr: resource, got: ${IMAGE_RESOURCE}" >&2
+  exit 1
+fi
+
+if ! command -v sima-cli >/dev/null 2>&1; then
+  echo "sima-cli is required to build SDK package metadata." >&2
+  exit 1
+fi
+
+if [[ -z "${PACKAGE_VERSION}" ]]; then
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+  elif [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_HEAD_REF}"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME}"
+  else
+    PACKAGE_VERSION="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+if [[ -z "${PACKAGE_RELEASE}" ]]; then
+  PACKAGE_RELEASE="${PACKAGE_VERSION}"
+fi
+
+tmp_dir="$(mktemp -d /tmp/sima-sdk-package-XXXXXX)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+artifacts_dir="${tmp_dir}/artifacts"
+mkdir -p "${artifacts_dir}"
+install -m 0755 "${ROOT_DIR}/tools/${INSTALL_SCRIPT_NAME}" "${artifacts_dir}/${INSTALL_SCRIPT_NAME}"
+
+SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
+  --name "${PACKAGE_NAME}" \
+  --version "${PACKAGE_VERSION}" \
+  --description "SiMa.ai Neat SDK install stub" \
+  --install-script "${INSTALL_SCRIPT_NAME}" \
+  --host-platform "ubuntu@22.04,ubuntu@24.04" \
+  --host-platform "windows" \
+  --host-platform "mac"
+
+python3 - "${artifacts_dir}/metadata.json" "${IMAGE_RESOURCE}" "${PACKAGE_RELEASE}" "${PACKAGE_DOWNLOAD_SIZE}" "${PACKAGE_INSTALL_SIZE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+metadata_path = Path(sys.argv[1])
+image_resource = sys.argv[2]
+release = sys.argv[3]
+download_size = sys.argv[4]
+install_size = sys.argv[5]
+
+metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+resources = metadata.setdefault("resources", [])
+if image_resource not in resources:
+    resources.append(image_resource)
+metadata["release"] = release
+metadata["size"] = {
+    "download": download_size,
+    "install": install_size,
+}
+metadata["installation"]["post-message"] = (
+    "[bold green]SDK setup complete.[/bold green]\n"
+    "Run [cyan]sima-cli sdk neat[/cyan] to open the Neat SDK container.\n"
+)
+metadata_path.write_text(json.dumps(metadata, indent=4) + "\n", encoding="utf-8")
+PY
+
+python3 -m json.tool "${artifacts_dir}/metadata.json" >/dev/null
+
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+cp -f "${artifacts_dir}/${INSTALL_SCRIPT_NAME}" "${artifacts_dir}/metadata.json" "${OUTPUT_DIR}/"
+
+echo "Prepared SDK install stub package:"
+ls -lh "${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary

Promotes the current SDK `main` branch into `release-2.1` for the 2.1 release line.

## User-facing impact

- Adds the SDK install stub needed for one-command SDK installation through `sima-cli neat install sdk@...`.
- Improves DevKit setup resilience by adding rsync fallback when NFS setup is unavailable or unreliable.
- Keeps rsync fallback workspace data on `/media/nvme` when available, reducing pressure on the root filesystem.
- Fixes rsync fallback path and cwd handling so project-relative commands continue to run from the expected workspace directory.
- Keeps the neat-insight URL updated when a DevKit is re-pointed.
- Bumps SDK dependency refs to the latest 2.1-compatible component versions.

## Repository and release automation

- Adds cleanup automation for SDK GHCR packages associated with deleted branches.
- Adds issue triage workflow configuration and SDK-specific triage guidance.
- Adds PR sanitization and release issue validation workflow updates.

## Validation

- Changes were merged through `main` via PR #84.
- Rsync fallback helper and scope tests are included for the DevKit path/cwd behavior.