### PR TITLE
Sync the complete Core DEB bundle to DevKit

### DIFF
--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -184,7 +184,7 @@ sync_neat_framework_to_devkit() {
 
   local -a deb_files=()
   local -a wheel_files=()
-  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f \( -name 'sima-neat-*-Linux-core.deb' -o -name 'sima-neat-*-Linux-dev.deb' -o -name 'neat-*.deb' -o -name 'sima-lmm-*.deb' \) | sort)
+  mapfile -t deb_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.deb' | sort)
   mapfile -t wheel_files < <(find "${cache_dir}" -maxdepth 1 -type f -name '*.whl' | sort)
 
   if [[ "${#deb_files[@]}" -lt 1 ]]; then


### PR DESCRIPTION
## Summary

Transfer every top-level DEB from the SDK's dedicated `neat-install-packages` cache during DevKit synchronization.

## Root cause

The previous filename allowlist excluded Core 0.3.0's bundled `simaai-memory-lib` runtime and development DEBs. The Core installer correctly stopped because it requires that local pair for its zero-removal replacement transaction.

## Impact

The DevKit receives the complete Core artifact bundle, including current and future support DEBs such as the memory-library payload.

## Validation

- `bash -n scripts/devkit.sh`
- `tests/sdk/test-devkit-rsync-scope.sh`

Fixes #121