### PR TITLE
Use Buildx registry cache for SDK images

### DIFF
--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -89,6 +89,11 @@ jobs:
               return !liveBranchSlugs.has(tag);
             }
 
+            function cacheBranchSlug(tag) {
+              const match = tag.match(/^(.*)-(x86_64|aarch64)$/);
+              return match ? match[1] : '';
+            }
+
             async function paginate(route, parameters) {
               return github.paginate(route, {
                 per_page: 100,
@@ -374,5 +379,65 @@ jobs:
               core.info(
                 `sdk: deleted ${deletedCanonical} deleted-branch-only version(s), ` +
                 `kept ${keptCanonical} version(s), skipped ${skippedCanonical} mixed-tag version(s).`,
+              );
+            }
+
+            if (!(await packageExists('sdk-buildcache'))) {
+              core.info('sdk-buildcache: package does not exist; skipping cache cleanup.');
+            } else {
+              const versions = await paginate(
+                'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
+                {
+                  org: owner,
+                  package_type: 'container',
+                  package_name: 'sdk-buildcache',
+                },
+              );
+              const untaggedRetentionMs = 7 * 24 * 60 * 60 * 1000;
+              const untaggedCutoff = Date.now() - untaggedRetentionMs;
+              let deletedCache = 0;
+              let keptCache = 0;
+              let skippedCache = 0;
+
+              for (const version of versions) {
+                const tags = version.metadata?.container?.tags ?? [];
+                if (tags.length === 0) {
+                  const updatedAt = Date.parse(version.updated_at || version.created_at || '');
+                  if (Number.isFinite(updatedAt) && updatedAt < untaggedCutoff) {
+                    await deletePackageVersion('sdk-buildcache', version);
+                    deletedCache += 1;
+                  } else {
+                    keptCache += 1;
+                  }
+                  continue;
+                }
+
+                const deletedBranchTags = tags.filter((tag) => {
+                  const slug = cacheBranchSlug(tag);
+                  return slug && !branchSlugs.has(slug);
+                });
+                if (deletedBranchTags.length === 0) {
+                  keptCache += 1;
+                  continue;
+                }
+
+                const retainedTags = tags.filter((tag) => !deletedBranchTags.includes(tag));
+                if (retainedTags.length > 0) {
+                  skippedCache += 1;
+                  core.warning(
+                    `sdk-buildcache: version ${version.id} has deleted-branch cache tag(s) ` +
+                    `[${deletedBranchTags.join(', ')}] but also retained tag(s) ` +
+                    `[${retainedTags.join(', ')}]; keeping the version.`,
+                  );
+                  continue;
+                }
+
+                await deletePackageVersion('sdk-buildcache', version);
+                deletedCache += 1;
+              }
+
+              core.info(
+                `sdk-buildcache: deleted ${deletedCache} stale version(s), ` +
+                `kept ${keptCache} version(s), skipped ${skippedCache} mixed-tag version(s).`,
               );
             }

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,6 +53,7 @@ jobs:
         id: image
         env:
           IMAGE_SUFFIX: ${{ matrix.image_suffix }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           set -euo pipefail
 
@@ -70,8 +71,15 @@ jobs:
           echo "name=ghcr.io/${owner}/${repo}" >> "${GITHUB_OUTPUT}"
 
           cache_ref_name="${GITHUB_REF_NAME}"
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${GITHUB_BASE_REF:-}" ]]; then
-            cache_ref_name="${GITHUB_BASE_REF}"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # Fork PRs can consume only the trusted develop cache. Same-repository
+            # PRs may additionally consume the cache previously written by their
+            # source branch, while remaining read-only below.
+            cache_ref_name="develop"
+            if [[ "${PR_HEAD_REPOSITORY:-}" == "${GITHUB_REPOSITORY}" &&
+                  -n "${GITHUB_HEAD_REF:-}" ]]; then
+              cache_ref_name="${GITHUB_HEAD_REF}"
+            fi
           elif [[ "${GITHUB_REF}" == refs/tags/v* ]] &&
                [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.] ]]; then
             cache_ref_name="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -40,15 +40,22 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
-      - name: Run SDK package installer tests
-        run: tests/sdk/test-install-sdk-stub.sh
+      - name: Run SDK build and package tests
+        run: |
+          tests/sdk/test-install-sdk-stub.sh
+          tests/sdk/test-neat-deps.sh
+          tests/sdk/test-build-script.sh
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Compute image name
         id: image
+        env:
+          IMAGE_SUFFIX: ${{ matrix.image_suffix }}
         run: |
+          set -euo pipefail
+
           owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
           if [[ "${GITHUB_REF}" == refs/heads/main || "${GITHUB_REF}" == refs/tags/v* ]]; then
             repo="sdk"
@@ -62,27 +69,57 @@ jobs:
           fi
           echo "name=ghcr.io/${owner}/${repo}" >> "${GITHUB_OUTPUT}"
 
-      - name: Build Docker image
-        run: ./build.sh sdk "${IMAGE_TAG}"
-        env:
-          IMAGE_TAG: ci-${{ matrix.image_suffix }}
+          cache_ref_name="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" && -n "${GITHUB_BASE_REF:-}" ]]; then
+            cache_ref_name="${GITHUB_BASE_REF}"
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]] &&
+               [[ "${GITHUB_REF_NAME}" =~ ^v([0-9]+)[.]([0-9]+)[.] ]]; then
+            cache_ref_name="release-${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          fi
+          cache_scope="$(echo "${cache_ref_name}" | tr '[:upper:]' '[:lower:]')"
+          cache_scope="$(echo "${cache_scope}" | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+          if [[ -z "${cache_scope}" ]]; then
+            cache_scope="branch"
+          fi
+          cache_ref="ghcr.io/${owner}/sdk-buildcache:${cache_scope}-${IMAGE_SUFFIX}"
+          base_cache_ref="ghcr.io/${owner}/sdk-buildcache:develop-${IMAGE_SUFFIX}"
+          echo "cache_ref=${cache_ref}" >> "${GITHUB_OUTPUT}"
+          if [[ "${cache_ref}" == "${base_cache_ref}" ]]; then
+            echo "cache_from=${cache_ref}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "cache_from=${cache_ref} ${base_cache_ref}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish architecture image
-        if: github.event_name != 'pull_request'
+      - name: Build Docker image
         run: |
-          docker tag "sdk:ci-${IMAGE_SUFFIX}" "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
-          docker push "${IMAGE_NAME}:${GITHUB_SHA}-${IMAGE_SUFFIX}"
+          set -euo pipefail
+
+          export BUILDX_CACHE_FROM="${CACHE_FROM}"
+          export BUILDX_PROVENANCE=false
+
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            export BUILDX_OUTPUT=load
+            ./build.sh sdk "ci-${IMAGE_SUFFIX}"
+          else
+            export BUILDX_OUTPUT=push
+            if [[ "${GITHUB_REF_TYPE}" == "branch" ]]; then
+              export BUILDX_CACHE_TO="${CACHE_REF}"
+            fi
+            ./build.sh "${IMAGE_NAME}" "${GITHUB_SHA}-${IMAGE_SUFFIX}"
+          fi
         env:
           IMAGE_NAME: ${{ steps.image.outputs.name }}
           IMAGE_SUFFIX: ${{ matrix.image_suffix }}
+          CACHE_REF: ${{ steps.image.outputs.cache_ref }}
+          CACHE_FROM: ${{ steps.image.outputs.cache_from }}
+          DOCKER_PLATFORM: ${{ matrix.platform }}
 
   publish-manifest:
     name: Publish multi-arch manifest

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,6 @@ RUN chmod 755 /usr/local/bin/install-cross-toolchain.sh && \
 FROM ${SDK_BASE_IMAGE}
 
 ARG SDK_PKG_LIST
-ARG SDK_GIT_BRANCH=unknown
-ARG SDK_GIT_HASH=nogit
-ARG SDK_RELEASE_REF=unknown-nogit
 ARG BASE_SDK_VERSION=2.1.2
 ARG MINIMAL_IMAGE=0
 ARG NEAT_BRANCH=main
@@ -41,11 +38,6 @@ ENV PIP_DEFAULT_TIMEOUT=120
 ENV PIP_RETRIES=10
 ENV RUSTUP_HOME=/opt/toolchain/rust
 ENV CARGO_HOME=/opt/toolchain/rust
-ENV SDK_GIT_BRANCH="${SDK_GIT_BRANCH}"
-ENV SDK_RELEASE_REF="${SDK_RELEASE_REF}"
-ENV SDK_IMAGE_BRANCH="${SDK_GIT_BRANCH}"
-ENV SDK_IMAGE_TAG="${SDK_RELEASE_REF}"
-ENV SDK_PROMPT_HOSTNAME="neat-sdk-${SDK_RELEASE_REF}"
 ENV PATH="${OPENVSCODE_SERVER_DIR}/bin:${NEAT_INSIGHT_VENV_DIR}/bin:${CARGO_HOME}/bin:${PATH}"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -154,7 +146,6 @@ RUN chmod 755 /usr/local/bin/pin-cross-toolchain.sh && \
     rm -f /tmp/cross-smoke.o /tmp/cross-smoke.c /tmp/cross-smoke.cpp /tmp/cross-smoke-cxx
 
 COPY config/platform-package-patterns.txt /usr/local/share/sima-sdk/platform-package-patterns.txt
-COPY deps/manifest.json /usr/local/share/sima-sdk/deps/manifest.json
 COPY scripts/configure-apt-repos.sh /usr/local/bin/configure-apt-repos.sh
 
 RUN chmod 755 /usr/local/bin/configure-apt-repos.sh && \
@@ -175,7 +166,6 @@ COPY scripts/simaai_setup_sdk.py /opt/bin/simaai_setup_sdk.py
 COPY scripts/install-rustup.sh /usr/local/bin/install-rustup.sh
 COPY scripts/install-sima-cli.sh /usr/local/bin/install-sima-cli.sh
 COPY scripts/sima-code.sh /usr/local/bin/sima-code
-COPY scripts/neat-deps.sh /usr/local/bin/neat-deps.sh
 COPY scripts/setup-sdk-sysroot.sh /usr/local/bin/setup-sdk-sysroot.sh
 COPY scripts/validate-sysroot-package-versions.sh /usr/local/bin/validate-sysroot-package-versions.sh
 RUN chmod 755 /opt/bin/simaai-init-build-env \
@@ -183,7 +173,6 @@ RUN chmod 755 /opt/bin/simaai-init-build-env \
               /usr/local/bin/install-rustup.sh \
               /usr/local/bin/install-sima-cli.sh \
               /usr/local/bin/sima-code \
-              /usr/local/bin/neat-deps.sh \
               /usr/local/bin/setup-sdk-sysroot.sh \
               /usr/local/bin/validate-sysroot-package-versions.sh
 
@@ -194,7 +183,6 @@ RUN getent group docker >/dev/null || groupadd --system docker
 RUN install-rustup.sh
 
 RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
-    install-sima-cli.sh && \
     cp -a /opt/bookworm-cross-toolchain/. / && \
     pin-cross-toolchain.sh && \
     aarch64-linux-gnu-gcc --version && \
@@ -206,9 +194,24 @@ RUN setup-sdk-sysroot.sh "${BASE_SDK_VERSION}" "${SDK_PKG_LIST}" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*.deb /tmp/*
 
+# sima-cli uses /etc/sdk-release to distinguish a Palette SDK from a generic
+# Linux host. Keep this build-time marker stable so dependency layers are not
+# invalidated by the branch/commit identity written into the final image.
+RUN printf 'Platform Version = %s\nSDK Version = %s_Palette_SDK\n' \
+      "${BASE_SDK_VERSION}" "${BASE_SDK_VERSION}" > /etc/sdk-release
+
+ARG SIMA_CLI_REF
+ARG SIMA_CLI_VERSION
+RUN SIMA_CLI_REF="${SIMA_CLI_REF}" \
+    SIMA_CLI_VERSION="${SIMA_CLI_VERSION}" \
+    install-sima-cli.sh && \
+    rm -rf /tmp/*
+
 COPY scripts/install-sysroot-overlay.sh /usr/local/bin/install-sysroot-overlay.sh
 COPY scripts/install-sdk-sysroot-overlay.sh /usr/local/bin/install-sdk-sysroot-overlay.sh
 COPY scripts/sysroot.sh /usr/local/bin/sysroot
+COPY scripts/neat-deps.sh /usr/local/bin/neat-deps.sh
+COPY deps/manifest.json /usr/local/share/sima-sdk/deps/manifest.json
 COPY config/sysroot-overlay.conf /usr/local/share/sima-sdk/sysroot-overlay.conf
 COPY config/supervisor-neat-insight.conf /etc/supervisor/conf.available/neat-insight.conf
 COPY config/supervisor-openvscode.conf /etc/supervisor/conf.available/openvscode.conf
@@ -221,6 +224,7 @@ COPY scripts/devkit-sync-rsync.sh /usr/local/bin/devkit-sync-rsync.sh
 RUN chmod 755 /usr/local/bin/install-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/install-sdk-sysroot-overlay.sh && \
     chmod 755 /usr/local/bin/sysroot && \
+    chmod 755 /usr/local/bin/neat-deps.sh && \
     chmod 755 /usr/local/bin/docker-entrypoint.sh && \
     chmod 755 /usr/local/bin/insight-admin && \
     chmod 755 /usr/local/bin/neat-insight-supervised && \
@@ -241,6 +245,30 @@ COPY config/profile.d/*.sh /etc/profile.d/
 RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
               /etc/profile.d/pkg-config-sysroot.sh
 
+WORKDIR /workspace
+
+# Preinstall Neat Framework and resources
+COPY scripts/install-neat-resources.sh /usr/local/bin/install-neat-resources.sh
+RUN chmod 755 /usr/local/bin/install-neat-resources.sh
+ARG NEAT_CORE_SOURCE_REF=
+ARG NEAT_APPS_SOURCE_REF=
+RUN NEAT_CORE_SOURCE_REF="${NEAT_CORE_SOURCE_REF}" \
+    NEAT_APPS_SOURCE_REF="${NEAT_APPS_SOURCE_REF}" \
+    install-neat-resources.sh
+
+# Apply volatile build identity only after the stable SDK/toolchain/resource layers. Keeping these
+# values at the tail lets closely related images reuse the large layers below them.
+ARG SDK_GIT_BRANCH=unknown
+ARG SDK_GIT_HASH=nogit
+ARG SDK_RELEASE_REF=unknown-nogit
+ENV SDK_GIT_BRANCH="${SDK_GIT_BRANCH}"
+ENV SDK_RELEASE_REF="${SDK_RELEASE_REF}"
+ENV SDK_IMAGE_BRANCH="${SDK_GIT_BRANCH}"
+ENV SDK_IMAGE_TAG="${SDK_RELEASE_REF}"
+ENV SDK_PROMPT_HOSTNAME="neat-sdk-${SDK_RELEASE_REF}"
+LABEL org.opencontainers.image.source="https://github.com/sima-neat/sdk" \
+      org.opencontainers.image.revision="${SDK_GIT_HASH}" \
+      org.opencontainers.image.version="${SDK_RELEASE_REF}"
 RUN if printf '%s' "${SDK_RELEASE_REF}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+'; then \
       printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
         "${SDK_RELEASE_REF}" \
@@ -254,13 +282,6 @@ RUN if printf '%s' "${SDK_RELEASE_REF}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+';
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
         "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}"; \
     fi > /etc/sdk-release
-
-WORKDIR /workspace
-
-# Preinstall Neat Framework and resources
-COPY scripts/install-neat-resources.sh /usr/local/bin/install-neat-resources.sh
-RUN chmod 755 /usr/local/bin/install-neat-resources.sh
-RUN install-neat-resources.sh
 
 # Expose required ports
 EXPOSE 9900 9999 10000 9000-9079 9100-9179 8081 8554

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/scripts/neat-deps.sh"
+
 DOCKERFILE="${DOCKERFILE:-${SCRIPT_DIR}/Dockerfile}"
 CONTEXT_DIR="${CONTEXT_DIR:-${SCRIPT_DIR}}"
 IMAGE_NAME="${IMAGE_NAME:-sdk}"
@@ -17,6 +20,18 @@ NEAT_VERSION="${NEAT_VERSION:-latest}"
 NEAT_CORE_TARGET="${NEAT_CORE_TARGET:-}"
 NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH:-}"
 NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION:-}"
+NEAT_CORE_SOURCE_REF="${NEAT_CORE_SOURCE_REF:-$(
+  neat_resolve_dependency_source_ref core https://github.com/sima-neat/core.git
+)}"
+NEAT_APPS_SOURCE_REF="${NEAT_APPS_SOURCE_REF:-$(
+  neat_resolve_dependency_source_ref apps https://github.com/sima-neat/apps.git
+)}"
+SIMA_CLI_REF="${SIMA_CLI_REF:-$(neat_dependency_ref sima-cli)}"
+SIMA_CLI_VERSION="${SIMA_CLI_VERSION:-}"
+BUILDX_OUTPUT="${BUILDX_OUTPUT:-load}"
+BUILDX_CACHE_FROM="${BUILDX_CACHE_FROM:-}"
+BUILDX_CACHE_TO="${BUILDX_CACHE_TO:-}"
+BUILDX_PROVENANCE="${BUILDX_PROVENANCE:-}"
 
 usage() {
   cat <<EOF
@@ -39,6 +54,14 @@ Environment overrides:
   NEAT_CORE_TARGET  Override the Neat Core Vulcan package target from deps/manifest.json
   NEAT_INSIGHT_BRANCH  Override the Insight branch/release channel from deps/manifest.json
   NEAT_INSIGHT_VERSION  Override the Insight version/tag from deps/manifest.json
+  NEAT_CORE_SOURCE_REF  Override the Core source commit resolved from deps/manifest.json
+  NEAT_APPS_SOURCE_REF  Override the Apps source commit resolved from deps/manifest.json
+  SIMA_CLI_REF  Override the sima-cli release or branch ref from deps/manifest.json
+  SIMA_CLI_VERSION  Override the sima-cli branch artifact version (default: manifest spec or latest)
+  BUILDX_OUTPUT  Buildx output mode: load, push, or cache-only (default: ${BUILDX_OUTPUT})
+  BUILDX_CACHE_FROM  Optional space-separated Buildx registry cache import references
+  BUILDX_CACHE_TO  Optional Buildx registry cache export reference
+  BUILDX_PROVENANCE  Optional Buildx provenance setting, e.g. false
 EOF
 }
 
@@ -74,6 +97,45 @@ fi
 if [[ ! -f "${DOCKERFILE}" ]]; then
   echo "Dockerfile not found: ${DOCKERFILE}" >&2
   exit 1
+fi
+
+if [[ "${SIMA_CLI_REF}" == *:* ]]; then
+  sima_cli_ref_spec="${SIMA_CLI_REF#*:}"
+  SIMA_CLI_REF="${SIMA_CLI_REF%%:*}"
+  SIMA_CLI_VERSION="${SIMA_CLI_VERSION:-${sima_cli_ref_spec}}"
+else
+  SIMA_CLI_VERSION="${SIMA_CLI_VERSION:-latest}"
+fi
+
+if [[ "${SIMA_CLI_REF}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([A-Za-z0-9_.-]+)?$ ]]; then
+  if [[ "${SIMA_CLI_VERSION}" != "latest" ]]; then
+    echo "A sima-cli PyPI release ref such as ${SIMA_CLI_REF} must not specify an artifact version." >&2
+    exit 1
+  fi
+else
+  if [[ ! "${SIMA_CLI_REF}" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "Unsupported sima-cli branch ref: ${SIMA_CLI_REF}" >&2
+    exit 1
+  fi
+  if [[ "${SIMA_CLI_VERSION}" == "latest" ]]; then
+    sima_cli_ref_key="$(python3 - "${SIMA_CLI_REF}" <<'PY'
+import sys
+import urllib.parse
+
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+)"
+    SIMA_CLI_VERSION="$(
+      curl --fail --silent --show-error --location --retry 3 \
+        "https://artifacts.neat.sima.ai/sima-cli/${sima_cli_ref_key}/latest.tag"
+    )"
+    SIMA_CLI_VERSION="${SIMA_CLI_VERSION//$'\r'/}"
+    SIMA_CLI_VERSION="${SIMA_CLI_VERSION//$'\n'/}"
+  fi
+  if [[ ! "${SIMA_CLI_VERSION}" =~ ^[A-Fa-f0-9]+$ ]]; then
+    echo "Resolved sima-cli artifact version must be a hexadecimal commit identifier: ${SIMA_CLI_VERSION}" >&2
+    exit 1
+  fi
 fi
 
 git_branch="$(git -C "${SCRIPT_DIR}" branch --show-current 2>/dev/null || true)"
@@ -144,11 +206,14 @@ echo "NEAT version: ${NEAT_VERSION}"
 echo "NEAT Core target override: ${NEAT_CORE_TARGET:-<deps/manifest.json>}"
 echo "NEAT Insight branch override: ${NEAT_INSIGHT_BRANCH:-<deps/manifest.json>}"
 echo "NEAT Insight version override: ${NEAT_INSIGHT_VERSION:-<deps/manifest.json>}"
+echo "NEAT Core source commit: ${NEAT_CORE_SOURCE_REF}"
+echo "NEAT Apps source commit: ${NEAT_APPS_SOURCE_REF}"
+echo "sima-cli ref: ${SIMA_CLI_REF}"
+echo "sima-cli artifact version: ${SIMA_CLI_VERSION}"
 
 if docker buildx version >/dev/null 2>&1; then
   buildx_cmd=(
     docker buildx build
-    --load
     --platform "${docker_platform}"
     --build-arg MINIMAL_IMAGE="${MINIMAL_IMAGE}"
     --build-arg SDK_BASE_IMAGE="${SDK_BASE_IMAGE}"
@@ -159,14 +224,52 @@ if docker buildx version >/dev/null 2>&1; then
     --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"
     --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
     --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
+    --build-arg NEAT_CORE_SOURCE_REF="${NEAT_CORE_SOURCE_REF}"
+    --build-arg NEAT_APPS_SOURCE_REF="${NEAT_APPS_SOURCE_REF}"
+    --build-arg SIMA_CLI_REF="${SIMA_CLI_REF}"
+    --build-arg SIMA_CLI_VERSION="${SIMA_CLI_VERSION}"
     --build-arg SDK_GIT_BRANCH="${git_branch}"
     --build-arg SDK_GIT_HASH="${git_hash}"
     --build-arg SDK_RELEASE_REF="${sdk_release_ref}"
     -f "${DOCKERFILE}"
     -t "${image_ref}"
   )
+
+  case "${BUILDX_OUTPUT}" in
+    load)
+      buildx_cmd+=(--load)
+      ;;
+    push)
+      buildx_cmd+=(--push)
+      ;;
+    cache-only)
+      ;;
+    *)
+      echo "Unsupported BUILDX_OUTPUT: ${BUILDX_OUTPUT} (expected load, push, or cache-only)" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ -n "${BUILDX_CACHE_FROM}" ]]; then
+    read -r -a cache_from_refs <<< "${BUILDX_CACHE_FROM}"
+    for cache_from_ref in "${cache_from_refs[@]}"; do
+      buildx_cmd+=(--cache-from "type=registry,ref=${cache_from_ref}")
+    done
+  fi
+  if [[ -n "${BUILDX_CACHE_TO}" ]]; then
+    buildx_cmd+=(--cache-to "type=registry,ref=${BUILDX_CACHE_TO},mode=max,oci-mediatypes=true,image-manifest=true")
+  fi
+  if [[ -n "${BUILDX_PROVENANCE}" ]]; then
+    buildx_cmd+=(--provenance="${BUILDX_PROVENANCE}")
+  fi
+
   buildx_cmd+=("${CONTEXT_DIR}")
   exec "${buildx_cmd[@]}"
+fi
+
+if [[ "${BUILDX_OUTPUT}" != "load" || -n "${BUILDX_CACHE_FROM}${BUILDX_CACHE_TO}" ]]; then
+  echo "Buildx is required for output mode '${BUILDX_OUTPUT}' and registry cache support." >&2
+  exit 1
 fi
 
 build_cmd=(
@@ -181,6 +284,10 @@ build_cmd=(
   --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"
   --build-arg NEAT_INSIGHT_BRANCH="${NEAT_INSIGHT_BRANCH}"
   --build-arg NEAT_INSIGHT_VERSION="${NEAT_INSIGHT_VERSION}"
+  --build-arg NEAT_CORE_SOURCE_REF="${NEAT_CORE_SOURCE_REF}"
+  --build-arg NEAT_APPS_SOURCE_REF="${NEAT_APPS_SOURCE_REF}"
+  --build-arg SIMA_CLI_REF="${SIMA_CLI_REF}"
+  --build-arg SIMA_CLI_VERSION="${SIMA_CLI_VERSION}"
   --build-arg SDK_GIT_BRANCH="${git_branch}"
   --build-arg SDK_GIT_HASH="${git_hash}"
   --build-arg SDK_RELEASE_REF="${sdk_release_ref}"

--- a/deps/manifest.json
+++ b/deps/manifest.json
@@ -2,6 +2,12 @@
   "core": {
     "ref": "v0.3.0"
   },
+  "apps": {
+    "ref": "main:latest"
+  },
+  "sima-cli": {
+    "ref": "v2.1.15"
+  },
   "insight": {
     "ref": "v0.0.6"
   },

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -30,6 +30,27 @@ Build with a custom image name and tag:
 ./build.sh sdk 2.1.2
 ```
 
+By default, `build.sh` loads the completed native-architecture image into the local Docker
+daemon. It can instead push directly from Buildx, avoiding a second local image load and
+registry upload:
+
+```bash
+BUILDX_OUTPUT=push ./build.sh ghcr.io/sima-neat/sdk test
+```
+
+The helper also supports a registry-backed BuildKit cache:
+
+```bash
+BUILDX_OUTPUT=push \
+BUILDX_CACHE_FROM=ghcr.io/sima-neat/sdk-buildcache:develop-x86_64 \
+BUILDX_CACHE_TO=ghcr.io/sima-neat/sdk-buildcache:my-branch-x86_64 \
+./build.sh ghcr.io/sima-neat/sdk-my-branch test-x86_64
+```
+
+`BUILDX_CACHE_FROM` and `BUILDX_CACHE_TO` are cache references, not runnable SDK image
+tags. Do not pass credentials, tokens, or other secrets through Docker build arguments or
+write them into cached layers.
+
 The build helper supports both `aarch64` and `x86_64` hosts and automatically selects the matching Docker platform for the current machine.
 
 Example output:
@@ -39,6 +60,32 @@ Building sdk:latest
 Host architecture: arm64
 Docker platform: linux/arm64
 ```
+
+## CI Build Cache
+
+The Docker build workflow publishes each native-architecture image directly from Buildx.
+Branch builds import both their independent GHCR cache tag and the `develop` fallback,
+then update only their own tag in the `sdk-buildcache` package. The architecture suffix
+prevents x86_64 and aarch64 writers from colliding.
+Pull requests import the target branch cache but do not update it, so untrusted or
+speculative changes cannot poison a shared cache. Release tags reuse the matching
+`release-X.Y` cache without modifying it.
+
+The cleanup workflow removes cache versions belonging only to deleted branches and prunes
+untagged cache versions after seven days. The package is an implementation detail of CI;
+SDK consumers should continue pulling images from the normal `sdk` or branch-specific SDK
+packages.
+
+Neat Core and Neat Apps source trees embedded in the image are selected by the `ref` values
+in `deps/manifest.json`. Before Buildx starts, `build.sh` resolves release tags and
+`branch:latest` references to full Git commit SHAs. Those resolved commits become Docker
+build arguments, so moving a branch invalidates the source-installation layer without
+duplicating package and source selections in the manifest.
+
+The `sima-cli` dependency is also selected by `deps/manifest.json`. Release refs such as
+`v2.1.15` install that exact PyPI version. A branch ref may use `main:latest`; `build.sh`
+resolves `latest.tag` before invoking Buildx and passes the resulting artifact commit into
+the Docker build, so a new branch artifact invalidates the cached installation layer.
 
 ## Add Sysroot Packages
 

--- a/scripts/install-neat-resources.sh
+++ b/scripts/install-neat-resources.sh
@@ -3,11 +3,39 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/neat-deps.sh"
 
 mkdir -p /neat-resources/core-extra /neat-resources/core-src /neat-resources/apps-src
 
 core_target="${NEAT_CORE_TARGET:-$(neat_dependency_target core core)}"
+core_source_ref="${NEAT_CORE_SOURCE_REF:?NEAT_CORE_SOURCE_REF is required}"
+apps_source_ref="${NEAT_APPS_SOURCE_REF:?NEAT_APPS_SOURCE_REF is required}"
+
+clone_at_commit() {
+  local repository="$1"
+  local destination="$2"
+  local commit="$3"
+
+  if [[ ! "${commit}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Source revision for ${repository} must be a full Git commit SHA: ${commit}" >&2
+    return 1
+  fi
+
+  git init --quiet "${destination}"
+  git -C "${destination}" remote add origin "${repository}"
+  git -C "${destination}" fetch --quiet --depth 1 origin "${commit}"
+  git -C "${destination}" checkout --quiet --detach FETCH_HEAD
+
+  local resolved expected
+  resolved="$(git -C "${destination}" rev-parse HEAD)"
+  resolved="$(printf '%s' "${resolved}" | tr '[:upper:]' '[:lower:]')"
+  expected="$(printf '%s' "${commit}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${resolved}" != "${expected}" ]]; then
+    echo "Resolved ${repository} to ${resolved}, expected ${commit}." >&2
+    return 1
+  fi
+}
 
 (
   cd /neat-resources/core-extra
@@ -18,8 +46,10 @@ core_target="${NEAT_CORE_TARGET:-$(neat_dependency_target core core)}"
 find /neat-resources/core-extra -type f \
   \( -name '*.deb' -o -name '*.tar.gz' -o -name '*.whl' \) -delete
 
-git clone --depth 1 https://github.com/sima-neat/core.git /neat-resources/core-src
-git clone --depth 1 https://github.com/sima-neat/apps.git /neat-resources/apps-src
+echo "Installing Neat Core source at ${core_source_ref}"
+clone_at_commit https://github.com/sima-neat/core.git /neat-resources/core-src "${core_source_ref}"
+echo "Installing Neat Apps source at ${apps_source_ref}"
+clone_at_commit https://github.com/sima-neat/apps.git /neat-resources/apps-src "${apps_source_ref}"
 
 chown -R root:root /neat-resources
 chmod -R go-w /neat-resources

--- a/scripts/install-sima-cli.sh
+++ b/scripts/install-sima-cli.sh
@@ -4,11 +4,39 @@ set -euo pipefail
 
 root_venv=/root/.sima-cli/.venv
 install_venv=/opt/sima-cli/venv
+installer=/tmp/sima-cli-install.py
+installer_url=https://artifacts.neat.sima.ai/sima-cli/install.py
+installer_sha256=9d7acf0bfb24f7b32abd305754359744f1034bbd1a440b6310037eef90696c25
+sima_cli_ref="${SIMA_CLI_REF:?SIMA_CLI_REF is required}"
+sima_cli_version="${SIMA_CLI_VERSION:?SIMA_CLI_VERSION is required}"
 
-if ! curl -fsSL https://artifacts.neat.sima.ai/sima-cli/linux-mac.sh | bash; then
-  test -x "${root_venv}/bin/sima-cli"
+curl --fail --silent --show-error --location --retry 3 \
+  "${installer_url}" \
+  --output "${installer}"
+printf '%s  %s\n' "${installer_sha256}" "${installer}" | sha256sum --check -
+
+if [[ "${sima_cli_ref}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([A-Za-z0-9_.-]+)?$ ]]; then
+  if [[ "${sima_cli_version}" != "latest" ]]; then
+    echo "PyPI release ref ${sima_cli_ref} does not accept an artifact version." >&2
+    exit 1
+  fi
+  python3 "${installer}" "${sima_cli_ref}" --noninteractive
+else
+  python3 "${installer}" "${sima_cli_ref}" "${sima_cli_version}" --noninteractive
 fi
+
 test -x "${root_venv}/bin/sima-cli"
+if [[ "${sima_cli_ref}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+([A-Za-z0-9_.-]+)?$ ]]; then
+  installed_version="$(
+    "${root_venv}/bin/python" -c \
+      'import importlib.metadata; print(importlib.metadata.version("sima-cli"))'
+  )"
+  if [[ "v${installed_version}" != "${sima_cli_ref}" ]]; then
+    echo "Installed sima-cli ${installed_version}, expected ${sima_cli_ref}." >&2
+    exit 1
+  fi
+fi
+
 rm -rf /opt/sima-cli
 mkdir -p /opt/sima-cli
 cp -a "${root_venv}" "${install_venv}"

--- a/scripts/neat-deps.sh
+++ b/scripts/neat-deps.sh
@@ -93,3 +93,52 @@ raise SystemExit(
 )
 PY
 }
+
+neat_dependency_ref() {
+  local key="$1"
+  local marker="manifest-ref"
+  local target
+
+  target="$(neat_dependency_target "${key}" "${marker}")"
+  printf '%s\n' "${target#"${marker}"@}"
+}
+
+neat_resolve_git_ref() {
+  local repository="$1"
+  local spec="$2"
+  local branch version refs resolved
+
+  if [[ "${spec}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    printf '%s\n' "${spec}" | tr '[:upper:]' '[:lower:]'
+    return
+  fi
+
+  if [[ "${spec}" == *:* ]]; then
+    branch="${spec%%:*}"
+    version="${spec#*:}"
+    if [[ -z "${branch}" || "${version}" != "latest" ]]; then
+      echo "Git source refs must use branch:latest, a tag, or a full commit SHA: ${spec}" >&2
+      return 1
+    fi
+    resolved="$(git ls-remote "${repository}" "refs/heads/${branch}" | awk 'NR == 1 {print $1}')"
+  else
+    refs="$(git ls-remote "${repository}" "refs/tags/${spec}" "refs/tags/${spec}^{}")"
+    resolved="$(awk '$2 ~ /\^\{\}$/ {print $1; exit}' <<< "${refs}")"
+    if [[ -z "${resolved}" ]]; then
+      resolved="$(awk 'NR == 1 {print $1}' <<< "${refs}")"
+    fi
+  fi
+
+  if [[ ! "${resolved}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "Unable to resolve ${repository} ref ${spec} to a full Git commit SHA." >&2
+    return 1
+  fi
+  printf '%s\n' "${resolved}" | tr '[:upper:]' '[:lower:]'
+}
+
+neat_resolve_dependency_source_ref() {
+  local key="$1"
+  local repository="$2"
+
+  neat_resolve_git_ref "${repository}" "$(neat_dependency_ref "${key}")"
+}

--- a/scripts/neat-deps.sh
+++ b/scripts/neat-deps.sh
@@ -116,11 +116,18 @@ neat_resolve_git_ref() {
   if [[ "${spec}" == *:* ]]; then
     branch="${spec%%:*}"
     version="${spec#*:}"
-    if [[ -z "${branch}" || "${version}" != "latest" ]]; then
-      echo "Git source refs must use branch:latest, a tag, or a full commit SHA: ${spec}" >&2
+    if [[ -z "${branch}" ]]; then
+      echo "Git source refs must include a branch before the version: ${spec}" >&2
       return 1
     fi
-    resolved="$(git ls-remote "${repository}" "refs/heads/${branch}" | awk 'NR == 1 {print $1}')"
+    if [[ "${version}" == "latest" ]]; then
+      resolved="$(git ls-remote "${repository}" "refs/heads/${branch}" | awk 'NR == 1 {print $1}')"
+    elif [[ "${version}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+      resolved="${version}"
+    else
+      echo "Git source refs must use branch:latest, branch:<full-sha>, a tag, or a full commit SHA: ${spec}" >&2
+      return 1
+    fi
   else
     refs="$(git ls-remote "${repository}" "refs/tags/${spec}" "refs/tags/${spec}^{}")"
     resolved="$(awk '$2 ~ /\^\{\}$/ {print $1; exit}' <<< "${refs}")"

--- a/tests/sdk/test-build-script.sh
+++ b/tests/sdk/test-build-script.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+cat > "${TMP_DIR}/bin/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "buildx" && "${2:-}" == "version" ]]; then
+  exit 0
+fi
+
+printf '%s\n' "$@" > "${DOCKER_ARGS_LOG:?}"
+SH
+chmod +x "${TMP_DIR}/bin/docker"
+
+cat > "${TMP_DIR}/bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s' 'abcdef123456'
+SH
+chmod +x "${TMP_DIR}/bin/curl"
+
+run_build() {
+  DOCKER_ARGS_LOG="${TMP_DIR}/docker-args" \
+    PATH="${TMP_DIR}/bin:${PATH}" \
+    DOCKER_PLATFORM=linux/amd64 \
+    NEAT_CORE_SOURCE_REF=1111111111111111111111111111111111111111 \
+    NEAT_APPS_SOURCE_REF=2222222222222222222222222222222222222222 \
+    CONTEXT_DIR="${ROOT_DIR}" \
+    DOCKERFILE="${ROOT_DIR}/Dockerfile" \
+    "$@"
+}
+
+assert_arg() {
+  local expected="$1"
+  if ! grep -Fqx -- "${expected}" "${TMP_DIR}/docker-args"; then
+    echo "Missing expected Docker argument: ${expected}" >&2
+    cat "${TMP_DIR}/docker-args" >&2
+    exit 1
+  fi
+}
+
+BUILDX_OUTPUT=push \
+BUILDX_CACHE_FROM="ghcr.io/sima-neat/sdk-buildcache:test-x86_64 ghcr.io/sima-neat/sdk-buildcache:develop-x86_64" \
+BUILDX_CACHE_TO=ghcr.io/sima-neat/sdk-buildcache:test-x86_64 \
+BUILDX_PROVENANCE=false \
+  run_build "${ROOT_DIR}/build.sh" example/sdk test
+
+assert_arg buildx
+assert_arg build
+assert_arg --push
+assert_arg linux/amd64
+assert_arg type=registry,ref=ghcr.io/sima-neat/sdk-buildcache:develop-x86_64
+assert_arg type=registry,ref=ghcr.io/sima-neat/sdk-buildcache:test-x86_64
+assert_arg type=registry,ref=ghcr.io/sima-neat/sdk-buildcache:test-x86_64,mode=max,oci-mediatypes=true,image-manifest=true
+assert_arg --provenance=false
+assert_arg NEAT_CORE_SOURCE_REF=1111111111111111111111111111111111111111
+assert_arg NEAT_APPS_SOURCE_REF=2222222222222222222222222222222222222222
+assert_arg SIMA_CLI_REF=v2.1.15
+assert_arg SIMA_CLI_VERSION=latest
+assert_arg example/sdk:test
+
+SIMA_CLI_REF=main:latest BUILDX_OUTPUT=load \
+  run_build "${ROOT_DIR}/build.sh" example/sdk branch-cli
+assert_arg SIMA_CLI_REF=main
+assert_arg SIMA_CLI_VERSION=abcdef123456
+assert_arg example/sdk:branch-cli
+
+BUILDX_OUTPUT=load run_build "${ROOT_DIR}/build.sh" example/sdk local
+assert_arg --load
+assert_arg example/sdk:local
+
+if BUILDX_OUTPUT=invalid run_build "${ROOT_DIR}/build.sh" example/sdk invalid >/dev/null 2>&1; then
+  echo "Expected an unsupported Buildx output mode to fail." >&2
+  exit 1
+fi
+
+palette_marker_line="$(grep -nF "SDK Version = %s_Palette_SDK" "${ROOT_DIR}/Dockerfile" | head -n 1 | cut -d: -f1)"
+sima_cli_install_line="$(grep -nF 'install-sima-cli.sh &&' "${ROOT_DIR}/Dockerfile" | tail -n 1 | cut -d: -f1)"
+resource_install_line="$(grep -nF 'install-neat-resources.sh' "${ROOT_DIR}/Dockerfile" | tail -n 1 | cut -d: -f1)"
+release_marker_line="$(grep -nF 'SDK Release = %s' "${ROOT_DIR}/Dockerfile" | head -n 1 | cut -d: -f1)"
+
+if (( palette_marker_line >= sima_cli_install_line )); then
+  echo "The stable Palette SDK marker must exist before sima-cli installs dependencies." >&2
+  exit 1
+fi
+if (( release_marker_line <= resource_install_line )); then
+  echo "The volatile SDK release marker must remain after dependency/resource layers." >&2
+  exit 1
+fi
+
+echo "SDK build helper tests passed."

--- a/tests/sdk/test-neat-deps.sh
+++ b/tests/sdk/test-neat-deps.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/neat-deps.sh"
+
+export SDK_DEPS_MANIFEST="${TMP_DIR}/manifest.json"
+cat > "${SDK_DEPS_MANIFEST}" <<'JSON'
+{
+  "core": {
+    "ref": "v0.3.0"
+  }
+}
+JSON
+
+[[ "$(neat_dependency_target core core)" == "core@v0.3.0" ]]
+[[ "$(neat_dependency_ref core)" == "v0.3.0" ]]
+
+export SDK_DEPS_MANIFEST="${ROOT_DIR}/deps/manifest.json"
+[[ "$(neat_dependency_ref core)" == "v0.3.0" ]]
+[[ "$(neat_dependency_ref apps)" == "main:latest" ]]
+[[ "$(neat_dependency_ref sima-cli)" == "v2.1.15" ]]
+
+git_repo="${TMP_DIR}/git-source"
+git init --quiet "${git_repo}"
+git -C "${git_repo}" config user.name test
+git -C "${git_repo}" config user.email test@example.com
+printf 'source\n' > "${git_repo}/README"
+git -C "${git_repo}" add README
+git -C "${git_repo}" commit --quiet -m source
+git -C "${git_repo}" branch -M main
+git -C "${git_repo}" tag -a v1.0.0 -m v1.0.0
+expected_commit="$(git -C "${git_repo}" rev-parse HEAD)"
+
+[[ "$(neat_resolve_git_ref "${git_repo}" v1.0.0)" == "${expected_commit}" ]]
+[[ "$(neat_resolve_git_ref "${git_repo}" main:latest)" == "${expected_commit}" ]]
+[[ "$(neat_resolve_git_ref "${git_repo}" "${expected_commit}")" == "${expected_commit}" ]]
+
+echo "Neat dependency manifest tests passed."

--- a/tests/sdk/test-neat-deps.sh
+++ b/tests/sdk/test-neat-deps.sh
@@ -38,6 +38,17 @@ expected_commit="$(git -C "${git_repo}" rev-parse HEAD)"
 
 [[ "$(neat_resolve_git_ref "${git_repo}" v1.0.0)" == "${expected_commit}" ]]
 [[ "$(neat_resolve_git_ref "${git_repo}" main:latest)" == "${expected_commit}" ]]
+[[ "$(neat_resolve_git_ref "${git_repo}" "main:${expected_commit}")" == "${expected_commit}" ]]
 [[ "$(neat_resolve_git_ref "${git_repo}" "${expected_commit}")" == "${expected_commit}" ]]
+
+export SDK_DEPS_MANIFEST="${TMP_DIR}/manifest.json"
+cat > "${SDK_DEPS_MANIFEST}" <<JSON
+{
+  "core": {
+    "ref": "main:${expected_commit}"
+  }
+}
+JSON
+[[ "$(neat_resolve_dependency_source_ref core "${git_repo}")" == "${expected_commit}" ]]
 
 echo "Neat dependency manifest tests passed."


### PR DESCRIPTION
## Summary

- publish per-architecture SDK images directly through Docker Buildx
- persist branch- and architecture-specific BuildKit caches in GHCR, with the matching `develop` cache as a fallback
- prevent pull requests from writing trusted shared caches
- resolve Core and Apps inputs to immutable commit SHAs and pin the `sima-cli` installer version
- move volatile SDK identity metadata behind stable dependency layers
- add cache retention, documentation, and regression tests

References #132.
References #100.

## Why

SDK builds previously used Buildx only as a local Docker replacement: each ephemeral runner rebuilt the image, loaded it into the local daemon, and then performed a separate push. The lack of a persistent external cache made repeat builds expensive, while early volatile metadata and mutable source inputs prevented safe reuse.

This change makes cache reuse explicit and reproducible without changing the native AMD64/ARM64 runner model or the existing multi-architecture publication, smoke-test, promotion, and Vulcan publication flow.

## Cache behavior

- trusted branch builds import and export a cache unique to branch and architecture
- branch builds also import the matching `develop` architecture cache
- pull requests may read trusted caches but do not export them
- `mode=max` preserves stable intermediate layers
- Core and Apps refs are resolved to immutable SHAs before the build
- volatile build identity remains in small final layers

## Validation

Local validation:

- warm local Buildx build: 10.39s
- non-interactive `sima-cli sdk setup`: 111.42s
- SDK provenance and architecture checks
- Modalix cross compiler
- sysroot overlay installation
- representative internals, Core, and LLiMa builds
- Hello Neat cross-build
- Neat Insight API and UDP ingest smoke tests
- ShellCheck, Actionlint, JSON, build-script, dependency-resolution, and install-stub tests

CI cache-seeding build:

| Architecture | Build job |
|---|---:|
| x86_64 | 8m 03s |
| aarch64 | 12m 57s |

https://github.com/sima-neat/sdk/actions/runs/29810734370

Identical warm-cache build:

| Architecture | Build job | Buildx step | Reduction |
|---|---:|---:|---:|
| x86_64 | 20s | 8s | 95.9% |
| aarch64 | 49s | 30s | 93.7% |

https://github.com/sima-neat/sdk/actions/runs/29812135693

Both workflows passed end-to-end for AMD64 and ARM64, including SDK setup, smoke tests, manifest creation, promotion, and Vulcan publication.