### PR TITLE
Fix SDK VS Code extension package install

### DIFF
--- a/tools/install_vscode_extension.sh
+++ b/tools/install_vscode_extension.sh
@@ -13,8 +13,10 @@ if command -v code >/dev/null 2>&1; then
   code --install-extension "${vsix_path}" --force
 elif command -v openvscode-server >/dev/null 2>&1; then
   openvscode-server --install-extension "${vsix_path}" --force
+elif [[ -x "${OPENVSCODE_SERVER_DIR:-/opt/openvscode-server}/bin/openvscode-server" ]]; then
+  "${OPENVSCODE_SERVER_DIR:-/opt/openvscode-server}/bin/openvscode-server" --install-extension "${vsix_path}" --force
 else
-  echo "'code' command not found. Run this installer from the SDK Code terminal." >&2
+  echo "Neither 'code' nor openvscode-server was found. Run this installer inside an SDK Code container." >&2
   exit 1
 fi
 

--- a/tools/prepare_vscode_extension_package.sh
+++ b/tools/prepare_vscode_extension_package.sh
@@ -10,7 +10,7 @@ Usage: tools/prepare_vscode_extension_package.sh \
 
 Builds the SiMa Neat VS Code extension VSIX and Vulcan/sima-cli package
 metadata. The package is compatible with Palette SDK containers and installs
-the extension by invoking `code --install-extension`.
+the extension by invoking the available VS Code or OpenVSCode Server CLI.
 USAGE
 }
 
@@ -103,7 +103,7 @@ SIMA_CLI_CHECK_FOR_UPDATE=0 sima-cli packages build "${artifacts_dir}" \
   --name "${PACKAGE_NAME}" \
   --version "${PACKAGE_VERSION}" \
   --description "SiMa Neat VS Code extension for SDK workspaces" \
-  --install-script "./${INSTALL_SCRIPT_NAME}" \
+  --install-script "bash ./${INSTALL_SCRIPT_NAME}" \
   --palette-platform
 
 python3 - "${artifacts_dir}/metadata.json" "${PACKAGE_RELEASE}" <<'PY'


### PR DESCRIPTION
## Context

`sima-cli sdk setup` now offers to install the SiMa Neat, Claude, and Codex browser VS Code extensions during SDK container setup. The SiMa Neat extension is installed through the Vulcan package:

```bash
sima-cli neat install sdk/vscode-extension
```

During setup testing, the package downloaded correctly, but the extension install did not complete reliably from the SDK setup flow.

## Root Cause

There were two assumptions in the extension package installer that are true from an interactive SDK Code terminal, but not true when the installer is launched by `sima-cli sdk setup` through `docker exec`:

- The metadata invoked `./install_vscode_extension.sh` directly, so installation failed if the downloaded script did not preserve executable permissions.
- The script preferred the `code` CLI and only checked `openvscode-server` on `PATH`; in the setup environment, the OpenVSCode binary exists at `/opt/openvscode-server/bin/openvscode-server`, but neither `code` nor `openvscode-server` is necessarily on `PATH`.

Observed failures included:

```text
bash: ./install_vscode_extension.sh: Permission denied
'code' command not found. Run this installer from the SDK Code terminal.
```

## Fix

- Generate package metadata with `bash ./install_vscode_extension.sh` so the install script does not depend on executable file mode.
- Add a fallback to `${OPENVSCODE_SERVER_DIR:-/opt/openvscode-server}/bin/openvscode-server` when `code` and `openvscode-server` are not on `PATH`.
- Update the package help text to describe the actual VS Code/OpenVSCode install behavior.

Refs #107

## Validation

- `bash -n tools/install_vscode_extension.sh`
- `bash -n tools/prepare_vscode_extension_package.sh`
- `git diff --check`
