### PR TITLE
Prepare SDK dependencies for 2.1.2.3

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,9 +1,9 @@
 {
   "core": {
-    "ref": "v0.2.2"
+    "ref": "v0.3.0"
   },
   "insight": {
-    "ref": "v0.0.4"
+    "ref": "v0.0.6"
   },
   "platform-version": "2.1.2"
 }


### PR DESCRIPTION
## Summary

Updates the SDK release dependency pins:

- Core: `v0.2.2` → `v0.3.0`
- Insight: `v0.0.4` → `v0.0.6`

## Validation

- Verified both upstream tags exist.
- `jq empty deps/manifest.json`
- `git diff --check`

Fixes #118.