### PR TITLE
Promote workflow-run artifact source fix to main

### DIFF
--- a/.github/workflows/offline-sdk-bundle.yml
+++ b/.github/workflows/offline-sdk-bundle.yml
@@ -272,6 +272,8 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      source_branch: ${{ github.event.workflow_run.head_branch || '' }}
+      source_commit: ${{ needs.resolve-inputs.outputs.source_sha }}
       artifact_pattern: sdk-offline-package-*
       artifact_glob: "**/*"
       min_artifact_count: 6
@@ -289,3 +291,5 @@ jobs:
     with:
       aws_region: us-west-2
       environment_name: ${{ vars.VULCAN_ENV || 'production' }}
+      source_branch: ${{ github.event.workflow_run.head_branch || '' }}
+      source_commit: ${{ needs.resolve-inputs.outputs.source_sha }}


### PR DESCRIPTION
## Summary

Promotes the merged workflow-run artifact source-context fix from `develop` to `main`.

## Impact

Unqualified `sima-cli neat install sdk` continues to resolve the latest successful `main` artifact, while branch-qualified SDK installs retain their own branch channels.

Fixes #123