### PR TITLE
Allow release branch SDK builds to update latest tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -573,7 +573,7 @@ jobs:
 
   mark-vulcan-install-stub-latest:
     name: Mark SDK install stub as latest
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request'
     needs: publish-vulcan-install-stub
     uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
     with:


### PR DESCRIPTION
## Summary

Fix the SDK Docker build workflow so release branch builds can update their Vulcan `latest.tag` marker after the SDK install stub is published.

## Root Cause

The workflow already publishes the SDK install stub for non-PR branch builds, including `release-2.1`, but the follow-up `mark-vulcan-install-stub-latest` job was gated to only run for `main` or version tags:

```yaml
if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
```

As a result, a `release-2.1` branch build could publish metadata without updating the branch-specific `latest.tag` marker.

## Change

Allow the latest-marker job to run for all non-PR publishes. Pull request builds remain excluded.

## Expected Behavior

After this change lands on `release-2.1`, SDK builds from that branch should publish the install stub and update the branch-associated `latest.tag` marker.