### PR TITLE
Fix automatic offline SDK bundle workflow

### DIFF
--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -23,28 +23,25 @@ on:
 
 permissions:
   contents: read
+  actions: write
   id-token: write
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || inputs.image_ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.inputs.image_ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   resolve-inputs:
     name: Resolve offline bundle inputs
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v')
-      )
     runs-on: ubuntu-24.04
     outputs:
       image_ref: ${{ steps.resolve.outputs.image_ref }}
       package_version: ${{ steps.resolve.outputs.package_version }}
       package_release: ${{ steps.resolve.outputs.package_release }}
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
+      require_current_sha_manifest: ${{ steps.resolve.outputs.require_current_sha_manifest }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
     steps:
       - name: Resolve image and package version
         id: resolve
@@ -53,39 +50,88 @@ jobs:
           INPUT_IMAGE_REF: ${{ inputs.image_ref }}
           INPUT_PACKAGE_VERSION: ${{ inputs.package_version }}
           INPUT_PACKAGE_RELEASE: ${{ inputs.package_release }}
-          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
+
+          should_publish=true
+          require_current_sha_manifest=false
+          source_sha="${GITHUB_SHA}"
+
+          sanitize_ref() {
+            local ref="$1"
+            ref="$(echo "${ref}" | tr '[:upper:]' '[:lower:]')"
+            ref="$(echo "${ref}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            if [[ -z "${ref}" ]]; then
+              ref="branch"
+            fi
+            printf '%s' "${ref}"
+          }
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             image_ref="${INPUT_IMAGE_REF:?}"
             tag="${image_ref##*:}"
             package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
             package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
-          else
-            release_tag="${WORKFLOW_HEAD_BRANCH:?}"
-            if [[ ! "${release_tag}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$ ]]; then
-              echo "Offline bundle workflow_run only supports release tags, got: ${release_tag}" >&2
-              exit 1
+          elif [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ "${WORKFLOW_RUN_CONCLUSION}" != "success" || "${WORKFLOW_RUN_EVENT}" != "push" ]]; then
+              echo "Skipping offline bundle: Docker workflow conclusion=${WORKFLOW_RUN_CONCLUSION}, event=${WORKFLOW_RUN_EVENT}."
+              should_publish=false
+              image_ref=""
+              package_version=""
+              package_release=""
+            else
+              source_ref="${WORKFLOW_RUN_HEAD_BRANCH:?}"
+              source_sha="${WORKFLOW_RUN_HEAD_SHA:?}"
+              branch_tag="$(sanitize_ref "${source_ref}")"
+              if [[ "${source_ref}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$ ]]; then
+                repository="sdk"
+                image_tag="${source_ref}"
+                package_version="${source_ref#v}"
+              elif [[ "${branch_tag}" == "main" ]]; then
+                repository="sdk"
+                image_tag="latest"
+                package_version="${source_ref}"
+              else
+                repository="sdk-${branch_tag}"
+                image_tag="latest"
+                package_version="${source_ref}"
+              fi
+
+              owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+              image_ref="ghcr.io/${owner}/${repository}:${image_tag}"
+              package_release="${source_sha}"
+              require_current_sha_manifest=true
             fi
-            image_ref="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/sdk:${release_tag}"
-            package_version="${release_tag#v}"
-            package_release="${WORKFLOW_HEAD_SHA:?}"
+          else
+            echo "Skipping offline bundle: unsupported event ${EVENT_NAME}."
+            should_publish=false
+            image_ref=""
+            package_version=""
+            package_release=""
           fi
 
           {
             echo "image_ref=${image_ref}"
             echo "package_version=${package_version}"
             echo "package_release=${package_release}"
+            echo "should_publish=${should_publish}"
+            echo "require_current_sha_manifest=${require_current_sha_manifest}"
+            echo "source_sha=${source_sha}"
           } >> "${GITHUB_OUTPUT}"
 
           echo "image_ref=${image_ref}"
           echo "package_version=${package_version}"
           echo "package_release=${package_release}"
+          echo "should_publish=${should_publish}"
+          echo "require_current_sha_manifest=${require_current_sha_manifest}"
 
   build-offline-package:
     name: Build offline package (${{ matrix.arch }})
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
     needs: resolve-inputs
     runs-on: ubuntu-24.04
     strategy:
@@ -109,6 +155,40 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for SDK image manifest
+        env:
+          IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
+          REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
+          EXPECTED_ARCH_TAG: ${{ needs.resolve-inputs.outputs.source_sha }}-${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+
+          for attempt in {1..60}; do
+            if docker buildx imagetools inspect "${IMAGE_REF}" --format '{{json .Manifest}}' > /tmp/sdk-image-manifest.json 2>/tmp/sdk-image-manifest.err; then
+              if [[ "${REQUIRE_CURRENT_SHA_MANIFEST}" != "true" ]]; then
+                docker buildx imagetools inspect "${IMAGE_REF}"
+                echo "SDK image manifest is available: ${IMAGE_REF}"
+                exit 0
+              fi
+
+              repository="${IMAGE_REF%:*}"
+              expected_ref="${repository}:${EXPECTED_ARCH_TAG}"
+              expected_digest="$(docker buildx imagetools inspect "${expected_ref}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)"
+
+              if [[ -n "${expected_digest}" ]] &&
+                 jq -e --arg digest "${expected_digest}" '.manifests[]? | select(.digest == $digest)' /tmp/sdk-image-manifest.json >/dev/null; then
+                docker buildx imagetools inspect "${IMAGE_REF}"
+                echo "SDK image manifest includes ${expected_ref} (${expected_digest})."
+                exit 0
+              fi
+            fi
+            echo "SDK image manifest is not updated yet (${attempt}/60): ${IMAGE_REF}"
+            sleep 30
+          done
+
+          echo "Timed out waiting for SDK image manifest to include ${EXPECTED_ARCH_TAG}: ${IMAGE_REF}" >&2
+          exit 1
 
       - name: Install packaging tools
         run: |
@@ -159,18 +239,31 @@ jobs:
 
   publish-offline-package:
     name: Publish offline SDK package to Vulcan
-    needs: build-offline-package
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
+    needs:
+      - resolve-inputs
+      - build-offline-package
+    permissions:
+      contents: read
+      actions: write
+      id-token: write
     uses: sima-neat/.github/.github/workflows/vulcan-publish-artifacts.yml@main
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
       artifact_pattern: sdk-offline-package-*
       artifact_glob: "**/*"
-      min_artifact_count: 10
+      min_artifact_count: 6
 
   mark-offline-package-latest:
     name: Mark offline SDK package as latest
-    needs: publish-offline-package
+    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
+    needs:
+      - resolve-inputs
+      - publish-offline-package
+    permissions:
+      contents: read
+      id-token: write
     uses: sima-neat/.github/.github/workflows/vulcan-update-latest-artifacts.yml@main
     with:
       aws_region: us-west-2


### PR DESCRIPTION
## Summary
- grant the offline SDK bundle workflow actions: write so it can call the shared Vulcan publish workflow
- allow successful SDK Docker workflow_run events from all push branches/tags, not only v* tags
- resolve the correct promoted SDK image for branch, main, and tagged release builds
- wait for the promoted image manifest to include the triggering SHA's architecture images before packaging

References #103

## Validation
- actionlint .github/workflows/offline-sdk-bundle.yml
- Ruby YAML parse
- git diff --check