### PR TITLE
Keep workflow-run SDK artifacts in their source branch

### DIFF
--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -272,6 +272,8 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      source_branch: ${{ github.event.workflow_run.head_branch || '' }}
+      source_commit: ${{ needs.resolve-inputs.outputs.source_sha }}
       artifact_pattern: sdk-offline-package-*
       artifact_glob: "**/*"
       min_artifact_count: 6
@@ -289,3 +291,5 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      source_branch: ${{ github.event.workflow_run.head_branch || '' }}
+      source_commit: ${{ needs.resolve-inputs.outputs.source_sha }}


### PR DESCRIPTION
## Summary

Pass the triggering Docker build's branch and SHA to the reusable Vulcan publish and latest-tag workflows.

## Root cause

The offline-bundle workflow runs via `workflow_run`; its own GitHub ref/SHA identify the default branch rather than the triggering SDK build. A successful feature build could consequently update the `sdk/main` artifact channel.

## Result

- `sdk` remains the latest successful `main` build.
- `sdk@develop` tracks `develop`.
- `sdk@branch` tracks that branch.

## Validation

- YAML parse of `offline-sdk-bundle.yml`
- `git diff --check`

## Dependency

Requires [sima-neat/.github#113](https://github.com/sima-neat/.github/pull/113), which adds the reusable workflow inputs.

Fixes #123