### PR TITLE
Prepare SDK 2.1.2.3 dependencies

### DIFF
--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -1,9 +1,9 @@
 {
   "core": {
-    "ref": "v0.2.2"
+    "ref": "v0.3.0"
   },
   "insight": {
-    "ref": "v0.0.4"
+    "ref": "v0.0.6"
   },
   "platform-version": "2.1.2"
 }

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -184,7 +184,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'sima-neat-*-Linux-dev.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.deb' | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then


### PR DESCRIPTION
## Summary

Promotes the SDK dependency preparation from `develop` to `main`.

- Core: `v0.3.0`
- Insight: `v0.0.6`

## Tracking

Fixes #118.

## Validation

The dependency manifest and upstream release tags were validated in the prerequisite `2.1.2.3-prep` change.