### PR TITLE
Fix automatic offline SDK bundle workflow

### DIFF
--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -1,9 +1,11 @@
 name: Build SDK Offline Bundle
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows:
+      - Build SDK Docker Image
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       image_ref:
@@ -22,11 +24,12 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
+  id-token: write
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.image_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.event.inputs.image_ref || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -39,6 +42,7 @@ jobs:
       package_release: ${{ steps.resolve.outputs.package_release }}
       should_publish: ${{ steps.resolve.outputs.should_publish }}
       require_current_sha_manifest: ${{ steps.resolve.outputs.require_current_sha_manifest }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
     steps:
       - name: Resolve image and package version
         id: resolve
@@ -49,17 +53,74 @@ jobs:
           INPUT_IMAGE_REF: ${{ inputs.image_ref }}
           INPUT_PACKAGE_VERSION: ${{ inputs.package_version }}
           INPUT_PACKAGE_RELEASE: ${{ inputs.package_release }}
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 
           should_publish=true
           require_current_sha_manifest=false
+          source_sha="${GITHUB_SHA}"
+
+          sanitize_ref() {
+            local ref="$1"
+            ref="$(echo "${ref}" | tr '[:upper:]' '[:lower:]')"
+            ref="$(echo "${ref}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+            if [[ -z "${ref}" ]]; then
+              ref="branch"
+            fi
+            printf '%s' "${ref}"
+          }
+
+          has_source_branch() {
+            local ref="$1"
+            local remote_url="https://github.com/${GITHUB_REPOSITORY}.git"
+            if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+              git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" \
+                ls-remote --exit-code --heads "${remote_url}" "refs/heads/${ref}" >/dev/null 2>&1
+              return $?
+            fi
+            git ls-remote --exit-code --heads "${remote_url}" "refs/heads/${ref}" >/dev/null 2>&1
+          }
 
           if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             image_ref="${INPUT_IMAGE_REF:?}"
             tag="${image_ref##*:}"
             package_version="${INPUT_PACKAGE_VERSION:-${tag}}"
             package_release="${INPUT_PACKAGE_RELEASE:-${GITHUB_SHA}}"
+          elif [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ "${WORKFLOW_RUN_CONCLUSION}" != "success" || "${WORKFLOW_RUN_EVENT}" != "push" ]]; then
+              echo "Skipping offline bundle: Docker workflow conclusion=${WORKFLOW_RUN_CONCLUSION}, event=${WORKFLOW_RUN_EVENT}."
+              should_publish=false
+              image_ref=""
+              package_version=""
+              package_release=""
+            else
+              source_ref="${WORKFLOW_RUN_HEAD_BRANCH:?}"
+              source_sha="${WORKFLOW_RUN_HEAD_SHA:?}"
+              branch_tag="$(sanitize_ref "${source_ref}")"
+              if [[ "${source_ref}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([.][0-9]+)?$ ]] && ! has_source_branch "${source_ref}"; then
+                repository="sdk"
+                image_tag="${source_ref}"
+                package_version="${source_ref#v}"
+              elif [[ "${branch_tag}" == "main" ]]; then
+                repository="sdk"
+                image_tag="latest"
+                package_version="${source_ref}"
+              else
+                repository="sdk-${branch_tag}"
+                image_tag="latest"
+                package_version="${source_ref}"
+              fi
+
+              owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+              image_ref="ghcr.io/${owner}/${repository}:${image_tag}"
+              package_release="${source_sha}"
+              require_current_sha_manifest=true
+            fi
           elif [[ "${REF}" == refs/tags/v* ]]; then
             owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
             image_ref="ghcr.io/${owner}/sdk:${REF_NAME}"
@@ -80,6 +141,7 @@ jobs:
             echo "package_release=${package_release}"
             echo "should_publish=${should_publish}"
             echo "require_current_sha_manifest=${require_current_sha_manifest}"
+            echo "source_sha=${source_sha}"
           } >> "${GITHUB_OUTPUT}"
 
           echo "image_ref=${image_ref}"
@@ -88,75 +150,10 @@ jobs:
           echo "should_publish=${should_publish}"
           echo "require_current_sha_manifest=${require_current_sha_manifest}"
 
-  wait-for-docker-build:
-    name: Wait for SDK Docker workflow
-    if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
-    needs: resolve-inputs
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Wait for matching Docker workflow run
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          COMMIT_SHA: ${{ github.sha }}
-          REF_NAME: ${{ github.ref_name }}
-          REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
-        run: |
-          set -euo pipefail
-
-          if [[ "${REQUIRE_CURRENT_SHA_MANIFEST}" != "true" ]]; then
-            echo "Manual dispatch uses an existing image ref; no Docker workflow wait is required."
-            exit 0
-          fi
-
-          for attempt in {1..120}; do
-            runs_json="$(
-              gh run list \
-                --repo "${REPOSITORY}" \
-                --workflow docker-build.yml \
-                --event push \
-                --limit 100 \
-                --json databaseId,status,conclusion,url,createdAt,headBranch,headSha
-            )"
-
-            run_json="$(
-              jq -c \
-                --arg ref "${REF_NAME}" \
-                --arg sha "${COMMIT_SHA}" \
-                '[.[] | select(.headBranch == $ref and .headSha == $sha)] | sort_by(.createdAt) | reverse | .[0] // empty' \
-                <<< "${runs_json}"
-            )"
-            if [[ -n "${run_json}" ]]; then
-              run_id="$(jq -r '.databaseId' <<< "${run_json}")"
-              status="$(jq -r '.status' <<< "${run_json}")"
-              conclusion="$(jq -r '.conclusion // ""' <<< "${run_json}")"
-              url="$(jq -r '.url' <<< "${run_json}")"
-
-              echo "Docker workflow run ${run_id} for ${REF_NAME}@${COMMIT_SHA}: status=${status}, conclusion=${conclusion:-pending}, url=${url}"
-              if [[ "${status}" == "completed" ]]; then
-                if [[ "${conclusion}" == "success" ]]; then
-                  exit 0
-                fi
-                echo "Docker workflow completed with conclusion=${conclusion}: ${url}" >&2
-                exit 1
-              fi
-            else
-              echo "No matching Docker workflow run found yet for ${REF_NAME}@${COMMIT_SHA}."
-            fi
-
-            echo "Waiting for Docker workflow to complete (${attempt}/120)."
-            sleep 30
-          done
-
-          echo "Timed out waiting for Docker workflow to complete for ${REF_NAME}@${COMMIT_SHA}." >&2
-          exit 1
-
   build-offline-package:
     name: Build offline package (${{ matrix.arch }})
     if: ${{ needs.resolve-inputs.outputs.should_publish == 'true' }}
-    needs:
-      - resolve-inputs
-      - wait-for-docker-build
+    needs: resolve-inputs
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -167,6 +164,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -182,7 +181,7 @@ jobs:
         env:
           IMAGE_REF: ${{ needs.resolve-inputs.outputs.image_ref }}
           REQUIRE_CURRENT_SHA_MANIFEST: ${{ needs.resolve-inputs.outputs.require_current_sha_manifest }}
-          EXPECTED_ARCH_TAG: ${{ github.sha }}-${{ matrix.arch }}
+          EXPECTED_ARCH_TAG: ${{ needs.resolve-inputs.outputs.source_sha }}-${{ matrix.arch }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- grant the offline SDK bundle workflow actions: write so it can call the shared Vulcan publish workflow
- allow successful SDK Docker workflow_run events from all push branches/tags, not only release tags
- resolve the correct promoted SDK image for branch, main, and tagged release builds
- wait for the promoted image manifest to include the triggering SHA architecture images before packaging

References #103

## Validation
- actionlint .github/workflows/offline-sdk-bundle.yml
- Ruby YAML parse
- git diff --check