### PR TITLE
Harden offline SDK workflow manual dispatch

### DIFF
--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -110,19 +110,28 @@ jobs:
       - name: Wait for SDK image manifest
         env:
           IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
+          EXPECTED_ARCH_TAG: ${{ github.sha }}-${{ matrix.arch }}
         run: |
           set -euo pipefail
 
           for attempt in {1..60}; do
-            if docker buildx imagetools inspect "${IMAGE_REF}" >/dev/null 2>&1; then
-              docker buildx imagetools inspect "${IMAGE_REF}"
-              exit 0
+            if docker buildx imagetools inspect "${IMAGE_REF}" --format '{{json .Manifest}}' > /tmp/sdk-image-manifest.json 2>/tmp/sdk-image-manifest.err; then
+              repository="${IMAGE_REF%:*}"
+              expected_ref="${repository}:${EXPECTED_ARCH_TAG}"
+              expected_digest="$(docker buildx imagetools inspect "${expected_ref}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+
+              if [[ -n "${expected_digest}" ]] &&
+                 jq -e --arg digest "${expected_digest}" '.manifests[]? | select(.digest == $digest)' /tmp/sdk-image-manifest.json >/dev/null; then
+                docker buildx imagetools inspect "${IMAGE_REF}"
+                echo "SDK image manifest includes ${expected_ref} (${expected_digest})."
+                exit 0
+              fi
             fi
-            echo "SDK image is not available yet (${attempt}/60): ${IMAGE_REF}"
+            echo "SDK image manifest is not updated yet (${attempt}/60): ${IMAGE_REF}"
             sleep 30
           done
 
-          echo "Timed out waiting for SDK image manifest: ${IMAGE_REF}" >&2
+          echo "Timed out waiting for SDK image manifest to include ${EXPECTED_ARCH_TAG}: ${IMAGE_REF}" >&2
           exit 1
 
       - name: Install packaging tools

--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -1,6 +1,9 @@
 name: Build SDK Offline Bundle
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       image_ref:
@@ -18,13 +21,11 @@ on:
         type: string
 
 permissions:
-  actions: write
   contents: read
-  id-token: write
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.image_ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -35,33 +36,55 @@ jobs:
       image_ref: ${{ steps.resolve.outputs.image_ref }}
       package_version: ${{ steps.resolve.outputs.package_version }}
       package_release: ${{ steps.resolve.outputs.package_release }}
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
     steps:
       - name: Resolve image and package version
         id: resolve
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
           INPUT_IMAGE_REF: ${{ inputs.image_ref }}
           INPUT_PACKAGE_VERSION: ${{ inputs.package_version }}
           INPUT_PACKAGE_RELEASE: ${{ inputs.package_release }}
         run: |
           set -euo pipefail
 
-          image_ref="${INPUT_IMAGE_REF:?}"
-          tag="${image_ref##*:}"
-          package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
-          package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
+          should_publish=true
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            image_ref="${INPUT_IMAGE_REF:?}"
+            tag="${image_ref##*:}"
+            package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
+            package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
+          elif [[ "${REF}" == refs/tags/v* ]]; then
+            owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+            image_ref="ghcr.io/${owner}/sdk:${REF_NAME}"
+            package_version="${REF_NAME#v}"
+            package_release="${GITHUB_SHA}"
+          else
+            echo "Skipping offline bundle: unsupported event ${EVENT_NAME} on ${REF}."
+            should_publish=false
+            image_ref=""
+            package_version=""
+            package_release=""
+          fi
 
           {
             echo "image_ref=${image_ref}"
             echo "package_version=${package_version}"
             echo "package_release=${package_release}"
+            echo "should_publish=${should_publish}"
           } >> "${GITHUB_OUTPUT}"
 
           echo "image_ref=${image_ref}"
           echo "package_version=${package_version}"
           echo "package_release=${package_release}"
+          echo "should_publish=${should_publish}"
 
   build-offline-package:
     name: Build offline package (${{ matrix.arch }})
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
     needs: resolve-inputs
     runs-on: ubuntu-24.04
     strategy:
@@ -83,6 +106,24 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for SDK image manifest
+        env:
+          IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..60}; do
+            if docker buildx imagetools inspect "${IMAGE_REF}" >/dev/null 2>&1; then
+              docker buildx imagetools inspect "${IMAGE_REF}"
+              exit 0
+            fi
+            echo "SDK image is not available yet (${attempt}/60): ${IMAGE_REF}"
+            sleep 30
+          done
+
+          echo "Timed out waiting for SDK image manifest: ${IMAGE_REF}" >&2
+          exit 1
 
       - name: Install packaging tools
         run: |
@@ -133,7 +174,14 @@ jobs:
 
   publish-offline-package:
     name: Publish offline SDK package to Vulcan
-    needs: build-offline-package
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
+    needs:
+      - resolve-inputs
+      - build-offline-package
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
     with:
       aws_region: us-west-2
@@ -144,7 +192,13 @@ jobs:
 
   mark-offline-package-latest:
     name: Mark offline SDK package as latest
-    needs: publish-offline-package
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
+    needs:
+      - resolve-inputs
+      - publish-offline-package
+    permissions:
+      contents: read
+      id-token: write
     uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
     with:
       aws_region: us-west-2

--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -99,6 +99,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           COMMIT_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
           REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
         run: |
           set -euo pipefail
@@ -113,20 +114,25 @@ jobs:
               gh run list \
                 --repo "${REPOSITORY}" \
                 --workflow docker-build.yml \
-                --commit "${COMMIT_SHA}" \
                 --event push \
-                --limit 20 \
-                --json databaseId,status,conclusion,url,createdAt
+                --limit 100 \
+                --json databaseId,status,conclusion,url,createdAt,headBranch,headSha
             )"
 
-            run_json="$(jq -c 'sort_by(.createdAt) | reverse | .[0] // empty' <<< "${runs_json}")"
+            run_json="$(
+              jq -c \
+                --arg ref "${REF_NAME}" \
+                --arg sha "${COMMIT_SHA}" \
+                '[.[] | select(.headBranch == $ref and .headSha == $sha)] | sort_by(.createdAt) | reverse | .[0] // empty' \
+                <<< "${runs_json}"
+            )"
             if [[ -n "${run_json}" ]]; then
               run_id="$(jq -r '.databaseId' <<< "${run_json}")"
               status="$(jq -r '.status' <<< "${run_json}")"
               conclusion="$(jq -r '.conclusion // ""' <<< "${run_json}")"
               url="$(jq -r '.url' <<< "${run_json}")"
 
-              echo "Docker workflow run ${run_id}: status=${status}, conclusion=${conclusion:-pending}, url=${url}"
+              echo "Docker workflow run ${run_id} for ${REF_NAME}@${COMMIT_SHA}: status=${status}, conclusion=${conclusion:-pending}, url=${url}"
               if [[ "${status}" == "completed" ]]; then
                 if [[ "${conclusion}" == "success" ]]; then
                   exit 0
@@ -135,14 +141,14 @@ jobs:
                 exit 1
               fi
             else
-              echo "No matching Docker workflow run found yet for ${COMMIT_SHA}."
+              echo "No matching Docker workflow run found yet for ${REF_NAME}@${COMMIT_SHA}."
             fi
 
             echo "Waiting for Docker workflow to complete (${attempt}/120)."
             sleep 30
           done
 
-          echo "Timed out waiting for Docker workflow to complete for ${COMMIT_SHA}." >&2
+          echo "Timed out waiting for Docker workflow to complete for ${REF_NAME}@${COMMIT_SHA}." >&2
           exit 1
 
   build-offline-package:

--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -1,16 +1,12 @@
 name: Build SDK Offline Bundle
 
 on:
-  workflow_run:
-    workflows:
-      - Build SDK Docker Image
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       image_ref:
         description: SDK image ref to package, for example ghcr.io/sima-neat/sdk:release-2.1.
-        required: true
+        required: false
+        default: ghcr.io/sima-neat/sdk:release-2.1
         type: string
       package_version:
         description: Optional package version. Defaults to the image tag.
@@ -22,24 +18,18 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: read
   id-token: write
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.image_ref }}
+  group: ${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   resolve-inputs:
     name: Resolve offline bundle inputs
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v')
-      )
     runs-on: ubuntu-24.04
     outputs:
       image_ref: ${{ steps.resolve.outputs.image_ref }}
@@ -49,30 +39,16 @@ jobs:
       - name: Resolve image and package version
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_IMAGE_REF: ${{ inputs.image_ref }}
           INPUT_PACKAGE_VERSION: ${{ inputs.package_version }}
           INPUT_PACKAGE_RELEASE: ${{ inputs.package_release }}
-          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
-          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
-            image_ref="${INPUT_IMAGE_REF:?}"
-            tag="${image_ref##*:}"
-            package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
-            package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
-          else
-            release_tag="${WORKFLOW_HEAD_BRANCH:?}"
-            if [[ ! "${release_tag}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$ ]]; then
-              echo "Offline bundle workflow_run only supports release tags, got: ${release_tag}" >&2
-              exit 1
-            fi
-            image_ref="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/sdk:${release_tag}"
-            package_version="${release_tag#v}"
-            package_release="${WORKFLOW_HEAD_SHA:?}"
-          fi
+          image_ref="${INPUT_IMAGE_REF:?}"
+          tag="${image_ref##*:}"
+          package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
+          package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
 
           {
             echo "image_ref=${image_ref}"
@@ -97,8 +73,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -166,7 +140,7 @@ jobs:
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
       artifact_pattern: sdk-offline-package-*
       artifact_glob: "**/*"
-      min_artifact_count: 10
+      min_artifact_count: 6
 
   mark-offline-package-latest:
     name: Mark offline SDK package as latest

--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   packages: read
 
 concurrency:
@@ -37,6 +38,7 @@ jobs:
       package_version: ${{ steps.resolve.outputs.package_version }}
       package_release: ${{ steps.resolve.outputs.package_release }}
       should_publish: ${{ steps.resolve.outputs.should_publish }}
+      require_current_sha_manifest: ${{ steps.resolve.outputs.require_current_sha_manifest }}
     steps:
       - name: Resolve image and package version
         id: resolve
@@ -51,6 +53,7 @@ jobs:
           set -euo pipefail
 
           should_publish=true
+          require_current_sha_manifest=false
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             image_ref="${INPUT_IMAGE_REF:?}"
@@ -62,6 +65,7 @@ jobs:
             image_ref="ghcr.io/${owner}/sdk:${REF_NAME}"
             package_version="${REF_NAME#v}"
             package_release="${GITHUB_SHA}"
+            require_current_sha_manifest=true
           else
             echo "Skipping offline bundle: unsupported event ${EVENT_NAME} on ${REF}."
             should_publish=false
@@ -75,17 +79,78 @@ jobs:
             echo "package_version=${package_version}"
             echo "package_release=${package_release}"
             echo "should_publish=${should_publish}"
+            echo "require_current_sha_manifest=${require_current_sha_manifest}"
           } >> "${GITHUB_OUTPUT}"
 
           echo "image_ref=${image_ref}"
           echo "package_version=${package_version}"
           echo "package_release=${package_release}"
           echo "should_publish=${should_publish}"
+          echo "require_current_sha_manifest=${require_current_sha_manifest}"
+
+  wait-for-docker-build:
+    name: Wait for SDK Docker workflow
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
+    needs: resolve-inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Wait for matching Docker workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+          REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${REQUIRE_CURRENT_SHA_MANIFEST}" != "true" ]]; then
+            echo "Manual dispatch uses an existing image ref; no Docker workflow wait is required."
+            exit 0
+          fi
+
+          for attempt in {1..120}; do
+            runs_json="$(
+              gh run list \
+                --repo "${REPOSITORY}" \
+                --workflow docker-build.yml \
+                --commit "${COMMIT_SHA}" \
+                --event push \
+                --limit 20 \
+                --json databaseId,status,conclusion,url,createdAt
+            )"
+
+            run_json="$(jq -c 'sort_by(.createdAt) | reverse | .[0] // empty' <<< "${runs_json}")"
+            if [[ -n "${run_json}" ]]; then
+              run_id="$(jq -r '.databaseId' <<< "${run_json}")"
+              status="$(jq -r '.status' <<< "${run_json}")"
+              conclusion="$(jq -r '.conclusion // ""' <<< "${run_json}")"
+              url="$(jq -r '.url' <<< "${run_json}")"
+
+              echo "Docker workflow run ${run_id}: status=${status}, conclusion=${conclusion:-pending}, url=${url}"
+              if [[ "${status}" == "completed" ]]; then
+                if [[ "${conclusion}" == "success" ]]; then
+                  exit 0
+                fi
+                echo "Docker workflow completed with conclusion=${conclusion}: ${url}" >&2
+                exit 1
+              fi
+            else
+              echo "No matching Docker workflow run found yet for ${COMMIT_SHA}."
+            fi
+
+            echo "Waiting for Docker workflow to complete (${attempt}/120)."
+            sleep 30
+          done
+
+          echo "Timed out waiting for Docker workflow to complete for ${COMMIT_SHA}." >&2
+          exit 1
 
   build-offline-package:
     name: Build offline package (${{ matrix.arch }})
     if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
-    needs: resolve-inputs
+    needs:
+      - resolve-inputs
+      - wait-for-docker-build
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -110,12 +175,19 @@ jobs:
       - name: Wait for SDK image manifest
         env:
           IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
+          REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
           EXPECTED_ARCH_TAG: ${{ github.sha }}-${{ matrix.arch }}
         run: |
           set -euo pipefail
 
           for attempt in {1..60}; do
             if docker buildx imagetools inspect "${IMAGE_REF}" --format '{{json .Manifest}}' > /tmp/sdk-image-manifest.json 2>/tmp/sdk-image-manifest.err; then
+              if [[ "${REQUIRE_CURRENT_SHA_MANIFEST}" != "true" ]]; then
+                docker buildx imagetools inspect "${IMAGE_REF}"
+                echo "SDK image manifest is available: ${IMAGE_REF}"
+                exit 0
+              fi
+
               repository="${IMAGE_REF%:*}"
               expected_ref="${repository}:${EXPECTED_ARCH_TAG}"
               expected_digest="$(docker buildx imagetools inspect "${expected_ref}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"

--- a/tools/prepare_offline_sdk_bundle.sh
+++ b/tools/prepare_offline_sdk_bundle.sh
@@ -116,7 +116,6 @@ archive_path="${artifacts_dir}/${archive_name}"
 package_name="sdk-offline-${TARGET_ARCH}"
 metadata_name="metadata-offline-${METADATA_ARCH}.json"
 readme_name="README-offline-${METADATA_ARCH}.txt"
-checksums_name="SHA256SUMS-offline-${METADATA_ARCH}"
 
 echo "Pulling SDK image for ${DOCKER_PLATFORM}: ${IMAGE_REF}"
 docker pull --platform "${DOCKER_PLATFORM}" "${IMAGE_REF}"
@@ -145,11 +144,6 @@ The installer loads ${archive_name} into Docker and then runs the normal
 sima-cli SDK setup flow. sima-cli and Docker must already be installed on the
 target host.
 EOF
-
-(
-  cd "${artifacts_dir}"
-  sha256sum "${archive_name}" install_offline_sdk.sh "${readme_name}" > "${checksums_name}"
-)
 
 SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
   --name "${package_name}" \

--- a/tools/prepare_offline_sdk_bundle.sh
+++ b/tools/prepare_offline_sdk_bundle.sh
@@ -66,10 +66,12 @@ fi
 case "${TARGET_ARCH}" in
   x86_64)
     DOCKER_PLATFORM="linux/amd64"
+    METADATA_ARCH="x86"
     ;;
   aarch64|arm64)
     TARGET_ARCH="aarch64"
     DOCKER_PLATFORM="linux/arm64"
+    METADATA_ARCH="arm64"
     ;;
   *)
     echo "Unsupported target architecture: ${TARGET_ARCH}" >&2
@@ -112,6 +114,9 @@ mkdir -p "${artifacts_dir}"
 archive_name="sdk-image-${TARGET_ARCH}.tar.zst"
 archive_path="${artifacts_dir}/${archive_name}"
 package_name="sdk-offline-${TARGET_ARCH}"
+metadata_name="metadata-offline-${METADATA_ARCH}.json"
+readme_name="README-offline-${METADATA_ARCH}.txt"
+checksums_name="SHA256SUMS-offline-${METADATA_ARCH}"
 
 echo "Pulling SDK image for ${DOCKER_PLATFORM}: ${IMAGE_REF}"
 docker pull --platform "${DOCKER_PLATFORM}" "${IMAGE_REF}"
@@ -125,7 +130,7 @@ docker system prune -af >/dev/null 2>&1 || true
 
 install -m 0755 "${ROOT_DIR}/tools/install_offline_sdk.sh" "${artifacts_dir}/install_offline_sdk.sh"
 
-cat > "${artifacts_dir}/README.txt" <<EOF
+cat > "${artifacts_dir}/${readme_name}" <<EOF
 SiMa.ai Neat SDK offline bundle
 ================================
 
@@ -143,7 +148,7 @@ EOF
 
 (
   cd "${artifacts_dir}"
-  sha256sum "${archive_name}" install_offline_sdk.sh README.txt > SHA256SUMS
+  sha256sum "${archive_name}" install_offline_sdk.sh "${readme_name}" > "${checksums_name}"
 )
 
 SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
@@ -180,7 +185,8 @@ metadata["offline"] = {
 metadata_path.write_text(json.dumps(metadata, indent=4) + "\n", encoding="utf-8")
 PY
 
-python3 -m json.tool "${artifacts_dir}/metadata.json" >/dev/null
+mv "${artifacts_dir}/metadata.json" "${artifacts_dir}/${metadata_name}"
+python3 -m json.tool "${artifacts_dir}/${metadata_name}" >/dev/null
 
 rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"

--- a/tools/prepare_offline_sdk_bundle.sh
+++ b/tools/prepare_offline_sdk_bundle.sh
@@ -66,7 +66,7 @@ fi
 case "${TARGET_ARCH}" in
   x86_64)
     DOCKER_PLATFORM="linux/amd64"
-    METADATA_ARCH="x86"
+    METADATA_ARCH="amd64"
     ;;
   aarch64|arm64)
     TARGET_ARCH="aarch64"
@@ -172,7 +172,7 @@ target_arch = sys.argv[3]
 image_ref = sys.argv[4]
 
 metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-metadata.get("installation", {}).pop("script", None)
+metadata.setdefault("installation", {})["script"] = "echo 'Offline SDK package downloaded. Copy the downloaded files to the offline host, then run: bash ./install_offline_sdk.sh'"
 metadata["release"] = release
 metadata["installation"]["post-message"] = (
     "[bold green]Offline SDK setup complete.[/bold green]\n"

--- a/tools/prepare_offline_sdk_bundle.sh
+++ b/tools/prepare_offline_sdk_bundle.sh
@@ -79,12 +79,18 @@ case "${TARGET_ARCH}" in
     ;;
 esac
 
-for tool in docker sima-cli zstd sha256sum; do
+for tool in docker sima-cli zstd; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "Required command not found: ${tool}" >&2
     exit 1
   fi
 done
+
+if [[ "${IMAGE_REF}" != ghcr.io/*:* ]]; then
+  echo "--image-ref must use ghcr.io/<owner>/<image>:<tag>, got: ${IMAGE_REF}" >&2
+  exit 1
+fi
+image_resource="ghcr:${IMAGE_REF#ghcr.io/}"
 
 if [[ -z "${PACKAGE_VERSION}" ]]; then
   if [[ "${GITHUB_REF_TYPE:-}" == "tag" && -n "${GITHUB_REF_NAME:-}" ]]; then
@@ -166,10 +172,12 @@ target_arch = sys.argv[3]
 image_ref = sys.argv[4]
 
 metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+metadata.get("installation", {}).pop("script", None)
 metadata["release"] = release
 metadata["installation"]["post-message"] = (
     "[bold green]Offline SDK setup complete.[/bold green]\n"
-    "Run [cyan]sima-cli sdk neat[/cyan] to open the Neat SDK container.\n"
+    "Copy the downloaded files to the offline host, then run "
+    "[cyan]bash ./install_offline_sdk.sh[/cyan].\n"
 )
 metadata["offline"] = {
     "container-image": image_ref,
@@ -181,6 +189,13 @@ PY
 
 mv "${artifacts_dir}/metadata.json" "${artifacts_dir}/${metadata_name}"
 python3 -m json.tool "${artifacts_dir}/${metadata_name}" >/dev/null
+
+"${ROOT_DIR}/tools/prepare_s3_artifacts.sh" \
+  --output-dir "${tmp_dir}/online-package" \
+  --image-resource "${image_resource}" \
+  --version "${PACKAGE_VERSION}" \
+  --release "${PACKAGE_RELEASE}"
+cp -f "${tmp_dir}/online-package/install_sdk_stub.sh" "${tmp_dir}/online-package/metadata.json" "${artifacts_dir}/"
 
 rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"


### PR DESCRIPTION
## Summary
- remove the automatic `workflow_run` trigger from the offline SDK bundle workflow
- keep offline bundle generation as a manual `workflow_dispatch` flow for now
- default the manual image ref to `ghcr.io/sima-neat/sdk:release-2.1`
- grant `actions: write` because the reusable Vulcan publish workflow requests it for artifact handling
- set the Vulcan publish minimum artifact count to 6, matching the two architecture bundles produced today
- simplify concurrency and checkout logic now that the workflow is manual-only

Refs #103

## Validation
- `actionlint .github/workflows/offline-sdk-bundle.yml`
- `git diff --check`

## Notes
Runs `28548737121`, `28549418320`, and `28550762488` are all using the old workflow already on `main`; they fail at GitHub Actions startup before jobs are created because the automatic `workflow_run` path is still present there. Run `28551411313` was launched from the older feature branch and failed because the caller did not grant `actions: write` to the reusable Vulcan publisher. Run `28551526770` reached publish, but the reusable Vulcan publisher found 6 files while the workflow required at least 10. This PR targets `develop` per repository policy. After it merges, promote `develop` to `main` to remove the automatic trigger from the active workflow.
