### PR TITLE
Backport SDK install stub sima-cli lookup fix

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Run SDK package installer tests
+        run: tests/sdk/test-install-sdk-stub.sh
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/tests/sdk/test-install-sdk-stub.sh
+++ b/tests/sdk/test-install-sdk-stub.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="${ROOT_DIR}/tools/install_sdk_stub.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+write_fake_sima_cli() {
+  local path="$1"
+  local log="$2"
+
+  mkdir -p "$(dirname "${path}")"
+  cat > "${path}" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${log}"
+EOF
+  chmod +x "${path}"
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+home_dir="${tmpdir}/home"
+log_path="${tmpdir}/sima-cli.log"
+mkdir -p "${home_dir}"
+
+write_fake_sima_cli "${home_dir}/.sima-cli/.venv/bin/sima-cli" "${log_path}"
+
+printf 'n\n' | HOME="${home_dir}" PATH="/usr/bin:/bin" "${INSTALLER}" >/dev/null
+grep -Fxq "sdk setup" "${log_path}" || fail "installer did not use the user sima-cli install when PATH omitted it"
+
+: > "${log_path}"
+override_cli="${tmpdir}/override/sima-cli"
+write_fake_sima_cli "${override_cli}" "${log_path}"
+
+printf 'y\n10.0.0.244\n' | HOME="${home_dir}" PATH="/usr/bin:/bin" SIMA_CLI="${override_cli}" "${INSTALLER}" >/dev/null
+grep -Fxq "sdk setup --devkit 10.0.0.244" "${log_path}" || fail "installer did not honor SIMA_CLI override"
+
+if printf 'n\n' | HOME="${home_dir}" PATH="/usr/bin:/bin" SIMA_CLI="${tmpdir}/missing/sima-cli" "${INSTALLER}" >/dev/null 2>"${tmpdir}/stderr"; then
+  fail "installer should fail when SIMA_CLI points to a missing executable"
+fi
+grep -Fq "SIMA_CLI is set but is not executable" "${tmpdir}/stderr" || fail "missing SIMA_CLI error was not clear"
+
+echo "install sdk stub tests passed"

--- a/tools/install_sdk_stub.sh
+++ b/tools/install_sdk_stub.sh
@@ -22,16 +22,52 @@ prompt_yes_no() {
   done
 }
 
-require_command() {
-  local name="$1"
-  if ! command -v "${name}" >/dev/null 2>&1; then
-    echo "Required command not found: ${name}" >&2
-    exit 1
+resolve_sima_cli() {
+  local candidate
+  local candidates=()
+
+  if [[ -n "${SIMA_CLI:-}" ]]; then
+    if [[ -x "${SIMA_CLI}" ]]; then
+      printf '%s\n' "${SIMA_CLI}"
+      return 0
+    fi
+
+    echo "SIMA_CLI is set but is not executable: ${SIMA_CLI}" >&2
+    return 1
   fi
+
+  if command -v sima-cli >/dev/null 2>&1; then
+    command -v sima-cli
+    return 0
+  fi
+
+  candidates+=(
+    "${HOME}/.sima-cli/.venv/bin/sima-cli"
+    "${HOME}/.local/bin/sima-cli"
+    "/data/sima-cli/.venv/bin/sima-cli"
+    "/opt/sima-cli/venv/bin/sima-cli"
+    "/usr/local/bin/sima-cli"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 main() {
-  require_command sima-cli
+  local sima_cli
+
+  if ! sima_cli="$(resolve_sima_cli)"; then
+    echo "Required command not found: sima-cli" >&2
+    echo "Checked PATH and common user install locations under ${HOME}." >&2
+    echo "If sima-cli is installed elsewhere, set SIMA_CLI=/path/to/sima-cli and retry." >&2
+    exit 1
+  fi
 
   echo "SiMa.ai Palette Neat SDK image is available locally."
   echo "Starting SDK setup."
@@ -45,9 +81,9 @@ main() {
         echo "DevKit IP address cannot be empty."
       fi
     done
-    sima-cli sdk setup --devkit "${devkit_ip}"
+    "${sima_cli}" sdk setup --devkit "${devkit_ip}"
   else
-    sima-cli sdk setup
+    "${sima_cli}" sdk setup
   fi
 }
 


### PR DESCRIPTION
## Summary

Fixes #93.

Backports the SDK install stub sima-cli lookup fix to `develop` after applying the release-line hotfix to `release-2.1`.

## Changes

- Resolve sima-cli before invoking SDK setup from the SDK package install stub.
- Support an explicit `SIMA_CLI=/path/to/sima-cli` override.
- Fall back to common Unix-style sima-cli locations, including `$HOME/.sima-cli/.venv/bin/sima-cli`.
- Add a regression test for the case where sima-cli is installed under the managed user location but not present on `PATH`.
- Run the regression test from the SDK Docker build workflow.

## Validation

```bash
bash -n tools/install_sdk_stub.sh tests/sdk/test-install-sdk-stub.sh
tests/sdk/test-install-sdk-stub.sh
```

Result:

```text
install sdk stub tests passed
```

## Related PR

Release-line hotfix: #94