### PR TITLE
Fix release-line artifact retargeting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -592,14 +592,14 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ vars.VULCAN_ENV || 'production' }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
       - name: Download image metadata
         uses: actions/download-artifact@v7
         with:
           name: image-promotion-metadata
           path: .smoke
-
-      - name: Check out repository
-        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary

Applies the release-line retarget metadata-ordering fix to `develop`.

## Root cause

`actions/checkout@v5` ran after downloading `image-promotion-metadata` to `.smoke`. Its default clean operation removed the downloaded metadata before the retarget step consumed it.

## Change

Run checkout before downloading the artifact, consistent with the workflow's other artifact-consuming jobs.

## Validation

- Verified the PR contains only the three-line checkout/artifact-download reorder.
- Confirmed the retarget job checks out before downloading metadata.

Closes #129.