### PR TITLE
Allow all SDK branch builds to update latest tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -573,7 +573,7 @@ jobs:
 
   mark-vulcan-install-stub-latest:
     name: Mark SDK install stub as latest
-    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name != 'pull_request'
     needs: publish-vulcan-install-stub
     uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
     with:


### PR DESCRIPTION
## Summary

Update the SDK Docker build workflow on `develop` so every non-PR branch/tag publish can update its own Vulcan `latest.tag` marker after the SDK install stub is published.

## Root Cause

The install stub publish path already runs for branch builds, but the follow-up latest-marker job was restricted to `main` or version tags only:

```yaml
if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
```

That prevents branches such as `develop`, `release-2.1`, and future branch channels from maintaining their own latest marker.

## Change

Allow `mark-vulcan-install-stub-latest` to run for all non-PR publishes. Pull request builds remain excluded.

## Expected Behavior

Each SDK branch publish can maintain the branch-associated `latest.tag`, so `sima-cli neat install sdk@branch` can resolve to the latest published artifact for that branch.