### PR TITLE
Hotfix release-line artifact retargeting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -592,14 +592,14 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ vars.VULCAN_ENV || 'production' }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
       - name: Download image metadata
         uses: actions/download-artifact@v7
         with:
           name: image-promotion-metadata
           path: .smoke
-
-      - name: Check out repository
-        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary

Fixes the tagged SDK release-line retarget job deleting its downloaded image metadata.

## Root cause

The job downloaded `image-promotion-metadata` into `.smoke` before `actions/checkout@v5`. Checkout's default clean step then removed the untracked directory, causing `find .smoke` to fail.

## Change

Run checkout before downloading the artifact, matching the ordering used by the workflow's other artifact-consuming jobs.

## Validation

- Verified the workflow diff only reorders these two steps.
- Confirmed structurally that checkout precedes the metadata download in the retarget job.

Closes #129.