### PR TITLE
Promote develop to main

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - apt-mirror
+
+config-variables: null
+
+paths:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -592,14 +592,14 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ vars.VULCAN_ENV || 'production' }}
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
       - name: Download image metadata
         uses: actions/download-artifact@v7
         with:
           name: image-promotion-metadata
           path: .smoke
-
-      - name: Check out repository
-        uses: actions/checkout@v5
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/sync-debian-pre-release-mirror.yml
+++ b/.github/workflows/sync-debian-pre-release-mirror.yml
@@ -1,0 +1,91 @@
+name: Sync pre-release Debian mirror
+
+on:
+  schedule:
+    # Run away from the top of the hour to reduce GitHub Actions queue delays.
+    - cron: "27 9 * * *"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the validated mirror to production S3
+        required: true
+        default: false
+        type: boolean
+      force:
+        description: Run even when the published InRelease digest is unchanged
+        required: true
+        default: false
+        type: boolean
+      minimum_free_gib:
+        description: Minimum persistent disk space required before synchronization
+        required: true
+        default: "100"
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: debian-pre-release-mirror-production
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Validate and optionally publish production mirror
+    environment: production
+    runs-on: [self-hosted, Linux, X64, apt-mirror]
+    timeout-minutes: 720
+    env:
+      AWS_REGION: ${{ vars.VULCAN_DEBIAN_MIRROR_AWS_REGION || 'us-west-2' }}
+      DEBIAN_MIRROR_WORK_ROOT: ${{ vars.DEBIAN_MIRROR_WORK_ROOT || '/var/lib/sima-neat/debian-mirror' }}
+      VULCAN_DEBIAN_MIRROR_BUCKET: ${{ vars.VULCAN_DEBIAN_MIRROR_BUCKET || 'sima-neat-debian-production' }}
+      VULCAN_DEBIAN_MIRROR_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.VULCAN_DEBIAN_MIRROR_CLOUDFRONT_DISTRIBUTION_ID || 'E64NIJ10VID5O' }}
+      VULCAN_DEBIAN_MIRROR_KMS_KEY_ID: ${{ vars.VULCAN_DEBIAN_MIRROR_KMS_KEY_ID || 'arn:aws:kms:us-west-2:069171140053:key/4bf76f64-6ff3-4447-8572-b4f92163d497' }}
+      VULCAN_DEBIAN_MIRROR_PUBLISHER_ROLE_ARN: ${{ vars.VULCAN_DEBIAN_MIRROR_PUBLISHER_ROLE_ARN || 'arn:aws:iam::069171140053:role/NeatProductionDebianMirrorPublisher' }}
+
+    steps:
+      - name: Check out SDK
+        uses: actions/checkout@v5
+
+      - name: Install mirror dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            awscli \
+            curl \
+            debmirror \
+            jq \
+            python3 \
+            util-linux
+
+      - name: Prepare persistent mirror workspace
+        run: |
+          set -euo pipefail
+          sudo install -d \
+            -o "$(id -u)" \
+            -g "$(id -g)" \
+            -m 0750 \
+            "${DEBIAN_MIRROR_WORK_ROOT}"
+
+      - name: Configure production AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.VULCAN_DEBIAN_MIRROR_PUBLISHER_ROLE_ARN }}
+          role-session-name: sdk-debian-mirror-${{ github.run_id }}
+
+      - name: Synchronize and validate mirror
+        env:
+          MINIMUM_FREE_GIB: ${{ inputs.minimum_free_gib || '100' }}
+        run: |
+          set -euo pipefail
+          arguments=(--minimum-free-gib "${MINIMUM_FREE_GIB}")
+          if [[ "${{ github.event_name }}" == "schedule" || "${{ inputs.publish }}" == "true" ]]; then
+            arguments+=(--publish)
+          fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            arguments+=(--force)
+          fi
+          scripts/sync-debian-pre-release-mirror.sh "${arguments[@]}"

--- a/docs/debian-pre-release-mirror.md
+++ b/docs/debian-pre-release-mirror.md
@@ -1,0 +1,115 @@
+# Pre-release Debian mirror
+
+The `Sync pre-release Debian mirror` workflow pulls the corporate repository at
+`sw-web.eng.sima.ai/deb/pre-release`, validates it, and can publish it to the
+production mirror at `https://debian.neat.sima.ai/pre-release`.
+
+This is an operational mirror-transfer workflow only. It does not build or
+modify the SDK container, SDK packages, or SDK installation behavior; the SDK
+repository is only the home for the workflow and its synchronization utility.
+
+The workflow runs daily at 09:27 UTC and can also be started manually. Scheduled
+runs publish after validation; manual runs expose an explicit `publish` switch
+so the first production validation can download and verify without changing S3.
+
+## Private runner
+
+Use a corporate-network Linux x86_64 runner with these labels:
+
+```text
+self-hosted, Linux, X64, apt-mirror
+```
+
+Restrict the runner group to `sima-neat/sdk`. The host must resolve and reach
+`sw-web.eng.sima.ai`, allow passwordless `sudo` for package installation and
+workspace creation, and provide at least 150 GiB of persistent storage. The
+workflow stores incremental mirror state outside the Actions checkout at:
+
+```text
+/var/lib/sima-neat/debian-mirror
+```
+
+Set the protected SDK `production` environment variable
+`DEBIAN_MIRROR_WORK_ROOT` if the persistent volume is mounted elsewhere.
+
+## Pre-release trust model
+
+This mirror is limited to controlled internal pre-release testing. The private
+source is transported over the corporate network using HTTP, and its current
+repository signature cannot be verified with the public key it advertises.
+The synchronization therefore ignores the upstream Release signature while
+still verifying that every referenced package exists and matches the size and
+SHA256 recorded in the downloaded package indexes.
+
+Clients access the Vulcan mirror through HTTPS and must explicitly mark this
+pre-release source as trusted:
+
+```text
+deb [trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free
+```
+
+This configuration must not be reused for a production or publicly trusted
+package channel. HTTPS protects transport from Vulcan to the client, but the
+package-index checks do not establish the upstream publisher's identity.
+
+## First manual run
+
+1. Open **Actions → Sync pre-release Debian mirror → Run workflow**.
+2. Select `main`.
+3. Leave `publish` disabled for the first run. This downloads and validates
+   every referenced package without changing S3.
+4. Review the job summary and confirm the package count, byte count, source
+   date, and `InRelease` digest.
+5. Run it again with `publish` enabled. The persistent mirror makes this run
+   incremental.
+
+After rollout, the daily scheduled run performs the same validation and enables
+publication automatically. It exits successfully without uploading when the
+upstream `InRelease` digest has not changed.
+
+Each changed run compares the validated package indexes with the inventory from
+the last successful publication. The Actions summary reports package files
+added to the indexes, package files removed from the indexes, and correlated
+version changes by package and architecture. It shows up to 50 entries in each
+category and records the complete machine-readable inventory and change report
+under digest-addressed `.mirror/inventories/` and `.mirror/changes/` S3 keys.
+
+"Removed" means no longer referenced by the published APT indexes. Old package
+objects remain in the S3 pool during the initial rollout for safe rollback.
+
+Package objects and immutable `by-hash` indexes are uploaded before repository
+metadata. On the first publication, all ordinary index paths are also seeded,
+including the nested `binary-*/Release` files. The suite-level `Release` is
+replaced last and contains `Acquire-By-Hash: yes`, making that single S3 object
+the publication boundary. Later runs retain the previous ordinary index paths
+so clients holding an older `Release` continue to see a consistent generation.
+
+Because the destination `Release` is transformed to describe the binary-only
+mirror and enable by-hash, the upstream `InRelease` and `Release.gpg` signatures
+are not published. This is consistent with the explicitly trusted pre-release
+client configuration above. Old package-pool objects are not deleted by the
+initial implementation.
+
+The production CloudFront endpoint is currently blocked by WAF. Publishing can
+be validated through S3, but `apt update` requires a separately approved public
+or corporate/VPN CIDR access policy.
+
+## No-change behavior
+
+The workflow compares the upstream `InRelease` SHA256 with:
+
+```text
+s3://sima-neat-debian-production/pre-release/.mirror/publication.json
+```
+
+An unchanged repository exits successfully without downloading or publishing.
+Use the `force` input only when the local mirror must be rebuilt or revalidated.
+
+## Rollback
+
+The production bucket is versioned. To roll back, identify the last known-good
+version of `pre-release/dists/bookworm/Release` and restore that object last.
+The digest-addressed indexes and package-pool objects are immutable and must not
+be deleted. Invalidate `/pre-release/dists/*` after restoration, then verify the
+restored index and all referenced package checksums before reopening client
+access.

--- a/scripts/compare-debian-mirror-inventories.py
+++ b/scripts/compare-debian-mirror-inventories.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Compare two validated Debian mirror package inventories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def load_packages(path: Path | None) -> list[dict[str, object]]:
+    if path is None:
+        return []
+    document = json.loads(path.read_text(encoding="utf-8"))
+    packages = document.get("packages")
+    if not isinstance(packages, list):
+        raise ValueError(f"{path} does not contain a packages array")
+    return packages
+
+
+def compare_inventories(
+    previous: list[dict[str, object]], current: list[dict[str, object]], baseline: bool
+) -> dict[str, object]:
+    previous_by_file = {str(item["filename"]): item for item in previous}
+    current_by_file = {str(item["filename"]): item for item in current}
+
+    added = [current_by_file[name] for name in sorted(current_by_file.keys() - previous_by_file)]
+    removed = [previous_by_file[name] for name in sorted(previous_by_file.keys() - current_by_file)]
+    reused_file_content = []
+    for filename in sorted(previous_by_file.keys() & current_by_file.keys()):
+        before = previous_by_file[filename]
+        after = current_by_file[filename]
+        if (before.get("size"), before.get("sha256")) != (
+            after.get("size"),
+            after.get("sha256"),
+        ):
+            reused_file_content.append(
+                {
+                    "filename": filename,
+                    "previous_size": before.get("size"),
+                    "current_size": after.get("size"),
+                    "previous_sha256": before.get("sha256"),
+                    "current_sha256": after.get("sha256"),
+                }
+            )
+
+    def versions_by_identity(
+        packages: list[dict[str, object]],
+    ) -> dict[tuple[str, str], set[str]]:
+        result: dict[tuple[str, str], set[str]] = {}
+        for package in packages:
+            identity = (str(package["package"]), str(package["architecture"]))
+            result.setdefault(identity, set()).add(str(package["version"]))
+        return result
+
+    previous_versions = versions_by_identity(previous)
+    current_versions = versions_by_identity(current)
+    version_changes = []
+    for identity in sorted(previous_versions.keys() & current_versions):
+        before = previous_versions[identity]
+        after = current_versions[identity]
+        if before != after:
+            version_changes.append(
+                {
+                    "package": identity[0],
+                    "architecture": identity[1],
+                    "previous_versions": sorted(before),
+                    "current_versions": sorted(after),
+                }
+            )
+
+    return {
+        "schema_version": 1,
+        "baseline_available": baseline,
+        "counts": {
+            "added_files": len(added),
+            "removed_files": len(removed),
+            "reused_file_content": len(reused_file_content),
+            "version_changes": len(version_changes),
+        },
+        "added": added,
+        "removed": removed,
+        "reused_file_content": reused_file_content,
+        "version_changes": version_changes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--previous", type=Path)
+    parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        previous = load_packages(args.previous)
+        current = load_packages(args.current)
+        result = compare_inventories(previous, current, args.previous is not None)
+        args.output.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(f"inventory comparison failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare-debian-by-hash.py
+++ b/scripts/prepare-debian-by-hash.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Prepare an unsigned, Acquire-By-Hash APT distribution for publication."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+from pathlib import Path, PurePosixPath
+
+
+CHECKSUM_HEADERS = {"MD5Sum:", "SHA1:", "SHA256:", "SHA512:"}
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def safe_relative_path(value: str) -> Path:
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(f"unsafe Release path: {value}")
+    return Path(*path.parts)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_distribution(dists_root: Path, suite: str) -> tuple[int, int]:
+    suite_dir = dists_root / suite
+    release_path = suite_dir / "Release"
+    lines = release_path.read_text(encoding="utf-8").splitlines()
+
+    output: list[str] = []
+    sha256_entries: list[tuple[str, int, Path]] = []
+    checksum_section: str | None = None
+    acquire_by_hash_seen = False
+    checksum_seen = False
+
+    for line in lines:
+        if line.startswith("Acquire-By-Hash:"):
+            if not acquire_by_hash_seen:
+                output.append("Acquire-By-Hash: yes")
+                acquire_by_hash_seen = True
+            continue
+
+        if line in CHECKSUM_HEADERS:
+            if not checksum_seen and not acquire_by_hash_seen:
+                output.append("Acquire-By-Hash: yes")
+                acquire_by_hash_seen = True
+            checksum_seen = True
+            checksum_section = line
+            output.append(line)
+            continue
+
+        if checksum_section is not None and line.startswith(" "):
+            fields = line.split(maxsplit=2)
+            if len(fields) != 3:
+                raise ValueError(f"malformed {checksum_section} entry: {line}")
+            digest, size_text, relative_text = fields
+            relative_path = safe_relative_path(relative_text)
+            source = suite_dir / relative_path
+
+            # debmirror --nosource intentionally omits source indexes. Remove
+            # checksum records for any files that are not in the binary mirror.
+            if not source.is_file():
+                continue
+
+            output.append(line)
+            if checksum_section == "SHA256:":
+                if not SHA256_RE.fullmatch(digest):
+                    raise ValueError(f"invalid SHA256 digest for {relative_text}")
+                try:
+                    size = int(size_text)
+                except ValueError as error:
+                    raise ValueError(
+                        f"invalid size for {relative_text}: {size_text}"
+                    ) from error
+                sha256_entries.append((digest.lower(), size, relative_path))
+            continue
+
+        checksum_section = None
+        output.append(line)
+
+    if not checksum_seen or not sha256_entries:
+        raise ValueError("Release has no publishable SHA256 entries")
+
+    total_bytes = 0
+    for expected_digest, expected_size, relative_path in sha256_entries:
+        source = suite_dir / relative_path
+        actual_size = source.stat().st_size
+        if actual_size != expected_size:
+            raise ValueError(
+                f"size mismatch for {relative_path}: "
+                f"expected {expected_size}, got {actual_size}"
+            )
+        actual_digest = sha256_file(source)
+        if actual_digest != expected_digest:
+            raise ValueError(
+                f"SHA256 mismatch for {relative_path}: "
+                f"expected {expected_digest}, got {actual_digest}"
+            )
+
+        destination = source.parent / "by-hash" / "SHA256" / expected_digest
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.link(source, destination)
+        except FileExistsError:
+            if sha256_file(destination) != expected_digest:
+                raise ValueError(f"incorrect existing by-hash object: {destination}")
+        except OSError:
+            shutil.copyfile(source, destination)
+        total_bytes += actual_size
+
+    temporary_release = release_path.with_suffix(".tmp")
+    temporary_release.write_text("\n".join(output) + "\n", encoding="utf-8")
+    os.replace(temporary_release, release_path)
+
+    # The Release file was transformed, so the upstream signatures no longer
+    # describe it. Clients explicitly use [trusted=yes] for this test mirror.
+    for signature_name in ("InRelease", "Release.gpg"):
+        (suite_dir / signature_name).unlink(missing_ok=True)
+
+    return len(sha256_entries), total_bytes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dists_root", type=Path)
+    parser.add_argument("--suite", required=True)
+    arguments = parser.parse_args()
+
+    count, total_bytes = prepare_distribution(arguments.dists_root, arguments.suite)
+    print(f"Prepared {count} by-hash indexes ({total_bytes} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync-debian-pre-release-mirror.sh
+++ b/scripts/sync-debian-pre-release-mirror.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+UPSTREAM_HOST="sw-web.eng.sima.ai"
+UPSTREAM_ROOT="deb/pre-release"
+UPSTREAM_BASE_URL="http://${UPSTREAM_HOST}/${UPSTREAM_ROOT}"
+SUITE="bookworm"
+COMPONENT="non-free"
+ARCHITECTURES="arm64,arc,armhf,i386,amd64"
+
+PUBLISH=false
+FORCE=false
+MINIMUM_FREE_GIB="${MINIMUM_FREE_GIB:-100}"
+WORK_ROOT="${DEBIAN_MIRROR_WORK_ROOT:-/var/lib/sima-neat/debian-mirror}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+BUCKET="${VULCAN_DEBIAN_MIRROR_BUCKET:-}"
+KMS_KEY_ID="${VULCAN_DEBIAN_MIRROR_KMS_KEY_ID:-}"
+CLOUDFRONT_DISTRIBUTION_ID="${VULCAN_DEBIAN_MIRROR_CLOUDFRONT_DISTRIBUTION_ID:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: sync-debian-pre-release-mirror.sh [options]
+
+Options:
+  --publish            Upload a validated mirror to the production S3 bucket.
+  --force              Sync even when the published InRelease digest is unchanged.
+  --work-root PATH     Persistent mirror workspace.
+  --minimum-free-gib N Required free space before mirroring (default: 100).
+  --help               Show this help.
+EOF
+}
+
+while (($#)); do
+  case "$1" in
+    --publish) PUBLISH=true ;;
+    --force) FORCE=true ;;
+    --work-root) WORK_ROOT="${2:?--work-root requires a path}"; shift ;;
+    --minimum-free-gib) MINIMUM_FREE_GIB="${2:?--minimum-free-gib requires a value}"; shift ;;
+    --help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+for command in aws cp curl debmirror find flock jq python3 sha256sum; do
+  command -v "${command}" >/dev/null || {
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  }
+done
+
+if ! [[ "${MINIMUM_FREE_GIB}" =~ ^[0-9]+$ ]]; then
+  echo "--minimum-free-gib must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [[ -z "${BUCKET}" || -z "${KMS_KEY_ID}" || -z "${CLOUDFRONT_DISTRIBUTION_ID}" ]]; then
+  echo "VULCAN_DEBIAN_MIRROR_BUCKET, VULCAN_DEBIAN_MIRROR_KMS_KEY_ID, and VULCAN_DEBIAN_MIRROR_CLOUDFRONT_DISTRIBUTION_ID are required" >&2
+  exit 1
+fi
+
+mkdir -p "${WORK_ROOT}"
+exec 9>"${WORK_ROOT}/sync.lock"
+if ! flock -n 9; then
+  echo "Another Debian mirror synchronization owns ${WORK_ROOT}/sync.lock" >&2
+  exit 1
+fi
+
+REPOSITORY="${WORK_ROOT}/repository"
+mkdir -p "${REPOSITORY}"
+TEMP_DIR="$(mktemp -d "${WORK_ROOT}/run.XXXXXX")"
+trap 'rm -rf -- "${TEMP_DIR}"' EXIT
+
+INRELEASE="${TEMP_DIR}/InRelease"
+VALIDATION_JSON="${TEMP_DIR}/validation.json"
+CURRENT_INVENTORY_JSON="${TEMP_DIR}/inventory.json"
+PREVIOUS_INVENTORY_JSON="${TEMP_DIR}/previous-inventory.json"
+PREVIOUS_PUBLICATION_JSON="${TEMP_DIR}/previous-publication.json"
+CHANGES_JSON="${TEMP_DIR}/changes.json"
+PUBLICATION_JSON="${TEMP_DIR}/publication.json"
+PUBLISH_DISTS="${TEMP_DIR}/publish-dists"
+
+getent hosts "${UPSTREAM_HOST}" >/dev/null
+curl --fail --silent --show-error --location --max-time 120 \
+  --output "${INRELEASE}" "${UPSTREAM_BASE_URL}/dists/${SUITE}/InRelease"
+
+source_digest="$(sha256sum "${INRELEASE}" | awk '{print $1}')"
+source_date="$(sed -n 's/^Date: //p' "${INRELEASE}" | head -n 1)"
+source_architectures="$(sed -n 's/^Architectures: //p' "${INRELEASE}" | head -n 1)"
+source_components="$(sed -n 's/^Components: //p' "${INRELEASE}" | head -n 1)"
+
+[[ " ${source_architectures} " == *" arm64 "* ]]
+[[ " ${source_architectures} " == *" arc "* ]]
+[[ " ${source_architectures} " == *" armhf "* ]]
+[[ " ${source_architectures} " == *" i386 "* ]]
+[[ " ${source_architectures} " == *" amd64 "* ]]
+[[ " ${source_components} " == *" ${COMPONENT} "* ]]
+
+previous_digest=""
+previous_inventory_key=""
+if aws s3 cp "s3://${BUCKET}/pre-release/.mirror/publication.json" \
+  "${PREVIOUS_PUBLICATION_JSON}" --region "${AWS_REGION}" --only-show-errors 2>/dev/null; then
+  previous_digest="$(jq -r '.source.inrelease_sha256 // empty' "${PREVIOUS_PUBLICATION_JSON}")"
+  previous_inventory_key="$(jq -r '.publication.inventory_key // empty' "${PREVIOUS_PUBLICATION_JSON}")"
+fi
+
+if [[ "${FORCE}" != true && -n "${previous_digest}" && "${source_digest}" == "${previous_digest}" ]]; then
+  echo "Upstream InRelease is unchanged (${source_digest}); nothing to publish."
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo '## Debian mirror synchronization'
+      echo
+      echo "- Result: No change"
+      echo "- InRelease SHA256: \`${source_digest}\`"
+      echo "- Added package files: 0"
+      echo "- Removed from package indexes: 0"
+      echo "- Package version changes: 0"
+    } >>"${GITHUB_STEP_SUMMARY}"
+  fi
+  exit 0
+fi
+
+available_kib="$(df -Pk "${WORK_ROOT}" | awk 'NR == 2 {print $4}')"
+required_kib="$((MINIMUM_FREE_GIB * 1024 * 1024))"
+if ((available_kib < required_kib)); then
+  echo "Insufficient free space under ${WORK_ROOT}: require ${MINIMUM_FREE_GIB} GiB" >&2
+  exit 1
+fi
+
+debmirror "${REPOSITORY}" \
+  --host="${UPSTREAM_HOST}" \
+  --root="${UPSTREAM_ROOT}" \
+  --method=http \
+  --dist="${SUITE}" \
+  --section="${COMPONENT}" \
+  --arch="${ARCHITECTURES}" \
+  --nosource \
+  --ignore-release-gpg \
+  --rsync-extra=none \
+  --omit-suite-symlinks \
+  --progress
+
+mirrored_digest="$(sha256sum "${REPOSITORY}/dists/${SUITE}/InRelease" | awk '{print $1}')"
+if [[ "${mirrored_digest}" != "${source_digest}" ]]; then
+  echo "Mirrored InRelease changed during synchronization; refusing publication" >&2
+  exit 1
+fi
+
+python3 "${SCRIPT_DIR}/validate-debian-mirror.py" \
+  "${REPOSITORY}" \
+  --suite "${SUITE}" \
+  --component "${COMPONENT}" \
+  --architectures "${ARCHITECTURES}" \
+  --output "${VALIDATION_JSON}"
+
+# Publish a transformed unsigned Release with Acquire-By-Hash enabled. The
+# upstream signature cannot be retained because --nosource removes source
+# indexes and the Release file must describe only the mirrored content.
+cp -a "${REPOSITORY}/dists" "${PUBLISH_DISTS}"
+python3 "${SCRIPT_DIR}/prepare-debian-by-hash.py" \
+  "${PUBLISH_DISTS}" \
+  --suite "${SUITE}"
+
+jq '{schema_version: 1, packages: .packages}' \
+  "${VALIDATION_JSON}" >"${CURRENT_INVENTORY_JSON}"
+previous_inventory_arguments=()
+if [[ "${previous_inventory_key}" == pre-release/.mirror/inventories/*.json ]] && \
+  aws s3 cp "s3://${BUCKET}/${previous_inventory_key}" "${PREVIOUS_INVENTORY_JSON}" \
+    --region "${AWS_REGION}" --only-show-errors 2>/dev/null; then
+  previous_inventory_arguments=(--previous "${PREVIOUS_INVENTORY_JSON}")
+fi
+if [[ "${PUBLISH}" == true && -n "${previous_digest}" && \
+  ${#previous_inventory_arguments[@]} -eq 0 ]]; then
+  echo "Previous publication inventory is unavailable; refusing publication" >&2
+  exit 1
+fi
+python3 "${SCRIPT_DIR}/compare-debian-mirror-inventories.py" \
+  "${previous_inventory_arguments[@]}" \
+  --current "${CURRENT_INVENTORY_JSON}" \
+  --output "${CHANGES_JSON}"
+
+package_count="$(jq -r '.package_count' "${VALIDATION_JSON}")"
+total_bytes="$(jq -r '.total_bytes' "${VALIDATION_JSON}")"
+added_count="$(jq -r '.counts.added_files' "${CHANGES_JSON}")"
+removed_count="$(jq -r '.counts.removed_files' "${CHANGES_JSON}")"
+version_change_count="$(jq -r '.counts.version_changes' "${CHANGES_JSON}")"
+reused_file_content_count="$(jq -r '.counts.reused_file_content' "${CHANGES_JSON}")"
+if [[ "${PUBLISH}" == true && "${reused_file_content_count}" -gt 0 ]]; then
+  echo "Upstream reused ${reused_file_content_count} pool filename(s) with different content; refusing publication" >&2
+  jq -r '.reused_file_content[] | "- \(.filename): \(.previous_sha256) -> \(.current_sha256)"' \
+    "${CHANGES_JSON}" >&2
+  exit 1
+fi
+publication_time="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+inventory_key="pre-release/.mirror/inventories/${source_digest}.json"
+changes_key="pre-release/.mirror/changes/${source_digest}.json"
+jq -n \
+  --arg source_url "${UPSTREAM_BASE_URL}" \
+  --arg source_date "${source_date}" \
+  --arg source_digest "${source_digest}" \
+  --arg published_at "${publication_time}" \
+  --arg repository "${GITHUB_REPOSITORY:-local}" \
+  --arg workflow_run "${GITHUB_RUN_ID:-local}" \
+  --arg commit "${GITHUB_SHA:-local}" \
+  --arg inventory_key "${inventory_key}" \
+  --arg changes_key "${changes_key}" \
+  --argjson package_count "${package_count}" \
+  --argjson total_bytes "${total_bytes}" \
+  --slurpfile changes "${CHANGES_JSON}" \
+  '{schema_version: 1, source: {url: $source_url, date: $source_date, inrelease_sha256: $source_digest}, validation: {package_count: $package_count, total_bytes: $total_bytes}, changes: $changes[0].counts, publication: {published_at: $published_at, repository: $repository, workflow_run: $workflow_run, commit: $commit, inventory_key: $inventory_key, changes_key: $changes_key, apt_release_mode: "unsigned-by-hash"}}' \
+  >"${PUBLICATION_JSON}"
+
+if [[ "${PUBLISH}" == true ]]; then
+  s3_common=(--region "${AWS_REGION}" --sse aws:kms --sse-kms-key-id "${KMS_KEY_ID}" --only-show-errors)
+
+  # Versioned inventory records are uploaded before publication and become
+  # authoritative only when the final publication manifest references them.
+  aws s3 cp "${CURRENT_INVENTORY_JSON}" "s3://${BUCKET}/${inventory_key}" \
+    "${s3_common[@]}" --cache-control 'public,max-age=31536000,immutable' \
+    --content-type application/json
+  aws s3 cp "${CHANGES_JSON}" "s3://${BUCKET}/${changes_key}" \
+    "${s3_common[@]}" --cache-control 'public,max-age=31536000,immutable' \
+    --content-type application/json
+
+  # Package objects are immutable and must be available before any metadata
+  # that references them becomes visible to APT clients.
+  aws s3 sync "${REPOSITORY}/pool/" "s3://${BUCKET}/pre-release/pool/" \
+    "${s3_common[@]}" --cache-control 'public,max-age=31536000,immutable'
+
+  # Upload immutable index objects before the Release file that advertises
+  # them. APT fetches these digest-addressed paths after reading the new
+  # Acquire-By-Hash Release, so an interrupted upload cannot create a mixed
+  # generation of mutable Packages files.
+  aws s3 sync "${PUBLISH_DISTS}/" "s3://${BUCKET}/pre-release/dists/" \
+    "${s3_common[@]}" --cache-control 'public,max-age=31536000,immutable' \
+    --exclude '*' --include '*/by-hash/SHA256/*'
+
+  # Seed all ordinary index paths, including binary-*/Release, on the initial
+  # publication. Keep these paths unchanged on later runs so a client holding
+  # the previous Release can still fetch a consistent generation.
+  if [[ -z "${previous_digest}" ]]; then
+    aws s3 sync "${PUBLISH_DISTS}/" "s3://${BUCKET}/pre-release/dists/" \
+      "${s3_common[@]}" --cache-control 'no-cache,no-store,must-revalidate' \
+      --exclude '*/by-hash/SHA256/*' \
+      --exclude "${SUITE}/Release"
+  fi
+
+  # Older publisher versions excluded every path named Release. Seed any
+  # missing nested Release files without replacing a previous generation.
+  while IFS= read -r -d '' nested_release; do
+    relative_path="${nested_release#"${PUBLISH_DISTS}/"}"
+    object_key="pre-release/dists/${relative_path}"
+    if ! aws s3api head-object --bucket "${BUCKET}" --key "${object_key}" \
+      --region "${AWS_REGION}" >/dev/null 2>&1; then
+      aws s3 cp "${nested_release}" "s3://${BUCKET}/${object_key}" \
+        "${s3_common[@]}" --cache-control 'no-cache,no-store,must-revalidate'
+    fi
+  done < <(find "${PUBLISH_DISTS}/${SUITE}" -mindepth 3 -type f \
+    -name Release -print0)
+
+  # The transformed Release is intentionally unsigned. Remove any previously
+  # published source signatures before switching the suite Release.
+  for signature_name in InRelease Release.gpg; do
+    aws s3 rm "s3://${BUCKET}/pre-release/dists/${SUITE}/${signature_name}" \
+      --region "${AWS_REGION}" --only-show-errors
+  done
+
+  # This single S3 object replacement is the publication boundary.
+  aws s3 cp "${PUBLISH_DISTS}/${SUITE}/Release" \
+    "s3://${BUCKET}/pre-release/dists/${SUITE}/Release" \
+    "${s3_common[@]}" --cache-control 'no-cache,no-store,must-revalidate'
+
+  aws s3 cp "${PUBLICATION_JSON}" \
+    "s3://${BUCKET}/pre-release/.mirror/publication.json" \
+    "${s3_common[@]}" --cache-control 'no-cache,no-store,must-revalidate' \
+    --content-type application/json
+
+  aws cloudfront create-invalidation \
+    --region "${AWS_REGION}" \
+    --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+    --paths '/pre-release/dists/*' '/pre-release/.mirror/publication.json' \
+    >/dev/null
+  result="Published"
+else
+  result="Validated only"
+fi
+
+echo "${result}: ${package_count} packages, ${total_bytes} bytes, InRelease ${source_digest}"
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo '## Debian mirror synchronization'
+    echo
+    echo "- Result: ${result}"
+    echo "- Source date: ${source_date}"
+    echo "- InRelease SHA256: \`${source_digest}\`"
+    echo "- Unique packages: ${package_count}"
+    echo "- Referenced bytes: ${total_bytes}"
+    echo "- Added package files: ${added_count}"
+    echo "- Removed from package indexes: ${removed_count}"
+    echo "- Package version changes: ${version_change_count}"
+    if [[ "$(jq -r '.baseline_available' "${CHANGES_JSON}")" != true ]]; then
+      echo "- Baseline: no previous inventory; all current package files are reported as added"
+    fi
+    echo
+    echo '### Version changes (up to 50)'
+    echo
+    echo '| Package | Architecture | Previous | Current |'
+    echo '|---|---|---|---|'
+    jq -r '.version_changes[:50][] | "| `\(.package)` | `\(.architecture)` | `\(.previous_versions | join(", "))` | `\(.current_versions | join(", "))` |"' "${CHANGES_JSON}"
+    echo
+    echo '### Added package files (up to 50)'
+    echo
+    echo '| Package | Version | Architecture | File |'
+    echo '|---|---|---|---|'
+    jq -r '.added[:50][] | "| `\(.package)` | `\(.version)` | `\(.architecture)` | `\(.filename)` |"' "${CHANGES_JSON}"
+    echo
+    echo '### Removed from package indexes (up to 50)'
+    echo
+    echo '| Package | Version | Architecture | File |'
+    echo '|---|---|---|---|'
+    jq -r '.removed[:50][] | "| `\(.package)` | `\(.version)` | `\(.architecture)` | `\(.filename)` |"' "${CHANGES_JSON}"
+    echo
+    if [[ "${PUBLISH}" == true ]]; then
+      echo "Full inventory: \`${inventory_key}\`"
+      echo "Full change report: \`${changes_key}\`"
+    else
+      echo 'Full inventory and change report will be retained when publication is enabled.'
+    fi
+  } >>"${GITHUB_STEP_SUMMARY}"
+fi

--- a/scripts/validate-debian-mirror.py
+++ b/scripts/validate-debian-mirror.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Validate package indexes and every package object in a Debian mirror."""
+
+from __future__ import annotations
+
+import argparse
+import bz2
+import concurrent.futures
+import gzip
+import hashlib
+import json
+import lzma
+import os
+from pathlib import Path
+import sys
+from typing import Iterable, TextIO
+
+
+INDEX_NAMES = ("Packages", "Packages.xz", "Packages.gz", "Packages.bz2")
+
+
+def open_index(path: Path) -> TextIO:
+    if path.suffix == ".xz":
+        return lzma.open(path, "rt", encoding="utf-8", errors="strict")
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", encoding="utf-8", errors="strict")
+    if path.suffix == ".bz2":
+        return bz2.open(path, "rt", encoding="utf-8", errors="strict")
+    return path.open("r", encoding="utf-8", errors="strict")
+
+
+def parse_control_records(lines: Iterable[str]) -> Iterable[dict[str, str]]:
+    record: dict[str, str] = {}
+    current_key: str | None = None
+    for raw_line in lines:
+        line = raw_line.rstrip("\n")
+        if not line:
+            if record:
+                yield record
+                record = {}
+                current_key = None
+            continue
+        if line[0].isspace():
+            if current_key is not None:
+                record[current_key] += "\n" + line
+            continue
+        if ":" not in line:
+            raise ValueError(f"invalid control-file line: {line!r}")
+        current_key, value = line.split(":", 1)
+        record[current_key] = value.lstrip()
+    if record:
+        yield record
+
+
+def find_indexes(
+    repository: Path, suite: str, component: str, architecture: str
+) -> list[Path]:
+    directory = repository / "dists" / suite / component / f"binary-{architecture}"
+    indexes = [directory / name for name in INDEX_NAMES if (directory / name).is_file()]
+    if not indexes:
+        raise FileNotFoundError(f"no Packages index found under {directory}")
+    return indexes
+
+
+def read_index_metadata(index_path: Path) -> dict[str, dict[str, object]]:
+    packages: dict[str, dict[str, object]] = {}
+    with open_index(index_path) as package_index:
+        for ordinal, record in enumerate(parse_control_records(package_index), start=1):
+            missing = {
+                "Package",
+                "Version",
+                "Architecture",
+                "Filename",
+                "Size",
+                "SHA256",
+            } - record.keys()
+            if missing:
+                raise ValueError(
+                    f"{index_path}: record {ordinal} is missing {sorted(missing)}"
+                )
+            filename = record["Filename"]
+            relative_path = Path(filename)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise ValueError(f"unsafe package filename in {index_path}: {filename}")
+            metadata: dict[str, object] = {
+                "package": record["Package"],
+                "version": record["Version"],
+                "architecture": record["Architecture"],
+                "filename": filename,
+                "size": int(record["Size"]),
+                "sha256": record["SHA256"].lower(),
+            }
+            previous = packages.setdefault(filename, metadata)
+            if previous != metadata:
+                raise ValueError(f"conflicting metadata for {filename} in {index_path}")
+    return packages
+
+
+def package_metadata(
+    repository: Path, suite: str, component: str, architectures: list[str]
+) -> dict[str, dict[str, object]]:
+    packages: dict[str, dict[str, object]] = {}
+    for architecture in architectures:
+        indexes = find_indexes(repository, suite, component, architecture)
+        reference_path = indexes[0]
+        architecture_packages = read_index_metadata(reference_path)
+        for index_path in indexes[1:]:
+            candidate_packages = read_index_metadata(index_path)
+            if candidate_packages != architecture_packages:
+                raise ValueError(
+                    f"Packages index mismatch: {index_path} does not match "
+                    f"{reference_path}"
+                )
+        for filename, metadata in architecture_packages.items():
+            previous = packages.setdefault(filename, metadata)
+            if previous != metadata:
+                raise ValueError(f"conflicting metadata for {filename}")
+    return packages
+
+
+def validate_package(
+    repository: Path, item: tuple[str, dict[str, object]]
+) -> tuple[str, int]:
+    filename, metadata = item
+    expected_size = int(metadata["size"])
+    expected_sha256 = str(metadata["sha256"])
+    package_path = repository / filename
+    if not package_path.is_file():
+        raise FileNotFoundError(f"referenced package is missing: {filename}")
+    actual_size = package_path.stat().st_size
+    if actual_size != expected_size:
+        raise ValueError(
+            f"size mismatch for {filename}: expected {expected_size}, got {actual_size}"
+        )
+    digest = hashlib.sha256()
+    with package_path.open("rb") as package_file:
+        for chunk in iter(lambda: package_file.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    actual_sha256 = digest.hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"SHA256 mismatch for {filename}: expected {expected_sha256}, got {actual_sha256}"
+        )
+    return filename, actual_size
+
+
+def validate_repository(
+    repository: Path,
+    suite: str,
+    component: str,
+    architectures: list[str],
+    workers: int,
+) -> dict[str, object]:
+    inrelease = repository / "dists" / suite / "InRelease"
+    if not inrelease.is_file():
+        raise FileNotFoundError(f"repository metadata is missing: {inrelease}")
+
+    packages = package_metadata(repository, suite, component, architectures)
+    if not packages:
+        raise ValueError("package indexes did not reference any packages")
+
+    total_bytes = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = [executor.submit(validate_package, repository, item) for item in packages.items()]
+        for future in concurrent.futures.as_completed(futures):
+            _, package_size = future.result()
+            total_bytes += package_size
+
+    return {
+        "architectures": architectures,
+        "component": component,
+        "package_count": len(packages),
+        "packages": sorted(packages.values(), key=lambda package: str(package["filename"])),
+        "suite": suite,
+        "total_bytes": total_bytes,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repository", type=Path)
+    parser.add_argument("--suite", default="bookworm")
+    parser.add_argument("--component", default="non-free")
+    parser.add_argument(
+        "--architectures", default="arm64,arc,armhf,i386,amd64"
+    )
+    parser.add_argument("--workers", type=int, default=min(8, os.cpu_count() or 1))
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    if args.workers < 1:
+        parser.error("--workers must be at least 1")
+    architectures = [value.strip() for value in args.architectures.split(",") if value.strip()]
+    if not architectures:
+        parser.error("--architectures must not be empty")
+
+    try:
+        result = validate_repository(
+            args.repository.resolve(),
+            args.suite,
+            args.component,
+            architectures,
+            args.workers,
+        )
+    except (OSError, ValueError) as error:
+        print(f"mirror validation failed: {error}", file=sys.stderr)
+        return 1
+
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/sdk/test-debian-by-hash.py
+++ b/tests/sdk/test-debian-by-hash.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import hashlib
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts" / "prepare-debian-by-hash.py"
+SPEC = importlib.util.spec_from_file_location("prepare_debian_by_hash", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PrepareDebianByHashTests(unittest.TestCase):
+    def make_distribution(self, root: Path, digest: str) -> tuple[Path, Path]:
+        suite = root / "bookworm"
+        index = suite / "non-free" / "binary-amd64" / "Packages.gz"
+        index.parent.mkdir(parents=True)
+        index.write_bytes(b"package index\n")
+        missing_digest = hashlib.sha256(b"missing source index\n").hexdigest()
+        (suite / "Release").write_text(
+            "Origin: Test\n"
+            "Architectures: amd64\n"
+            "Components: non-free\n"
+            "SHA256:\n"
+            f" {digest} {index.stat().st_size} non-free/binary-amd64/Packages.gz\n"
+            f" {missing_digest} 21 non-free/source/Sources.gz\n",
+            encoding="utf-8",
+        )
+        (suite / "InRelease").write_text("signed", encoding="utf-8")
+        (suite / "Release.gpg").write_text("signature", encoding="utf-8")
+        return suite, index
+
+    def test_prepares_by_hash_and_unsigned_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            digest = hashlib.sha256(b"package index\n").hexdigest()
+            suite, index = self.make_distribution(root, digest)
+
+            count, total_bytes = MODULE.prepare_distribution(root, "bookworm")
+
+            release = (suite / "Release").read_text(encoding="utf-8")
+            self.assertIn("Acquire-By-Hash: yes\n", release)
+            self.assertNotIn("non-free/source/Sources.gz", release)
+            self.assertFalse((suite / "InRelease").exists())
+            self.assertFalse((suite / "Release.gpg").exists())
+            by_hash = index.parent / "by-hash" / "SHA256" / digest
+            self.assertEqual(by_hash.read_bytes(), index.read_bytes())
+            self.assertEqual(count, 1)
+            self.assertEqual(total_bytes, index.stat().st_size)
+
+    def test_rejects_digest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.make_distribution(root, "0" * 64)
+            with self.assertRaisesRegex(ValueError, "SHA256 mismatch"):
+                MODULE.prepare_distribution(root, "bookworm")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sdk/test-debian-mirror-changes.py
+++ b/tests/sdk/test-debian-mirror-changes.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPARATOR = ROOT / "scripts" / "compare-debian-mirror-inventories.py"
+SPEC = importlib.util.spec_from_file_location("debian_mirror_changes", COMPARATOR)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def package(name: str, version: str, architecture: str = "arm64") -> dict[str, object]:
+    return {
+        "package": name,
+        "version": version,
+        "architecture": architecture,
+        "filename": f"pool/{name}_{version}_{architecture}.deb",
+        "size": 1,
+        "sha256": "0" * 64,
+    }
+
+
+class DebianMirrorChangesTest(unittest.TestCase):
+    def test_reports_added_removed_and_version_changes(self) -> None:
+        result = MODULE.compare_inventories(
+            [package("upgrade", "1"), package("removed", "1")],
+            [package("upgrade", "2"), package("added", "1")],
+            True,
+        )
+        self.assertEqual(result["counts"], {
+            "added_files": 2,
+            "removed_files": 2,
+            "reused_file_content": 0,
+            "version_changes": 1,
+        })
+        self.assertEqual(result["version_changes"][0]["package"], "upgrade")
+
+    def test_initial_inventory_marks_every_file_added(self) -> None:
+        result = MODULE.compare_inventories([], [package("first", "1")], False)
+        self.assertFalse(result["baseline_available"])
+        self.assertEqual(result["counts"]["added_files"], 1)
+
+    def test_reports_changed_content_at_same_pool_filename(self) -> None:
+        previous = package("reused", "1")
+        current = dict(previous, size=2, sha256="1" * 64)
+        result = MODULE.compare_inventories([previous], [current], True)
+
+        self.assertEqual(result["counts"]["reused_file_content"], 1)
+        self.assertEqual(
+            result["reused_file_content"][0]["filename"], previous["filename"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sdk/test-debian-mirror-validator.py
+++ b/tests/sdk/test-debian-mirror-validator.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import gzip
+import hashlib
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "scripts" / "validate-debian-mirror.py"
+SPEC = importlib.util.spec_from_file_location("debian_mirror_validator", VALIDATOR)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class DebianMirrorValidatorTest(unittest.TestCase):
+    def create_repository(self, root: Path, checksum: str | None = None) -> Path:
+        repository = root / "repository"
+        package = repository / "pool" / "non-free" / "h" / "hello" / "hello.deb"
+        package.parent.mkdir(parents=True)
+        package.write_bytes(b"package bytes")
+        digest = checksum or hashlib.sha256(package.read_bytes()).hexdigest()
+        record = (
+            "Package: hello\n"
+            "Version: 1.0\n"
+            "Architecture: amd64\n"
+            "Filename: pool/non-free/h/hello/hello.deb\n"
+            f"Size: {package.stat().st_size}\n"
+            f"SHA256: {digest}\n\n"
+        )
+        index = repository / "dists" / "bookworm" / "non-free" / "binary-amd64" / "Packages.gz"
+        index.parent.mkdir(parents=True)
+        with gzip.open(index, "wt", encoding="utf-8") as package_index:
+            package_index.write(record)
+        (repository / "dists" / "bookworm" / "InRelease").write_text("metadata\n")
+        return repository
+
+    def test_validates_indexed_package(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = MODULE.validate_repository(
+                self.create_repository(Path(directory)),
+                "bookworm",
+                "non-free",
+                ["amd64"],
+                1,
+            )
+        self.assertEqual(result["package_count"], 1)
+        self.assertEqual(result["total_bytes"], len(b"package bytes"))
+        self.assertEqual(result["packages"][0]["version"], "1.0")
+
+    def test_rejects_checksum_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = self.create_repository(Path(directory), checksum="0" * 64)
+            with self.assertRaisesRegex(ValueError, "SHA256 mismatch"):
+                MODULE.validate_repository(repository, "bookworm", "non-free", ["amd64"], 1)
+
+    def test_rejects_conflicting_compressed_index(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repository = self.create_repository(Path(directory))
+            binary_directory = (
+                repository / "dists" / "bookworm" / "non-free" / "binary-amd64"
+            )
+            with gzip.open(
+                binary_directory / "Packages.gz", "rt", encoding="utf-8"
+            ) as compressed_index:
+                record = compressed_index.read()
+            (binary_directory / "Packages").write_text(
+                record.replace("Version: 1.0", "Version: 2.0"), encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(ValueError, "Packages index mismatch"):
+                MODULE.validate_repository(
+                    repository, "bookworm", "non-free", ["amd64"], 1
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sdk/test-debian-mirror-workflow.sh
+++ b/tests/sdk/test-debian-mirror-workflow.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="${repo_root}/.github/workflows/sync-debian-pre-release-mirror.yml"
+sync_script="${repo_root}/scripts/sync-debian-pre-release-mirror.sh"
+documentation="${repo_root}/docs/debian-pre-release-mirror.md"
+
+bash -n "${sync_script}"
+python3 -m py_compile "${repo_root}/scripts/validate-debian-mirror.py"
+python3 -m py_compile "${repo_root}/scripts/compare-debian-mirror-inventories.py"
+python3 -m py_compile "${repo_root}/scripts/prepare-debian-by-hash.py"
+python3 "${repo_root}/tests/sdk/test-debian-by-hash.py"
+
+grep -Fq 'workflow_dispatch:' "${workflow}"
+grep -Fq 'schedule:' "${workflow}"
+grep -Fq 'cron: "27 9 * * *"' "${workflow}"
+grep -Fq 'github.event_name }}" == "schedule"' "${workflow}"
+grep -Fq "inputs.minimum_free_gib || '100'" "${workflow}"
+grep -Fq 'runs-on: [self-hosted, Linux, X64, apt-mirror]' "${workflow}"
+grep -Fq 'cancel-in-progress: false' "${workflow}"
+grep -Fq 'environment: production' "${workflow}"
+grep -Fq 'id-token: write' "${workflow}"
+grep -Fq -- '--rsync-extra=none' "${sync_script}"
+grep -Fq -- '--omit-suite-symlinks' "${sync_script}"
+grep -Fq -- '--ignore-release-gpg' "${sync_script}"
+grep -Fq 'Acquire-By-Hash' "${repo_root}/scripts/prepare-debian-by-hash.py"
+grep -Fq -- '-name Release -print0' "${sync_script}"
+grep -Fq 'deb [trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free' "${documentation}"
+if grep -Eq 'gpgv|SIGNING_KEY|PINNED_KEY' "${sync_script}" "${workflow}"; then
+  echo "The internal pre-release mirror must not require an APT signing key" >&2
+  exit 1
+fi
+grep -Fq 'Added package files:' "${sync_script}"
+grep -Fq 'Removed from package indexes:' "${sync_script}"
+grep -Fq 'Package version changes:' "${sync_script}"
+grep -Fq 'pool filename(s) with different content; refusing publication' "${sync_script}"
+# shellcheck disable=SC2016
+grep -Fq '.mirror/inventories/${source_digest}.json' "${sync_script}"
+# shellcheck disable=SC2016
+grep -Fq '.mirror/changes/${source_digest}.json' "${sync_script}"
+
+# These grep patterns intentionally match literal shell expressions in the
+# implementation rather than expanding them in this test process.
+# shellcheck disable=SC2016
+pool_upload_line="$(grep -nF 's3 sync "${REPOSITORY}/pool/' "${sync_script}" | cut -d: -f1)"
+# shellcheck disable=SC2016
+by_hash_upload_line="$(grep -nF 's3 sync "${PUBLISH_DISTS}/' "${sync_script}" | head -n 1 | cut -d: -f1)"
+# shellcheck disable=SC2016
+release_upload_line="$(grep -nF 'aws s3 cp "${PUBLISH_DISTS}/${SUITE}/Release"' "${sync_script}" | cut -d: -f1)"
+manifest_upload_line="$(grep -n 'pre-release/.mirror/publication.json' "${sync_script}" | tail -n 1 | cut -d: -f1)"
+
+test "${pool_upload_line}" -lt "${by_hash_upload_line}"
+test "${by_hash_upload_line}" -lt "${release_upload_line}"
+test "${release_upload_line}" -lt "${manifest_upload_line}"
+
+echo "Debian mirror workflow checks passed"


### PR DESCRIPTION
## Summary

Promote the current `develop` branch to `main`.

Included changes:

- #131 — fix release-line metadata retarget ordering
- #138 — add private Debian pre-release mirror synchronization, validation, change reporting, generation-safe by-hash publication, and daily/manual workflows

## Scope

`develop` is two commits ahead of `main`. This promotion contains the merged changes above without additional branch-specific modifications.