### PR TITLE
Promote SDK offline installation package workflow

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -3,6 +3,7 @@ name: Cleanup GHCR Packages
 on:
   schedule:
     - cron: "23 9 * * *"
+  delete:
   workflow_dispatch:
     inputs:
       dry_run:
@@ -10,8 +11,14 @@ on:
         required: false
         default: false
         type: boolean
+      branch_name:
+        description: "Optional deleted branch name to clean up directly"
+        required: false
+        default: ""
+        type: string
 
 permissions:
+  actions: read
   contents: read
   packages: write
 
@@ -28,12 +35,20 @@ jobs:
         uses: actions/github-script@v8
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+          REQUESTED_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.branch_name || '' }}
+          DELETED_REF: ${{ github.event_name == 'delete' && github.event.ref || '' }}
+          DELETED_REF_TYPE: ${{ github.event_name == 'delete' && github.event.ref_type || '' }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const repoFullName = `${owner}/${repo}`;
             const dryRun = String(process.env.DRY_RUN).toLowerCase() === 'true';
+            const requestedBranch = String(process.env.REQUESTED_BRANCH || '').trim();
+            const deletedRef = String(process.env.DELETED_REF || '').trim();
+            const deletedRefType = String(process.env.DELETED_REF_TYPE || '').trim();
+            const buildWorkflowFile = 'docker-build.yml';
+            const workflowRunPageLimit = 50;
 
             const protectedBranchNames = new Set(['develop', 'main']);
 
@@ -74,6 +89,13 @@ jobs:
               return !liveBranchSlugs.has(tag);
             }
 
+            async function paginate(route, parameters) {
+              return github.paginate(route, {
+                per_page: 100,
+                ...parameters,
+              });
+            }
+
             function packageRepositoryFullName(pkg) {
               if (pkg.repository?.full_name) {
                 return pkg.repository.full_name;
@@ -86,18 +108,89 @@ jobs:
               return '';
             }
 
-            async function paginate(route, parameters) {
-              return github.paginate(route, {
-                per_page: 100,
-                ...parameters,
-              });
+            async function getPackage(packageName) {
+              try {
+                const response = await github.request('GET /orgs/{org}/packages/{package_type}/{package_name}', {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: packageName,
+                });
+                return response.data;
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+                throw error;
+              }
             }
 
-            async function deletePackage(packageName) {
+            async function packageHasSdkWorkflowVersion(packageName, commitShas) {
+              if (!commitShas || commitShas.size === 0) {
+                return false;
+              }
+
+              const expectedTags = new Set();
+              for (const sha of commitShas) {
+                expectedTags.add(sha);
+                expectedTags.add(`staged-${sha}`);
+                expectedTags.add(`${sha}-x86_64`);
+                expectedTags.add(`${sha}-aarch64`);
+              }
+
+              const versions = await paginate(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: packageName,
+                },
+              );
+
+              for (const version of versions) {
+                const tags = version.metadata?.container?.tags ?? [];
+                if (tags.some((tag) => expectedTags.has(tag))) {
+                  return true;
+                }
+              }
+              return false;
+            }
+
+            async function deletePackage(packageName, commitShas = new Set()) {
+              const pkg = await getPackage(packageName);
+              if (!pkg) {
+                core.info(`${packageName}: package does not exist; nothing to delete.`);
+                return;
+              }
+
+              const packageRepo = packageRepositoryFullName(pkg);
+              if (packageRepo && packageRepo !== repoFullName) {
+                core.warning(
+                  `${packageName}: skipping package associated with ${packageRepo}; ` +
+                  `expected ${repoFullName}.`,
+                );
+                return;
+              }
+
+              if (!packageRepo) {
+                const hasSdkWorkflowVersion = await packageHasSdkWorkflowVersion(packageName, commitShas);
+                if (!hasSdkWorkflowVersion) {
+                  core.warning(
+                    `${packageName}: skipping package with unknown repository ownership because no version tags ` +
+                    `matched SDK workflow commit history.`,
+                  );
+                  return;
+                }
+                core.warning(
+                  `${packageName}: package repository metadata is unavailable; proceeding because version tags ` +
+                  `match SDK workflow commit history.`,
+                );
+              }
+
               if (dryRun) {
                 core.info(`[dry-run] would delete package ${packageName}`);
                 return;
               }
+
               await github.request('DELETE /orgs/{org}/packages/{package_type}/{package_name}', {
                 org: owner,
                 package_type: 'container',
@@ -137,6 +230,41 @@ jobs:
               }
             }
 
+            async function listWorkflowRunsForBuildWorkflow() {
+              const runs = [];
+              for (let page = 1; page <= workflowRunPageLimit; page += 1) {
+                const response = await github.request(
+                  'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
+                  {
+                    owner,
+                    repo,
+                    workflow_id: buildWorkflowFile,
+                    per_page: 100,
+                    page,
+                  },
+                );
+                const pageRuns = response.data.workflow_runs ?? [];
+                runs.push(...pageRuns);
+                if (pageRuns.length < 100) {
+                  break;
+                }
+              }
+              return runs;
+            }
+
+            function shouldTrackBranchPackageFromRun(run) {
+              if (!run.head_branch) {
+                return false;
+              }
+              if (!['push', 'pull_request', 'workflow_dispatch'].includes(run.event)) {
+                return false;
+              }
+              if (run.head_branch.startsWith('v') && /^v[0-9]/.test(run.head_branch)) {
+                return false;
+              }
+              return true;
+            }
+
             const branches = await paginate('GET /repos/{owner}/{repo}/branches', {
               owner,
               repo,
@@ -158,28 +286,45 @@ jobs:
             core.info(`Found ${branches.length} branch(es).`);
             core.info(`Found ${protectedBranchPackages.size} protected branch package name(s).`);
 
-            const packages = await paginate('GET /orgs/{org}/packages', {
-              org: owner,
-              package_type: 'container',
-            });
-            const sdkBranchPackages = packages
-              .filter((pkg) => pkg.name.startsWith('sdk-'))
-              .filter((pkg) => {
-                const packageRepo = packageRepositoryFullName(pkg);
-                if (packageRepo === repoFullName) {
-                  return true;
+            const sdkBranchPackages = new Map();
+            function addSdkBranchPackage(branchName, commitSha = '') {
+              const packageName = sdkPackageForBranch(branchName);
+              if (!sdkBranchPackages.has(packageName)) {
+                sdkBranchPackages.set(packageName, new Set());
+              }
+              if (commitSha) {
+                sdkBranchPackages.get(packageName).add(commitSha);
+              }
+              return packageName;
+            }
+
+            if (requestedBranch) {
+              addSdkBranchPackage(requestedBranch);
+              core.info(`Added requested branch package candidate for ${requestedBranch}.`);
+            }
+            if (deletedRef && deletedRefType === 'branch') {
+              addSdkBranchPackage(deletedRef);
+              core.info(`Added deleted branch package candidate for ${deletedRef}.`);
+            } else if (deletedRef && deletedRefType) {
+              core.info(`Delete event was for ${deletedRefType} ${deletedRef}; skipping direct branch package cleanup.`);
+            }
+
+            if (!requestedBranch && context.eventName !== 'delete') {
+              const workflowRuns = await listWorkflowRunsForBuildWorkflow();
+              core.info(`Scanned ${workflowRuns.length} ${buildWorkflowFile} workflow run(s).`);
+              for (const run of workflowRuns) {
+                if (shouldTrackBranchPackageFromRun(run)) {
+                  addSdkBranchPackage(run.head_branch, run.head_sha || '');
                 }
-                core.info(`${pkg.name}: skipping package associated with ${packageRepo || 'unknown repository'}.`);
-                return false;
-              })
-              .map((pkg) => pkg.name);
+              }
+            }
 
-            core.info(`Found ${sdkBranchPackages.length} sdk-* GHCR package(s).`);
+            core.info(`Found ${sdkBranchPackages.size} SDK branch package candidate(s).`);
 
-            for (const packageName of sdkBranchPackages) {
+            for (const [packageName, commitShas] of sdkBranchPackages) {
               if (!branchPackages.has(packageName)) {
                 core.info(`${packageName}: no matching branch; deleting entire package.`);
-                await deletePackage(packageName);
+                await deletePackage(packageName, commitShas);
                 continue;
               }
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -140,6 +140,7 @@ jobs:
             release_tag="${GITHUB_REF_NAME}"
             if [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.][0-9]+([.][0-9]+)?$ ]]; then
               release_latest_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}-latest"
+              release_line_ref="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
             else
               echo "Release tags must use vX.Y.Z or vX.Y.Z.N format: ${GITHUB_REF_NAME}" >&2
               exit 1
@@ -160,6 +161,7 @@ jobs:
             echo "commit_sha=${GITHUB_SHA}"
             echo "release_tag=${release_tag}"
             echo "release_latest_tag=${release_latest_tag}"
+            echo "release_line_ref=${release_line_ref:-}"
             echo "branch_tag=${branch_tag}"
             echo "promote_latest=${promote_latest}"
           } > image-metadata/image.env
@@ -582,3 +584,60 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+
+  retarget-release-line-install-stub:
+    name: Retarget SDK release-line install stub
+    if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish-vulcan-install-stub
+    runs-on: ubuntu-24.04
+    environment: ${{ vars.VULCAN_ENV || 'production' }}
+    steps:
+      - name: Download image metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: image-promotion-metadata
+          path: .smoke
+
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-west-2
+          role-to-assume: ${{ vars.VULCAN_ARTIFACT_PUBLISHER_ROLE_ARN }}
+          role-session-name: sdk-retarget-release-line-${{ github.run_id }}
+
+      - name: Retarget release-line metadata to tagged SDK image
+        env:
+          ARTIFACT_BUCKET: ${{ vars.VULCAN_ARTIFACT_BUCKET }}
+          SSE_KMS_KEY_ID: ${{ vars.VULCAN_ARTIFACT_KMS_KEY_ID }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.VULCAN_ARTIFACT_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          set -euo pipefail
+
+          metadata_file="$(find .smoke -type f -name image.env -print -quit)"
+          # shellcheck disable=SC1090
+          source "${metadata_file}"
+
+          if [[ -z "${release_line_ref:-}" ]]; then
+            echo "release_line_ref is required for release-line install stub retargeting." >&2
+            exit 1
+          fi
+          if [[ -z "${release_tag:-}" ]]; then
+            echo "release_tag is required for release-line install stub retargeting." >&2
+            exit 1
+          fi
+          if [[ -z "${ARTIFACT_BUCKET:-}" ]]; then
+            echo "VULCAN_ARTIFACT_BUCKET is required." >&2
+            exit 1
+          fi
+          release_image_resource="ghcr:${repository#ghcr.io/}:${release_tag}"
+
+          tools/retarget_release_line_metadata.py \
+            --bucket "${ARTIFACT_BUCKET}" \
+            --repository sdk \
+            --release-line-ref "${release_line_ref}" \
+            --image-resource "${release_image_resource}" \
+            --sse-kms-key-id "${SSE_KMS_KEY_ID:-}" \
+            --cloudfront-distribution-id "${CLOUDFRONT_DISTRIBUTION_ID:-}"

--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -1,0 +1,177 @@
+name: Build SDK Offline Bundle
+
+on:
+  workflow_run:
+    workflows:
+      - Build SDK Docker Image
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_ref:
+        description: SDK image ref to package, for example ghcr.io/sima-neat/sdk:release-2.1.
+        required: true
+        type: string
+      package_version:
+        description: Optional package version. Defaults to the image tag.
+        required: false
+        type: string
+      package_release:
+        description: Optional package release id. Defaults to the current commit SHA.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.image_ref }}
+  cancel-in-progress: false
+
+jobs:
+  resolve-inputs:
+    name: Resolve offline bundle inputs
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')
+      )
+    runs-on: ubuntu-24.04
+    outputs:
+      image_ref: ${{ steps.resolve.outputs.image_ref }}
+      package_version: ${{ steps.resolve.outputs.package_version }}
+      package_release: ${{ steps.resolve.outputs.package_release }}
+    steps:
+      - name: Resolve image and package version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_IMAGE_REF: ${{ inputs.image_ref }}
+          INPUT_PACKAGE_VERSION: ${{ inputs.package_version }}
+          INPUT_PACKAGE_RELEASE: ${{ inputs.package_release }}
+          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            image_ref="${INPUT_IMAGE_REF:?}"
+            tag="${image_ref##*:}"
+            package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
+            package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
+          else
+            release_tag="${WORKFLOW_HEAD_BRANCH:?}"
+            if [[ ! "${release_tag}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$ ]]; then
+              echo "Offline bundle workflow_run only supports release tags, got: ${release_tag}" >&2
+              exit 1
+            fi
+            image_ref="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/sdk:${release_tag}"
+            package_version="${release_tag#v}"
+            package_release="${WORKFLOW_HEAD_SHA:?}"
+          fi
+
+          {
+            echo "image_ref=${image_ref}"
+            echo "package_version=${package_version}"
+            echo "package_release=${package_release}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "image_ref=${image_ref}"
+          echo "package_version=${package_version}"
+          echo "package_release=${package_release}"
+
+  build-offline-package:
+    name: Build offline package (${{ matrix.arch }})
+    needs: resolve-inputs
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+          - arch: aarch64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install packaging tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends zstd
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install sima-cli
+          SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli --version
+
+      - name: Report disk usage before packaging
+        run: |
+          set -euo pipefail
+          df -h
+          docker system df || true
+
+      - name: Build offline SDK package
+        env:
+          IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
+          PACKAGE_VERSION: ${{ needs.resolve-inputs.outputs.package_version }}
+          PACKAGE_RELEASE: ${{ needs.resolve-inputs.outputs.package_release }}
+          TARGET_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          source .venv/bin/activate
+          tools/prepare_offline_sdk_bundle.sh \
+            --output-dir "dist/${TARGET_ARCH}" \
+            --image-ref "${IMAGE_REF}" \
+            --target-arch "${TARGET_ARCH}" \
+            --version "${PACKAGE_VERSION}" \
+            --release "${PACKAGE_RELEASE}"
+
+      - name: Report disk usage after packaging
+        if: always()
+        run: |
+          set -euo pipefail
+          df -h
+          docker system df || true
+
+      - name: Upload offline SDK package
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdk-offline-package-${{ matrix.arch }}
+          path: dist/${{ matrix.arch }}/
+          if-no-files-found: error
+
+  publish-offline-package:
+    name: Publish offline SDK package to Vulcan
+    needs: build-offline-package
+    uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      artifact_pattern: sdk-offline-package-*
+      artifact_glob: "**/*"
+      min_artifact_count: 10
+
+  mark-offline-package-latest:
+    name: Mark offline SDK package as latest
+    needs: publish-offline-package
+    uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
+    with:
+      aws_region: us-west-2
+      environment_name: ${{ vars.VULCAN_ENV || 'production' }}

--- a/tools/install_offline_sdk.sh
+++ b/tools/install_offline_sdk.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt_yes_no() {
+  local prompt="$1"
+  local answer
+
+  while true; do
+    read -r -p "${prompt} [y/N]: " answer
+    answer="$(printf '%s' "${answer}" | tr '[:upper:]' '[:lower:]')"
+    case "${answer}" in
+      y|yes)
+        return 0
+        ;;
+      ""|n|no)
+        return 1
+        ;;
+      *)
+        echo "Please answer y or n."
+        ;;
+    esac
+  done
+}
+
+resolve_sima_cli() {
+  local candidate
+  local candidates=()
+
+  if [[ -n "${SIMA_CLI:-}" ]]; then
+    if [[ -x "${SIMA_CLI}" ]]; then
+      printf '%s\n' "${SIMA_CLI}"
+      return 0
+    fi
+
+    echo "SIMA_CLI is set but is not executable: ${SIMA_CLI}" >&2
+    return 1
+  fi
+
+  if command -v sima-cli >/dev/null 2>&1; then
+    command -v sima-cli
+    return 0
+  fi
+
+  candidates+=(
+    "${HOME}/.sima-cli/.venv/bin/sima-cli"
+    "${HOME}/.local/bin/sima-cli"
+    "/data/sima-cli/.venv/bin/sima-cli"
+    "/opt/sima-cli/venv/bin/sima-cli"
+    "/usr/local/bin/sima-cli"
+  )
+
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+find_image_archive() {
+  local script_dir="$1"
+  local archive
+
+  while IFS= read -r archive; do
+    if [[ -n "${archive}" ]]; then
+      printf '%s\n' "${archive}"
+      return 0
+    fi
+  done < <(find "${script_dir}" -maxdepth 1 -type f \( -name 'sdk-image-*.tar.zst' -o -name 'sdk-image-*.tar.gz' -o -name 'sdk-image-*.tar' \) | sort)
+
+  return 1
+}
+
+load_image_archive() {
+  local archive="$1"
+
+  echo "Loading SDK Docker image archive: $(basename "${archive}")"
+  case "${archive}" in
+    *.tar.zst)
+      if docker load -i "${archive}"; then
+        return 0
+      fi
+      if command -v zstd >/dev/null 2>&1; then
+        zstd -dc "${archive}" | docker load
+        return 0
+      fi
+      echo "Docker could not load the zstd-compressed archive directly, and zstd is not installed." >&2
+      echo "Install zstd or use a Docker version that supports zstd-compressed image archives." >&2
+      return 1
+      ;;
+    *)
+      docker load -i "${archive}"
+      ;;
+  esac
+}
+
+main() {
+  local script_dir
+  local sima_cli
+  local archive
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Required command not found: docker" >&2
+    exit 1
+  fi
+  docker info >/dev/null
+
+  if ! archive="$(find_image_archive "${script_dir}")"; then
+    echo "No SDK image archive found next to this installer." >&2
+    exit 1
+  fi
+
+  load_image_archive "${archive}"
+
+  if ! sima_cli="$(resolve_sima_cli)"; then
+    echo "Required command not found: sima-cli" >&2
+    echo "Checked PATH and common user install locations under ${HOME}." >&2
+    echo "If sima-cli is installed elsewhere, set SIMA_CLI=/path/to/sima-cli and retry." >&2
+    exit 1
+  fi
+
+  echo "SiMa.ai Neat SDK image is loaded locally."
+  echo "Starting SDK setup."
+
+  if prompt_yes_no "Do you want to pair this SDK with a DevKit now?"; then
+    local devkit_ip=""
+    while [[ -z "${devkit_ip}" ]]; do
+      read -r -p "Enter DevKit IP address: " devkit_ip
+      devkit_ip="${devkit_ip//[[:space:]]/}"
+      if [[ -z "${devkit_ip}" ]]; then
+        echo "DevKit IP address cannot be empty."
+      fi
+    done
+    "${sima_cli}" sdk setup --devkit "${devkit_ip}"
+  else
+    "${sima_cli}" sdk setup
+  fi
+}
+
+main "$@"

--- a/tools/prepare_offline_sdk_bundle.sh
+++ b/tools/prepare_offline_sdk_bundle.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: tools/prepare_offline_sdk_bundle.sh \
+  --output-dir <path> \
+  --image-ref <ghcr.io/sima-neat/sdk:tag> \
+  --target-arch <x86_64|aarch64> \
+  [--version <package-version>] \
+  [--release <release-id>]
+
+Builds an architecture-specific offline SDK package. The package contains a
+compressed Docker image archive and an installer script that loads the image
+before running the normal SDK setup flow.
+USAGE
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR=""
+IMAGE_REF=""
+TARGET_ARCH=""
+PACKAGE_VERSION=""
+PACKAGE_RELEASE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      OUTPUT_DIR="${2:-}"
+      shift 2
+      ;;
+    --image-ref)
+      IMAGE_REF="${2:-}"
+      shift 2
+      ;;
+    --target-arch)
+      TARGET_ARCH="${2:-}"
+      shift 2
+      ;;
+    --version)
+      PACKAGE_VERSION="${2:-}"
+      shift 2
+      ;;
+    --release)
+      PACKAGE_RELEASE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${OUTPUT_DIR}" || -z "${IMAGE_REF}" || -z "${TARGET_ARCH}" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 1
+fi
+
+case "${TARGET_ARCH}" in
+  x86_64)
+    DOCKER_PLATFORM="linux/amd64"
+    ;;
+  aarch64|arm64)
+    TARGET_ARCH="aarch64"
+    DOCKER_PLATFORM="linux/arm64"
+    ;;
+  *)
+    echo "Unsupported target architecture: ${TARGET_ARCH}" >&2
+    exit 1
+    ;;
+esac
+
+for tool in docker sima-cli zstd sha256sum; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "Required command not found: ${tool}" >&2
+    exit 1
+  fi
+done
+
+if [[ -z "${PACKAGE_VERSION}" ]]; then
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME#v}"
+  elif [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_HEAD_REF}"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    PACKAGE_VERSION="${GITHUB_REF_NAME}"
+  else
+    PACKAGE_VERSION="$(git -C "${ROOT_DIR}" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+if [[ -z "${PACKAGE_RELEASE}" ]]; then
+  PACKAGE_RELEASE="${PACKAGE_VERSION}"
+fi
+
+tmp_dir="$(mktemp -d /tmp/sima-sdk-offline-package-XXXXXX)"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+artifacts_dir="${tmp_dir}/artifacts"
+mkdir -p "${artifacts_dir}"
+
+archive_name="sdk-image-${TARGET_ARCH}.tar.zst"
+archive_path="${artifacts_dir}/${archive_name}"
+package_name="sdk-offline-${TARGET_ARCH}"
+
+echo "Pulling SDK image for ${DOCKER_PLATFORM}: ${IMAGE_REF}"
+docker pull --platform "${DOCKER_PLATFORM}" "${IMAGE_REF}"
+
+echo "Saving and compressing SDK image archive: ${archive_name}"
+docker save "${IMAGE_REF}" | zstd -T0 -10 -o "${archive_path}"
+
+echo "Cleaning local Docker image data after archive creation."
+docker image rm "${IMAGE_REF}" >/dev/null 2>&1 || true
+docker system prune -af >/dev/null 2>&1 || true
+
+install -m 0755 "${ROOT_DIR}/tools/install_offline_sdk.sh" "${artifacts_dir}/install_offline_sdk.sh"
+
+cat > "${artifacts_dir}/README.txt" <<EOF
+SiMa.ai Neat SDK offline bundle
+================================
+
+Image: ${IMAGE_REF}
+Architecture: ${TARGET_ARCH}
+
+To install:
+
+  bash ./install_offline_sdk.sh
+
+The installer loads ${archive_name} into Docker and then runs the normal
+sima-cli SDK setup flow. sima-cli and Docker must already be installed on the
+target host.
+EOF
+
+(
+  cd "${artifacts_dir}"
+  sha256sum "${archive_name}" install_offline_sdk.sh README.txt > SHA256SUMS
+)
+
+SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
+  --name "${package_name}" \
+  --version "${PACKAGE_VERSION}" \
+  --description "SiMa.ai Neat SDK offline install bundle (${TARGET_ARCH})" \
+  --install-script "install_offline_sdk.sh" \
+  --host-platform "ubuntu@22.04,ubuntu@24.04" \
+  --host-platform "windows" \
+  --host-platform "mac" \
+  --host-arch "${TARGET_ARCH}"
+
+python3 - "${artifacts_dir}/metadata.json" "${PACKAGE_RELEASE}" "${TARGET_ARCH}" "${IMAGE_REF}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+metadata_path = Path(sys.argv[1])
+release = sys.argv[2]
+target_arch = sys.argv[3]
+image_ref = sys.argv[4]
+
+metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+metadata["release"] = release
+metadata["installation"]["post-message"] = (
+    "[bold green]Offline SDK setup complete.[/bold green]\n"
+    "Run [cyan]sima-cli sdk neat[/cyan] to open the Neat SDK container.\n"
+)
+metadata["offline"] = {
+    "container-image": image_ref,
+    "architecture": target_arch,
+    "archive": f"sdk-image-{target_arch}.tar.zst",
+}
+metadata_path.write_text(json.dumps(metadata, indent=4) + "\n", encoding="utf-8")
+PY
+
+python3 -m json.tool "${artifacts_dir}/metadata.json" >/dev/null
+
+rm -rf "${OUTPUT_DIR}"
+mkdir -p "${OUTPUT_DIR}"
+cp -f "${artifacts_dir}/"* "${OUTPUT_DIR}/"
+
+echo "Prepared SDK offline package:"
+ls -lh "${OUTPUT_DIR}"

--- a/tools/retarget_release_line_metadata.py
+++ b/tools/retarget_release_line_metadata.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Retarget an SDK release-line install stub to a tagged SDK image.
+
+The SDK release flow publishes two useful install targets:
+
+* `sdk@2.1.2.3` points directly at the tagged SDK release package.
+* `sdk@release-2.1` points at the latest install-stub package produced by the
+  `release-2.1` branch build.
+
+After a patch release is tagged, we want `sdk@release-2.1` to keep using the
+same release-line package location and `latest.tag`, but pull the immutable
+tagged SDK container image instead of the mutable branch image. This script
+performs that small in-place metadata retarget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+
+def run(*args: str) -> None:
+    print("+", " ".join(args), flush=True)
+    subprocess.run(args, check=True)
+
+
+def clean_path_part(raw: str, fallback: str) -> str:
+    value = raw.strip() or fallback
+    value = value.replace("/", "-")
+    value = re.sub(r"[^A-Za-z0-9._-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip(".-")
+    if not value:
+        raise SystemExit(f"Invalid path component: {raw!r}")
+    return value
+
+
+def s3_cp_args(sse_kms_key_id: str) -> list[str]:
+    args = ["--sse", "aws:kms"]
+    if sse_kms_key_id:
+        args.extend(["--sse-kms-key-id", sse_kms_key_id])
+    return args
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, data: dict, indent: int) -> None:
+    path.write_text(json.dumps(data, indent=indent) + "\n", encoding="utf-8")
+
+
+def retarget_metadata_resource(metadata_path: Path, image_resource: str) -> None:
+    """Replace only the SDK container resource in metadata.json.
+
+    The install stub itself remains in the same package. Only the GHCR SDK image
+    resource changes from a release-line tag, such as `ghcr:sima-neat/sdk:release-2.1`,
+    to a version tag, such as `ghcr:sima-neat/sdk:v2.1.2.3`.
+    """
+    metadata = load_json(metadata_path)
+    resources = metadata.get("resources")
+    if not isinstance(resources, list):
+        raise SystemExit("metadata.json does not contain a resources list")
+
+    replaced = False
+    updated_resources = []
+    for resource in resources:
+        if isinstance(resource, str) and re.fullmatch(r"ghcr:sima-neat/sdk:[^\s]+", resource):
+            updated_resources.append(image_resource)
+            replaced = True
+        else:
+            updated_resources.append(resource)
+
+    if not replaced:
+        raise SystemExit("metadata.json does not contain a ghcr:sima-neat/sdk:* resource")
+
+    metadata["resources"] = updated_resources
+    write_json(metadata_path, metadata, indent=4)
+
+
+def update_manifest_metadata_entry(manifest_path: Path, metadata_path: Path) -> None:
+    """Refresh manifest metadata for metadata.json after editing it.
+
+    The Vulcan manifest records artifact size and SHA256. Since this script
+    rewrites metadata.json in place, the manifest must be kept consistent with
+    the uploaded metadata file.
+    """
+    manifest = load_json(manifest_path)
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise SystemExit("manifest.json does not contain an artifacts list")
+
+    metadata_sha = sha256_file(metadata_path)
+    metadata_size = metadata_path.stat().st_size
+    for artifact in artifacts:
+        if artifact.get("path") == "metadata.json":
+            artifact["sha256"] = metadata_sha
+            artifact["size"] = metadata_size
+            break
+    else:
+        raise SystemExit("manifest.json does not contain metadata.json artifact entry")
+
+    write_json(manifest_path, manifest, indent=2)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Retarget the existing SDK release-line metadata.json resource to a tagged SDK image "
+            "without changing latest.tag."
+        )
+    )
+    parser.add_argument("--bucket", required=True, help="Vulcan artifact S3 bucket.")
+    parser.add_argument("--repository", default="sdk", help="Repository key under the artifact bucket.")
+    parser.add_argument("--release-line-ref", required=True, help="Release-line ref, e.g. release-2.1.")
+    parser.add_argument(
+        "--image-resource",
+        required=True,
+        help="Tagged SDK image resource, e.g. ghcr:sima-neat/sdk:v2.1.2.3.",
+    )
+    parser.add_argument("--sse-kms-key-id", default="", help="Optional KMS key for S3 uploads.")
+    parser.add_argument(
+        "--cloudfront-distribution-id",
+        default="",
+        help="Optional CloudFront distribution to invalidate after updating metadata.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.image_resource.startswith("ghcr:sima-neat/sdk:"):
+        raise SystemExit(f"--image-resource must target ghcr:sima-neat/sdk, got: {args.image_resource}")
+
+    repo_name = clean_path_part(args.repository, "repository")
+    encoded_branch_key = quote(args.release_line_ref, safe="")
+
+    with tempfile.TemporaryDirectory(prefix="sdk-release-line-") as tmp:
+        work_dir = Path(tmp)
+        latest_path = work_dir / "latest.tag"
+        # Preserve the existing release-line pointer. The release branch build is
+        # responsible for choosing the current package folder; this tag publish
+        # step only retargets that package's SDK image resource to the release tag.
+        run(
+            "aws",
+            "s3",
+            "cp",
+            f"s3://{args.bucket}/{repo_name}/{encoded_branch_key}/latest.tag",
+            str(latest_path),
+        )
+
+        latest_tag = latest_path.read_text(encoding="utf-8").strip()
+        if not latest_tag:
+            raise SystemExit(f"Empty latest.tag for {repo_name}/{args.release_line_ref}")
+
+        prefix = f"{repo_name}/{encoded_branch_key}/{latest_tag}"
+        metadata_path = work_dir / "metadata.json"
+        manifest_path = work_dir / "manifest.json"
+        run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/metadata.json", str(metadata_path))
+        run("aws", "s3", "cp", f"s3://{args.bucket}/{prefix}/manifest.json", str(manifest_path))
+
+        # Edit locally first, then upload metadata and its manifest together.
+        # latest.tag is intentionally not changed.
+        retarget_metadata_resource(metadata_path, args.image_resource)
+        update_manifest_metadata_entry(manifest_path, metadata_path)
+
+        upload_args = s3_cp_args(args.sse_kms_key_id)
+        run(
+            "aws",
+            "s3",
+            "cp",
+            str(metadata_path),
+            f"s3://{args.bucket}/{prefix}/metadata.json",
+            "--content-type",
+            "application/json",
+            *upload_args,
+        )
+        run(
+            "aws",
+            "s3",
+            "cp",
+            str(manifest_path),
+            f"s3://{args.bucket}/{prefix}/manifest.json",
+            "--content-type",
+            "application/json",
+            *upload_args,
+        )
+
+        if args.cloudfront_distribution_id:
+            run(
+                "aws",
+                "cloudfront",
+                "create-invalidation",
+                "--distribution-id",
+                args.cloudfront_distribution_id,
+                "--paths",
+                f"/{prefix}/metadata.json",
+                f"/{prefix}/manifest.json",
+            )
+
+        print(f"release_line_ref={args.release_line_ref}")
+        print(f"latest_tag={latest_tag}")
+        print(f"metadata=s3://{args.bucket}/{prefix}/metadata.json")
+        print(f"image_resource={args.image_resource}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the SDK offline installation bundle workflow and installer scripts
- publish offline SDK packages for release-tag and manual workflow paths so workshop/offline installs do not require pulling directly from GHCR
- include release-line SDK install metadata retargeting so release-line install metadata can point at the latest tagged SDK image
- include the develop-line GHCR cleanup workflow improvements already merged into develop

Refs #103

## Validation
- Changes were merged and validated through the develop branch PR flow before this main promotion PR.
- Release/offline package behavior will be exercised by the release workflow and manual workflow dispatch.