### PR TITLE
Retarget release-line SDK install metadata on tag publish

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -140,6 +140,7 @@ jobs:
             release_tag="${GITHUB_REF_NAME}"
             if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+([.][0-9]+)?$ ]]; then
               release_latest_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-latest"
+              release_line_ref="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
             else
               echo "Release tags must use vX.Y.Z or vX.Y.Z.N format: ${GITHUB_REF_NAME}" >&2
               exit 1
@@ -160,6 +161,7 @@ jobs:
             echo "commit_sha=${GITHUB_SHA}"
             echo "release_tag=${release_tag}"
             echo "release_latest_tag=${release_latest_tag}"
+            echo "release_line_ref=${release_line_ref:-}"
             echo "branch_tag=${branch_tag}"
             echo "promote_latest=${promote_latest}"
           } > image-metadata/image.env
@@ -582,3 +584,60 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+
+  retarget-release-line-install-stub:
+    name: Retarget SDK release-line install stub
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-vulcan-install-stub
+    runs-on: ubuntu-24.04
+    environment: ${{ vars.VULCAN_ENV || 'production' }}
+    steps:
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.VULCAN_ARTIFACT_PUBLISHER_ROLE_ARN }}
+          role-session-name: sdk-retarget-release-line-${{ github.run_id }}
+
+      - name: Retarget release-line metadata to tagged SDK image
+        env:
+          ARTIFACT_BUCKET: ${{ vars.VULCAN_ARTIFACT_BUCKET }}
+          SSE_KMS_KEY_ID: ${{ vars.VULCAN_ARTIFACT_KMS_KEY_ID }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.VULCAN_ARTIFACT_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          if [[ -z "${release_line_ref:-}" ]]; then
+            echo "release_line_ref is required for release-line install stub retargeting." >&2
+            exit 1
+          fi
+          if [[ -z "${release_tag:-}" ]]; then
+            echo "release_tag is required for release-line install stub retargeting." >&2
+            exit 1
+          fi
+          if [[ -z "${ARTIFACT_BUCKET:-}" ]]; then
+            echo "VULCAN_ARTIFACT_BUCKET is required." >&2
+            exit 1
+          fi
+          release_image_resource="ghcr:${repository#ghcr.io/}:${release_tag}"
+
+          tools/retarget_release_line_metadata.py \
+            --bucket "${ARTIFACT_BUCKET}" \
+            --repository sdk \
+            --release-line-ref "${release_line_ref}" \
+            --image-resource "${release_image_resource}" \
+            --sse-kms-key-id "${SSE_KMS_KEY_ID:-}" \
+            --cloudfront-distribution-id "${CLOUDFRONT_DISTRIBUTION_ID:-}"

--- a/tools/retarget_release_line_metadata.py
+++ b/tools/retarget_release_line_metadata.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Retarget an SDK release-line install stub to a tagged SDK image."""
+"""Retarget an SDK release-line install stub to a tagged SDK image.
+
+The SDK release flow publishes two useful install targets:
+
+* `sdk@2.1.2.3` points directly at the tagged SDK release package.
+* `sdk@release-2.1` points at the latest install-stub package produced by the
+  `release-2.1` branch build.
+
+After a patch release is tagged, we want `sdk@release-2.1` to keep using the
+same release-line package location and `latest.tag`, but pull the immutable
+tagged SDK container image instead of the mutable branch image. This script
+performs that small in-place metadata retarget.
+"""
 
 from __future__ import annotations
 
@@ -52,6 +64,12 @@ def write_json(path: Path, data: dict, indent: int) -> None:
 
 
 def retarget_metadata_resource(metadata_path: Path, image_resource: str) -> None:
+    """Replace only the SDK container resource in metadata.json.
+
+    The install stub itself remains in the same package. Only the GHCR SDK image
+    resource changes from a release-line tag, such as `ghcr:sima-neat/sdk:release-2.1`,
+    to a version tag, such as `ghcr:sima-neat/sdk:v2.1.2.3`.
+    """
     metadata = load_json(metadata_path)
     resources = metadata.get("resources")
     if not isinstance(resources, list):
@@ -74,6 +92,12 @@ def retarget_metadata_resource(metadata_path: Path, image_resource: str) -> None
 
 
 def update_manifest_metadata_entry(manifest_path: Path, metadata_path: Path) -> None:
+    """Refresh manifest metadata for metadata.json after editing it.
+
+    The Vulcan manifest records artifact size and SHA256. Since this script
+    rewrites metadata.json in place, the manifest must be kept consistent with
+    the uploaded metadata file.
+    """
     manifest = load_json(manifest_path)
     artifacts = manifest.get("artifacts")
     if not isinstance(artifacts, list):
@@ -128,6 +152,9 @@ def main() -> None:
     with tempfile.TemporaryDirectory(prefix="sdk-release-line-") as tmp:
         work_dir = Path(tmp)
         latest_path = work_dir / "latest.tag"
+        # Preserve the existing release-line pointer. The release branch build is
+        # responsible for choosing the current package folder; this tag publish
+        # step only retargets that package's SDK image resource to the release tag.
         run(
             "aws",
             "s3",
@@ -146,6 +173,8 @@ def main() -> None:
         run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/metadata.json", str(metadata_path))
         run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/manifest.json", str(manifest_path))
 
+        # Edit locally first, then upload metadata and its manifest together.
+        # latest.tag is intentionally not changed.
         retarget_metadata_resource(metadata_path, args.image_resource)
         update_manifest_metadata_entry(manifest_path, metadata_path)
 

--- a/tools/retarget_release_line_metadata.py
+++ b/tools/retarget_release_line_metadata.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Retarget an SDK release-line install stub to a tagged SDK image."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+
+def run(*args: str) -> None:
+    print("+", " ".join(args), flush=True)
+    subprocess.run(args, check=True)
+
+
+def clean_path_part(raw: str, fallback: str) -> str:
+    value = raw.strip() or fallback
+    value = value.replace("/", "-")
+    value = re.sub(r"[^A-Za-z0-9._-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip(".-")
+    if not value:
+        raise SystemExit(f"Invalid path component: {raw!r}")
+    return value
+
+
+def s3_cp_args(sse_kms_key_id: str) -> list[str]:
+    args = ["--sse", "aws:kms"]
+    if sse_kms_key_id:
+        args.extend(["--sse-kms-key-id", sse_kms_key_id])
+    return args
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict, indent: int) -> None:
+    path.write_text(json.dumps(data, indent=indent) + "\n", encoding="utf-8")
+
+
+def retarget_metadata_resource(metadata_path: Path, image_resource: str) -> None:
+    metadata = load_json(metadata_path)
+    resources = metadata.get("resources")
+    if not isinstance(resources, list):
+        raise SystemExit("metadata.json does not contain a resources list")
+
+    replaced = False
+    updated_resources = []
+    for resource in resources:
+        if isinstance(resource, str) and re.fullmatch(r"ghcr:sima-neat/sdk:[^\s]+", resource):
+            updated_resources.append(image_resource)
+            replaced = True
+        else:
+            updated_resources.append(resource)
+
+    if not replaced:
+        raise SystemExit("metadata.json does not contain a ghcr:sima-neat/sdk:* resource")
+
+    metadata["resources"] = updated_resources
+    write_json(metadata_path, metadata, indent=4)
+
+
+def update_manifest_metadata_entry(manifest_path: Path, metadata_path: Path) -> None:
+    manifest = load_json(manifest_path)
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise SystemExit("manifest.json does not contain an artifacts list")
+
+    metadata_sha = sha256_file(metadata_path)
+    metadata_size = metadata_path.stat().st_size
+    for artifact in artifacts:
+        if artifact.get("path") == "metadata.json":
+            artifact["sha256"] = metadata_sha
+            artifact["size"] = metadata_size
+            break
+    else:
+        raise SystemExit("manifest.json does not contain metadata.json artifact entry")
+
+    write_json(manifest_path, manifest, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Retarget the existing SDK release-line metadata.json resource to a tagged SDK image "
+            "without changing latest.tag."
+        )
+    )
+    parser.add_argument("--bucket", required=True, help="Vulcan artifact S3 bucket.")
+    parser.add_argument("--repository", default="sdk", help="Repository key under the artifact bucket.")
+    parser.add_argument("--release-line-ref", required=True, help="Release-line ref, e.g. release-2.1.")
+    parser.add_argument(
+        "--image-resource",
+        required=True,
+        help="Tagged SDK image resource, e.g. ghcr:sima-neat/sdk:v2.1.2.3.",
+    )
+    parser.add_argument("--sse-kms-key-id", default="", help="Optional KMS key for S3 uploads.")
+    parser.add_argument(
+        "--cloudfront-distribution-id",
+        default="",
+        help="Optional CloudFront distribution to invalidate after updating metadata.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.image_resource.startswith("ghcr:sima-neat/sdk:"):
+        raise SystemExit(f"--image-resource must target ghcr:sima-neat/sdk, got: {args.image_resource}")
+
+    repo_name = clean_path_part(args.repository, "repository")
+    encoded_branch_key = quote(args.release_line_ref, safe="")
+
+    with tempfile.TemporaryDirectory(prefix="sdk-release-line-") as tmp:
+        work_dir = Path(tmp)
+        latest_path = work_dir / "latest.tag"
+        run(
+            "aws",
+            "s3",
+            "cp",
+            f"s3://{args.bucket}/{repo_name}/{encoded_branch_key}/latest.tag",
+            str(latest_path),
+        )
+
+        latest_tag = latest_path.read_text(encoding="utf-8").strip()
+        if not latest_tag:
+            raise SystemExit(f"Empty latest.tag for {repo_name}/{args.release_line_ref}")
+
+        prefix = f"{repo_name}/{encoded_branch_key}/{latest_tag}"
+        metadata_path = work_dir / "metadata.json"
+        manifest_path = work_dir / "manifest.json"
+        run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/metadata.json", str(metadata_path))
+        run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/manifest.json", str(manifest_path))
+
+        retarget_metadata_resource(metadata_path, args.image_resource)
+        update_manifest_metadata_entry(manifest_path, metadata_path)
+
+        upload_args = s3_cp_args(args.sse_kms_key_id)
+        run(
+            "aws",
+            "s3",
+            "cp",
+            str(metadata_path),
+            f"s3://{args.bucket}/{prefix}/metadata.json",
+            "--content-type",
+            "application/json",
+            *upload_args,
+        )
+        run(
+            "aws",
+            "s3",
+            "cp",
+            str(manifest_path),
+            f"s3://{args.bucket}/{prefix}/manifest.json",
+            "--content-type",
+            "application/json",
+            *upload_args,
+        )
+
+        if args.cloudfront_distribution_id:
+            run(
+                "aws",
+                "cloudfront",
+                "create-invalidation",
+                "--distribution-id",
+                args.cloudfront_distribution_id,
+                "--paths",
+                f"/{prefix}/metadata.json",
+                f"/{prefix}/manifest.json",
+            )
+
+        print(f"release_line_ref={args.release_line_ref}")
+        print(f"latest_tag={latest_tag}")
+        print(f"metadata=s3://{args.bucket}/{prefix}/metadata.json")
+        print(f"image_resource={args.image_resource}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes the release-line SDK install metadata flow so `sima-cli neat install sdk@release-2.1` continues to resolve through the existing `release-2.1/latest.tag`, but installs the latest tagged SDK image after a tag release is published.

## Details

- Derive `release_line_ref` during tag builds, for example `v2.1.2.3` -> `release-2.1`.
- Add a tag-only workflow job after the normal SDK install stub publish.
- The job reads the existing release-line `latest.tag`, downloads that target's `metadata.json`, and updates only the SDK GHCR resource from the branch image to the tagged image.
- Update the matching `manifest.json` metadata entry checksum and size after changing `metadata.json`.
- Keep the S3 retargeting logic in `tools/retarget_release_line_metadata.py` instead of embedding it in the workflow YAML.

This preserves the existing release-line lookup behavior while ensuring the release-line install path pulls the tagged SDK container image.

## Validation

- `python3 -m py_compile tools/retarget_release_line_metadata.py`
- `actionlint .github/workflows/docker-build.yml`
- `bash tests/sdk/test-install-sdk-stub.sh`

Closes #101