### PR TITLE
Add pre-release platform-only SDK profile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,11 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+    inputs:
+      pre_release_base:
+        description: Optional platform selector (for example, 2.1.3 or 2.1.3~pre4593)
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -35,7 +40,7 @@ jobs:
       - name: Resolve stable or pre-release platform version
         id: resolve
         env:
-          PRE_RELEASE_BASE: ${{ vars.PRE_RELEASE_BASE }}
+          PRE_RELEASE_BASE: ${{ inputs.pre_release_base || vars.PRE_RELEASE_BASE }}
         run: |
           set -euo pipefail
           scripts/resolve-platform-config.sh | tee "${RUNNER_TEMP}/platform-config.env"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,8 +20,36 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-platform-config:
+    name: Resolve platform package configuration
+    runs-on: ubuntu-24.04
+    outputs:
+      sdk_apt_channel: ${{ steps.resolve.outputs.sdk_apt_channel }}
+      requested_pre_release_base: ${{ steps.resolve.outputs.requested_pre_release_base }}
+      base_sdk_version: ${{ steps.resolve.outputs.base_sdk_version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Resolve stable or pre-release platform version
+        id: resolve
+        env:
+          PRE_RELEASE_BASE: ${{ vars.PRE_RELEASE_BASE }}
+        run: |
+          set -euo pipefail
+          scripts/resolve-platform-config.sh | tee "${RUNNER_TEMP}/platform-config.env"
+          cat "${RUNNER_TEMP}/platform-config.env" >> "${GITHUB_OUTPUT}"
+
+      - name: Run platform profile tests
+        run: |
+          tests/sdk/test-resolve-platform-config.sh
+          tests/sdk/test-write-sdk-release.sh
+          tests/sdk/test-devkit-platform-profile.sh
+
   build:
     name: Build on ${{ matrix.arch }}
+    needs: resolve-platform-config
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
@@ -66,6 +94,9 @@ jobs:
         run: ./build.sh sdk "${IMAGE_TAG}"
         env:
           IMAGE_TAG: ci-${{ matrix.image_suffix }}
+          SDK_APT_CHANNEL: ${{ needs.resolve-platform-config.outputs.sdk_apt_channel }}
+          REQUESTED_PRE_RELEASE_BASE: ${{ needs.resolve-platform-config.outputs.requested_pre_release_base }}
+          BASE_SDK_VERSION: ${{ needs.resolve-platform-config.outputs.base_sdk_version }}
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ARG SDK_GIT_BRANCH=unknown
 ARG SDK_GIT_HASH=nogit
 ARG SDK_RELEASE_REF=unknown-nogit
 ARG BASE_SDK_VERSION=2.1.2
+ARG SDK_APT_CHANNEL=release
+ARG REQUESTED_PRE_RELEASE_BASE=
 ARG MINIMAL_IMAGE=0
 ARG NEAT_BRANCH=main
 ARG NEAT_VERSION=latest
@@ -38,6 +40,7 @@ ENV OPENVSCODE_SERVER_PORT=9999
 ENV OPENVSCODE_SERVER_HTTPS_PORT=10000
 ENV OPENVSCODE_SERVER_SUPERVISED=1
 ENV PIP_DEFAULT_TIMEOUT=120
+ENV SDK_APT_CHANNEL=${SDK_APT_CHANNEL}
 ENV PIP_RETRIES=10
 ENV RUSTUP_HOME=/opt/toolchain/rust
 ENV CARGO_HOME=/opt/toolchain/rust
@@ -241,26 +244,19 @@ COPY config/profile.d/*.sh /etc/profile.d/
 RUN chmod 755 /etc/profile.d/neat-sdk-prompt.sh \
               /etc/profile.d/pkg-config-sysroot.sh
 
-RUN if printf '%s' "${SDK_RELEASE_REF}" | grep -Eq '^v[0-9]+[.][0-9]+[.][0-9]+'; then \
-      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s\neLXr Version = %s_release_neat_%s\n' \
-        "${SDK_RELEASE_REF}" \
-        "${BASE_SDK_VERSION}" \
-        "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}" \
-        "${BASE_SDK_VERSION}" "${SDK_RELEASE_REF}"; \
-    else \
-      printf 'SDK Release = %s\nPlatform Version = %s\nSDK Version = %s_Palette_SDK_neat_%s_%s\neLXr Version = %s_release_neat_%s_%s\n' \
-        "${SDK_RELEASE_REF}" \
-        "${BASE_SDK_VERSION}" \
-        "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}" \
-        "${BASE_SDK_VERSION}" "${SDK_GIT_BRANCH}" "${SDK_GIT_HASH}"; \
-    fi > /etc/sdk-release
+COPY scripts/write-sdk-release.sh /usr/local/bin/write-sdk-release.sh
+RUN chmod 755 /usr/local/bin/write-sdk-release.sh && write-sdk-release.sh
 
 WORKDIR /workspace
 
 # Preinstall Neat Framework and resources
 COPY scripts/install-neat-resources.sh /usr/local/bin/install-neat-resources.sh
 RUN chmod 755 /usr/local/bin/install-neat-resources.sh
-RUN install-neat-resources.sh
+RUN if [ "${SDK_APT_CHANNEL}" = pre-release ]; then \
+      echo "Skipping bundled Neat Core resources for the pre-release platform SDK"; \
+    else \
+      install-neat-resources.sh; \
+    fi
 
 # Expose required ports
 EXPOSE 9900 9999 10000 9000-9079 9100-9179 8081 8554

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,8 @@ SDK_BASE_IMAGE="${SDK_BASE_IMAGE:-ubuntu:24.04}"
 SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE:-debian:bookworm}"
 DOCKER_PLATFORM="${DOCKER_PLATFORM:-}"
 BASE_SDK_VERSION="${BASE_SDK_VERSION:-2.1.2}"
+SDK_APT_CHANNEL="${SDK_APT_CHANNEL:-release}"
+REQUESTED_PRE_RELEASE_BASE="${REQUESTED_PRE_RELEASE_BASE:-}"
 NEAT_BRANCH="${NEAT_BRANCH:-main}"
 NEAT_VERSION="${NEAT_VERSION:-latest}"
 NEAT_CORE_TARGET="${NEAT_CORE_TARGET:-}"
@@ -34,6 +36,7 @@ Environment overrides:
   SDK_BASE_IMAGE  Base Docker image for the SDK host/container userspace (default: ${SDK_BASE_IMAGE})
   SDK_CROSS_TOOLCHAIN_IMAGE  Base image used only to source the pinned aarch64 cross compiler (default: ${SDK_CROSS_TOOLCHAIN_IMAGE})
   BASE_SDK_VERSION  Base eLxr/SiMa SDK package version to install (default: ${BASE_SDK_VERSION})
+  SDK_APT_CHANNEL  Platform package channel: release or pre-release (default: ${SDK_APT_CHANNEL})
   NEAT_BRANCH  NEAT Framework branch to bake into /neat-resources (default: ${NEAT_BRANCH})
   NEAT_VERSION  NEAT Framework version/tag to bake into /neat-resources (default: ${NEAT_VERSION})
   NEAT_CORE_TARGET  Override the Neat Core Vulcan package target from deps/manifest.json
@@ -133,6 +136,8 @@ echo "Git branch: ${git_branch}"
 echo "Git hash: ${git_hash}"
 echo "SDK release ref: ${sdk_release_ref}"
 echo "Base SDK version: ${BASE_SDK_VERSION}"
+echo "SDK apt channel: ${SDK_APT_CHANNEL}"
+echo "Requested pre-release base: ${REQUESTED_PRE_RELEASE_BASE:-<none>}"
 echo "SDK base image: ${SDK_BASE_IMAGE}"
 echo "SDK cross toolchain image: ${SDK_CROSS_TOOLCHAIN_IMAGE}"
 echo "Minimal image mode: ${MINIMAL_IMAGE}"
@@ -154,6 +159,8 @@ if docker buildx version >/dev/null 2>&1; then
     --build-arg SDK_BASE_IMAGE="${SDK_BASE_IMAGE}"
     --build-arg SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE}"
     --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
+    --build-arg SDK_APT_CHANNEL="${SDK_APT_CHANNEL}"
+    --build-arg REQUESTED_PRE_RELEASE_BASE="${REQUESTED_PRE_RELEASE_BASE}"
     --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
     --build-arg NEAT_VERSION="${NEAT_VERSION}"
     --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"
@@ -176,6 +183,8 @@ build_cmd=(
   --build-arg SDK_BASE_IMAGE="${SDK_BASE_IMAGE}"
   --build-arg SDK_CROSS_TOOLCHAIN_IMAGE="${SDK_CROSS_TOOLCHAIN_IMAGE}"
   --build-arg BASE_SDK_VERSION="${BASE_SDK_VERSION}"
+  --build-arg SDK_APT_CHANNEL="${SDK_APT_CHANNEL}"
+  --build-arg REQUESTED_PRE_RELEASE_BASE="${REQUESTED_PRE_RELEASE_BASE}"
   --build-arg NEAT_BRANCH="${NEAT_BRANCH}"
   --build-arg NEAT_VERSION="${NEAT_VERSION}"
   --build-arg NEAT_CORE_TARGET="${NEAT_CORE_TARGET}"

--- a/config/platform-package-patterns.txt
+++ b/config/platform-package-patterns.txt
@@ -3,7 +3,8 @@
 # Some SiMa packages intentionally carry independent package versions even when
 # they are part of an SDK release. Keep this list limited to packages whose
 # Debian version is expected to equal the SDK/platform version.
-simaai-palette-*
+simaai-palette-modalix
+simaai-palette-davinci
 appcomplex
 a65apps
 evtransforms

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -40,6 +40,23 @@ Host architecture: arm64
 Docker platform: linux/arm64
 ```
 
+## Build Against Pre-release Platform Packages
+
+CI reads the repository variable `PRE_RELEASE_BASE`. A value such as `2.1.3`
+selects the highest Debian version matching `2.1.3~pre*`; a value such as
+`2.1.3~pre4460` pins that exact build. The workflow resolves the value once and
+passes the same immutable version to both architecture builds.
+
+Pre-release images use the `platform-cross` profile. They contain the cross
+compiler and exact target sysroot but do not bundle Neat Core binaries or source
+checkouts. `/etc/sdk-release` records the requested selector, resolved platform
+version, repository, profile, and `Neat Core = not bundled`.
+
+Floating selectors are rejected on `main`, `release-*` branches, and tags.
+Those refs use the stable channel when `PRE_RELEASE_BASE` is unset and accept
+pre-release packages only when an exact `X.Y.Z~preN` version is explicitly
+pinned.
+
 ## Add Sysroot Packages
 
 Inside a running SDK container, install additional ARM64 Debian packages into the sysroot with `sysroot`:

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -52,6 +52,11 @@ compiler and exact target sysroot but do not bundle Neat Core binaries or source
 checkouts. `/etc/sdk-release` records the requested selector, resolved platform
 version, repository, profile, and `Neat Core = not bundled`.
 
+The pre-release mirror is configured as an overlay on the official release
+repository. Exact platform-version pins select the requested pre-release
+packages, while SDK-pinned dependencies that are not duplicated in the
+pre-release mirror remain available from the release repository.
+
 Floating selectors are rejected on `main`, `release-*` branches, and tags.
 Those refs use the stable channel when `PRE_RELEASE_BASE` is unset and accept
 pre-release packages only when an exact `X.Y.Z~preN` version is explicitly

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -47,6 +47,10 @@ selects the highest Debian version matching `2.1.3~pre*`; a value such as
 `2.1.3~pre4460` pins that exact build. The workflow resolves the value once and
 passes the same immutable version to both architecture builds.
 
+Floating selectors follow the mirror's `Release` metadata to its current
+Acquire-By-Hash package index. Exact `X.Y.Z~preN` values bypass latest-version
+selection but are still checked against that current index before the build.
+
 Pre-release images use the `platform-cross` profile. They contain the cross
 compiler and exact target sysroot but do not bundle Neat Core binaries or source
 checkouts. `/etc/sdk-release` records the requested selector, resolved platform

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -47,6 +47,11 @@ selects the highest Debian version matching `2.1.3~pre*`; a value such as
 `2.1.3~pre4460` pins that exact build. The workflow resolves the value once and
 passes the same immutable version to both architecture builds.
 
+For a manual workflow run, the optional **Platform selector** input overrides
+the repository variable. Leave it empty to use `PRE_RELEASE_BASE`, enter
+`X.Y.Z` to select the latest matching pre-release, or enter `X.Y.Z~preN` to pin
+that exact platform build.
+
 Floating selectors follow the mirror's `Release` metadata to its current
 Acquire-By-Hash package index. Exact `X.Y.Z~preN` values bypass latest-version
 selection but are still checked against that current index before the build.

--- a/scripts/configure-apt-repos.sh
+++ b/scripts/configure-apt-repos.sh
@@ -4,6 +4,24 @@ set -euo pipefail
 
 base_sdk_version="${1:?Usage: configure-apt-repos.sh BASE_SDK_VERSION [PATTERNS_FILE]}"
 patterns_file="${2:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
+sdk_apt_channel="${SDK_APT_CHANNEL:-release}"
+sdk_platform_repository="${SDK_PLATFORM_REPOSITORY:-}"
+sdk_apt_origin="${SDK_APT_ORIGIN:-}"
+
+case "${sdk_apt_channel}" in
+  release)
+    sdk_platform_repository="${sdk_platform_repository:-https://repo.sima.ai/elxr/deb/release}"
+    sdk_apt_origin="${sdk_apt_origin:-repo.sima.ai/elxr}"
+    ;;
+  pre-release)
+    sdk_platform_repository="${sdk_platform_repository:-https://debian.neat.sima.ai/pre-release}"
+    sdk_apt_origin="${sdk_apt_origin:-debian.neat.sima.ai}"
+    ;;
+  *)
+    echo "Unsupported SDK_APT_CHANNEL: ${sdk_apt_channel}" >&2
+    exit 1
+    ;;
+esac
 
 if [[ ! -f "${patterns_file}" ]]; then
   echo "Platform package patterns file not found: ${patterns_file}" >&2
@@ -23,9 +41,9 @@ if [[ -r /etc/os-release ]]; then
   host_id="${ID:-}"
 fi
 
-cat > /etc/apt/sources.list.d/elxr.list <<'EOF'
+cat > /etc/apt/sources.list.d/elxr.list <<EOF
 deb [signed-by=/etc/apt/trusted.gpg.d/elxr.gpg] https://mirror.elxr.dev/elxr aria main
-deb [trusted=yes] https://repo.sima.ai/elxr/deb/release bookworm non-free  # simaai repo
+deb [trusted=yes] ${sdk_platform_repository} bookworm non-free  # simaai ${sdk_apt_channel} repo
 EOF
 
 if [[ "${host_id}" == "ubuntu" ]]; then
@@ -35,9 +53,9 @@ deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http:/
 deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian-security bookworm-security main
 EOF
 
-  cat > /etc/apt/preferences.d/stable.pref <<'EOF'
+  cat > /etc/apt/preferences.d/stable.pref <<EOF
 Package: *
-Pin: origin "repo.sima.ai/elxr"
+Pin: origin "${sdk_apt_origin}"
 Pin-Priority: 100
 
 Package: *
@@ -50,9 +68,9 @@ Pin-Priority: 100
 
 EOF
 else
-  cat > /etc/apt/preferences.d/stable.pref <<'EOF'
+  cat > /etc/apt/preferences.d/stable.pref <<EOF
 Package: *
-Pin: origin "repo.sima.ai/elxr"
+Pin: origin "${sdk_apt_origin}"
 Pin-Priority: 999
 EOF
 fi

--- a/scripts/configure-apt-repos.sh
+++ b/scripts/configure-apt-repos.sh
@@ -7,6 +7,8 @@ patterns_file="${2:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
 sdk_apt_channel="${SDK_APT_CHANNEL:-release}"
 sdk_platform_repository="${SDK_PLATFORM_REPOSITORY:-}"
 sdk_apt_origin="${SDK_APT_ORIGIN:-}"
+sdk_fallback_repository=""
+sdk_fallback_origin=""
 
 case "${sdk_apt_channel}" in
   release)
@@ -16,6 +18,11 @@ case "${sdk_apt_channel}" in
   pre-release)
     sdk_platform_repository="${sdk_platform_repository:-https://debian.neat.sima.ai/pre-release}"
     sdk_apt_origin="${sdk_apt_origin:-debian.neat.sima.ai}"
+    # The pre-release mirror is an overlay, not a complete replacement for the
+    # release repository. Some SDK-pinned dependencies, including Modalix UAPI
+    # headers, intentionally remain available only from the release channel.
+    sdk_fallback_repository="https://repo.sima.ai/elxr/deb/release"
+    sdk_fallback_origin="repo.sima.ai/elxr"
     ;;
   *)
     echo "Unsupported SDK_APT_CHANNEL: ${sdk_apt_channel}" >&2
@@ -46,6 +53,12 @@ deb [signed-by=/etc/apt/trusted.gpg.d/elxr.gpg] https://mirror.elxr.dev/elxr ari
 deb [trusted=yes] ${sdk_platform_repository} bookworm non-free  # simaai ${sdk_apt_channel} repo
 EOF
 
+if [[ -n "${sdk_fallback_repository}" ]]; then
+  cat >> /etc/apt/sources.list.d/elxr.list <<EOF
+deb [trusted=yes] ${sdk_fallback_repository} bookworm non-free  # simaai release fallback
+EOF
+fi
+
 if [[ "${host_id}" == "ubuntu" ]]; then
   cat > /etc/apt/sources.list.d/debian-target.list <<'EOF'
 deb [arch=arm64 signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm main
@@ -67,12 +80,30 @@ Pin: origin "deb.debian.org"
 Pin-Priority: 100
 
 EOF
+
+  if [[ -n "${sdk_fallback_origin}" ]]; then
+    cat >> /etc/apt/preferences.d/stable.pref <<EOF
+Package: *
+Pin: origin "${sdk_fallback_origin}"
+Pin-Priority: 100
+
+EOF
+  fi
 else
   cat > /etc/apt/preferences.d/stable.pref <<EOF
 Package: *
 Pin: origin "${sdk_apt_origin}"
 Pin-Priority: 999
 EOF
+
+  if [[ -n "${sdk_fallback_origin}" ]]; then
+    cat >> /etc/apt/preferences.d/stable.pref <<EOF
+
+Package: *
+Pin: origin "${sdk_fallback_origin}"
+Pin-Priority: 100
+EOF
+  fi
 fi
 
 platform_packages="$(

--- a/scripts/devkit.sh
+++ b/scripts/devkit.sh
@@ -6,10 +6,40 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
   exit 2
 fi
 
-if [[ -z "${1:-}" && -z "${DEVKIT_SYNC_DEVKIT_IP:-}" ]]; then
+if [[ "${DEVKIT_SH_FUNCTIONS_ONLY:-0}" != "1" && -z "${1:-}" && -z "${DEVKIT_SYNC_DEVKIT_IP:-}" ]]; then
   echo "Usage: source devkit.sh [devkit-ip|$DEVKIT_SYNC_DEVKIT_IP] [devkit-user=sima] [devkit-port=22]" >&2
   return 2
 fi
+
+sdk_release_value() {
+  local key="$1"
+  local sdk_release="${2:-${SDK_RELEASE_FILE:-/etc/sdk-release}}"
+
+  [[ -r "${sdk_release}" ]] || return 1
+  awk -F= -v key="${key}" '
+    $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+      value = $2
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+  ' "${sdk_release}"
+}
+
+sdk_bundles_neat_core() {
+  local sdk_release="${1:-${SDK_RELEASE_FILE:-/etc/sdk-release}}"
+  local sdk_profile=""
+  local core_status=""
+
+  sdk_profile="$(sdk_release_value "SDK Profile" "${sdk_release}" 2>/dev/null || true)"
+  core_status="$(sdk_release_value "Neat Core" "${sdk_release}" 2>/dev/null || true)"
+
+  if [[ "${sdk_profile}" == "platform-cross" || "${core_status}" == "not bundled" ]]; then
+    return 1
+  fi
+  return 0
+}
 
 check_remote_passwordless_sudo() {
   local user="$1"
@@ -151,6 +181,11 @@ sync_neat_framework_to_devkit() {
     fi
     return 0
   }
+
+  if ! sdk_bundles_neat_core; then
+    echo "Neat Core is not bundled in this platform SDK; skipping DevKit Core synchronization."
+    return 0
+  fi
 
   case "${sync_enabled}" in
     OFF|off|0|false|FALSE|no|NO)
@@ -438,6 +473,10 @@ copy_insight_port_map_to_devkit() {
   printf "%bInsight port map copied to DevKit: ~/%s%b\n" "${c_green}" "${remote_port_map}" "${c_reset}"
   return 0
 }
+
+if [[ "${DEVKIT_SH_FUNCTIONS_ONLY:-0}" == "1" ]]; then
+  return 0
+fi
 
 _DEVKIT_IP="${1:-${DEVKIT_SYNC_DEVKIT_IP:-}}"
 _DEVKIT_USER="${2:-sima}"

--- a/scripts/install-sysroot-overlay.sh
+++ b/scripts/install-sysroot-overlay.sh
@@ -6,6 +6,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SYSROOT="${1:-/opt/toolchain/aarch64/modalix}"
 LIBDIR="${SYSROOT}/usr/lib/aarch64-linux-gnu"
 LINUX_LIBC_DEV_ARM64_VERSION="${SDK_SYSROOT_LINUX_LIBC_DEV_ARM64_VERSION:-${SDK_SYSROOT_LINUX_LIBC_DEV_VERSION:-}}"
+if [[ "${SDK_APT_CHANNEL:-release}" == "pre-release" ]]; then
+  SDK_APT_ORIGIN="debian.neat.sima.ai"
+else
+  SDK_APT_ORIGIN="repo.sima.ai/elxr"
+fi
 
 CONFIG_CANDIDATES=()
 if [[ -n "${SDK_SYSROOT_OVERLAY_CONFIG:-}" ]]; then
@@ -80,9 +85,9 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
-  cat >"${sysroot_pref}" <<'EOF'
+  cat >"${sysroot_pref}" <<EOF
 Package: *
-Pin: origin "repo.sima.ai/elxr"
+Pin: origin "${SDK_APT_ORIGIN}"
 Pin-Priority: 990
 
 Package: *

--- a/scripts/resolve-platform-config.sh
+++ b/scripts/resolve-platform-config.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pre_release_base="${PRE_RELEASE_BASE:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest_path="${SDK_DEPS_MANIFEST:-${script_dir}/../deps/manifest.json}"
+stable_base_sdk_version="${STABLE_BASE_SDK_VERSION:-}"
+github_ref_type="${GITHUB_REF_TYPE:-branch}"
+github_ref_name="${GITHUB_REF_NAME:-local}"
+packages_url="${PRE_RELEASE_PACKAGES_URL:-https://debian.neat.sima.ai/pre-release/dists/bookworm/non-free/binary-arm64/Packages.gz}"
+anchor_package="${PRE_RELEASE_ANCHOR_PACKAGE:-simaai-palette-modalix}"
+dpkg_command="${DPKG_COMMAND:-dpkg}"
+
+if [[ -z "${stable_base_sdk_version}" ]]; then
+  command -v python3 >/dev/null 2>&1 || {
+    echo "resolve-platform-config: python3 is required to read ${manifest_path}" >&2
+    exit 1
+  }
+  stable_base_sdk_version="$(
+    python3 - "${manifest_path}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as manifest_file:
+    value = json.load(manifest_file).get("platform-version", "")
+if not value:
+    raise SystemExit("deps manifest does not define platform-version")
+print(value)
+PY
+  )"
+fi
+
+die() {
+  echo "resolve-platform-config: $*" >&2
+  exit 1
+}
+
+emit() {
+  local channel="$1"
+  local requested="$2"
+  local resolved="$3"
+
+  printf 'sdk_apt_channel=%s\n' "${channel}"
+  printf 'requested_pre_release_base=%s\n' "${requested}"
+  printf 'base_sdk_version=%s\n' "${resolved}"
+}
+
+is_protected_ref() {
+  [[ "${github_ref_type}" == "tag" || \
+     "${github_ref_name}" == "main" || \
+     "${github_ref_name}" == release-* ]]
+}
+
+if [[ -z "${pre_release_base}" ]]; then
+  emit release "" "${stable_base_sdk_version}"
+  exit 0
+fi
+
+case "${pre_release_base}" in
+  *[!0-9.~a-zA-Z-]*)
+    die "invalid PRE_RELEASE_BASE: ${pre_release_base}"
+    ;;
+esac
+
+if [[ "${pre_release_base}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  selector_type="floating"
+  platform_base="${pre_release_base}"
+elif [[ "${pre_release_base}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)~pre[0-9]+$ ]]; then
+  selector_type="pinned"
+  platform_base="${BASH_REMATCH[1]}"
+else
+  die "PRE_RELEASE_BASE must be X.Y.Z or X.Y.Z~preN: ${pre_release_base}"
+fi
+
+if [[ "${selector_type}" == "floating" ]] && is_protected_ref; then
+  die "floating PRE_RELEASE_BASE=${pre_release_base} is not allowed for ${github_ref_type} ${github_ref_name}; use the stable channel or pin X.Y.Z~preN"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+packages_file="${tmpdir}/Packages"
+
+if [[ -n "${PRE_RELEASE_PACKAGES_FILE:-}" ]]; then
+  [[ -r "${PRE_RELEASE_PACKAGES_FILE}" ]] || die "Packages fixture is not readable: ${PRE_RELEASE_PACKAGES_FILE}"
+  cp "${PRE_RELEASE_PACKAGES_FILE}" "${packages_file}"
+else
+  command -v curl >/dev/null 2>&1 || die "curl is required to query the pre-release mirror"
+  command -v gzip >/dev/null 2>&1 || die "gzip is required to read the pre-release package index"
+  curl -fsSL --retry 4 --retry-all-errors "${packages_url}" | gzip -dc > "${packages_file}"
+fi
+
+resolved=""
+candidate_count=0
+use_dpkg=0
+if [[ "${selector_type}" == "floating" ]] && command -v "${dpkg_command}" >/dev/null 2>&1; then
+  use_dpkg=1
+fi
+while IFS= read -r candidate; do
+  candidate_count=$((candidate_count + 1))
+  if [[ "${selector_type}" == "pinned" ]]; then
+    if [[ "${candidate}" == "${pre_release_base}" ]]; then
+      resolved="${candidate}"
+    fi
+  else
+    [[ "${candidate}" == "${platform_base}"~pre* ]] || continue
+    candidate_is_newer=0
+    if [[ -z "${resolved}" ]]; then
+      candidate_is_newer=1
+    elif [[ "${use_dpkg}" == "1" ]]; then
+      if "${dpkg_command}" --compare-versions "${candidate}" gt "${resolved}"; then
+        candidate_is_newer=1
+      fi
+    elif (( 10#${candidate##*~pre} > 10#${resolved##*~pre} )); then
+      # All accepted floating candidates share X.Y.Z~preN. Numeric N ordering
+      # is equivalent to Debian ordering for this deliberately narrow format.
+      candidate_is_newer=1
+    fi
+    if [[ "${candidate_is_newer}" == "1" ]]; then
+      resolved="${candidate}"
+    fi
+  fi
+done < <(
+  awk -v package="${anchor_package}" '
+    $1 == "Package:" { current_package = $2 }
+    $1 == "Version:" && current_package == package { print $2 }
+  ' "${packages_file}" | awk '!seen[$0]++'
+)
+
+[[ "${candidate_count}" -gt 0 ]] || die "no versions found for anchor package ${anchor_package}"
+
+if [[ "${selector_type}" == "pinned" ]]; then
+  [[ -n "${resolved}" ]] || die "pinned version ${pre_release_base} is not present for ${anchor_package}"
+else
+  [[ -n "${resolved}" ]] || die "no ${platform_base}~pre* version found for ${anchor_package}"
+fi
+
+emit pre-release "${pre_release_base}" "${resolved}"

--- a/scripts/resolve-platform-config.sh
+++ b/scripts/resolve-platform-config.sh
@@ -8,9 +8,12 @@ manifest_path="${SDK_DEPS_MANIFEST:-${script_dir}/../deps/manifest.json}"
 stable_base_sdk_version="${STABLE_BASE_SDK_VERSION:-}"
 github_ref_type="${GITHUB_REF_TYPE:-branch}"
 github_ref_name="${GITHUB_REF_NAME:-local}"
-packages_url="${PRE_RELEASE_PACKAGES_URL:-https://debian.neat.sima.ai/pre-release/dists/bookworm/non-free/binary-arm64/Packages.gz}"
+release_url="${PRE_RELEASE_RELEASE_URL:-https://debian.neat.sima.ai/pre-release/dists/bookworm/Release}"
+packages_url="${PRE_RELEASE_PACKAGES_URL:-}"
+packages_path="${PRE_RELEASE_PACKAGES_PATH:-non-free/binary-arm64/Packages.gz}"
 anchor_package="${PRE_RELEASE_ANCHOR_PACKAGE:-simaai-palette-modalix}"
 dpkg_command="${DPKG_COMMAND:-dpkg}"
+curl_command="${CURL_COMMAND:-curl}"
 
 if [[ -z "${stable_base_sdk_version}" ]]; then
   command -v python3 >/dev/null 2>&1 || {
@@ -85,9 +88,23 @@ if [[ -n "${PRE_RELEASE_PACKAGES_FILE:-}" ]]; then
   [[ -r "${PRE_RELEASE_PACKAGES_FILE}" ]] || die "Packages fixture is not readable: ${PRE_RELEASE_PACKAGES_FILE}"
   cp "${PRE_RELEASE_PACKAGES_FILE}" "${packages_file}"
 else
-  command -v curl >/dev/null 2>&1 || die "curl is required to query the pre-release mirror"
+  command -v "${curl_command}" >/dev/null 2>&1 || die "curl is required to query the pre-release mirror"
   command -v gzip >/dev/null 2>&1 || die "gzip is required to read the pre-release package index"
-  curl -fsSL --retry 4 --retry-all-errors "${packages_url}" | gzip -dc > "${packages_file}"
+  if [[ -z "${packages_url}" ]]; then
+    release_file="${tmpdir}/Release"
+    "${curl_command}" -fsSL --retry 4 --retry-all-errors "${release_url}" > "${release_file}"
+    packages_digest="$(
+      awk -v wanted="${packages_path}" '
+        $0 == "SHA256:" { in_sha256 = 1; next }
+        in_sha256 && $0 !~ /^ / { in_sha256 = 0 }
+        in_sha256 && $3 == wanted { print $1; exit }
+      ' "${release_file}"
+    )"
+    [[ "${packages_digest}" =~ ^[0-9a-fA-F]{64}$ ]] || \
+      die "Release does not contain a valid SHA256 for ${packages_path}"
+    packages_url="${release_url%/*}/${packages_path%/*}/by-hash/SHA256/${packages_digest}"
+  fi
+  "${curl_command}" -fsSL --retry 4 --retry-all-errors "${packages_url}" | gzip -dc > "${packages_file}"
 fi
 
 resolved=""

--- a/scripts/setup-sdk-sysroot.sh
+++ b/scripts/setup-sdk-sysroot.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 base_sdk_version="${1:?Usage: setup-sdk-sysroot.sh BASE_SDK_VERSION SDK_PKG_LIST}"
 sdk_pkg_list="${2:-}"
 sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
+if [[ "${SDK_APT_CHANNEL:-release}" == "pre-release" ]]; then
+  sdk_apt_origin="debian.neat.sima.ai"
+else
+  sdk_apt_origin="repo.sima.ai/elxr"
+fi
 
 cleanup_sysroot_pref() {
   rm -f "${sysroot_pref}"
@@ -21,9 +26,9 @@ if [[ "${MINIMAL_IMAGE:-0}" == "1" ]]; then
 fi
 
 if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
-  cat >"${sysroot_pref}" <<'EOF'
+  cat >"${sysroot_pref}" <<EOF
 Package: *
-Pin: origin "repo.sima.ai/elxr"
+Pin: origin "${sdk_apt_origin}"
 Pin-Priority: 990
 
 Package: *

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -27,7 +27,8 @@ import time
 
 
 DEFAULT_PLATFORM_PACKAGE_PATTERNS = (
-    "simaai-palette-*",
+    "simaai-palette-modalix",
+    "simaai-palette-davinci",
     "appcomplex",
     "a65apps",
     "evtransforms",

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -290,7 +290,12 @@ download_for_manifest() {
   local arch="$1"
   local outdir="$2"
   local sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
+  local sdk_apt_origin="repo.sima.ai/elxr"
   shift 2
+
+  if [[ "${SDK_APT_CHANNEL:-release}" == "pre-release" ]]; then
+    sdk_apt_origin="debian.neat.sima.ai"
+  fi
 
   mkdir -p "${outdir}/archives/partial"
   touch "${outdir}/status"
@@ -300,9 +305,9 @@ download_for_manifest() {
   fi
 
   if [[ -f /etc/apt/sources.list.d/debian-target.list ]]; then
-    cat >"${sysroot_pref}" <<'EOF'
+    cat >"${sysroot_pref}" <<EOF
 Package: *
-Pin: origin "repo.sima.ai/elxr"
+Pin: origin "${sdk_apt_origin}"
 Pin-Priority: 990
 
 Package: *

--- a/scripts/validate-sysroot-package-versions.sh
+++ b/scripts/validate-sysroot-package-versions.sh
@@ -23,7 +23,8 @@ if [[ ! -d "${deb_dir}" ]]; then
 fi
 
 platform_package_patterns=(
-  simaai-palette-*
+  simaai-palette-modalix
+  simaai-palette-davinci
   appcomplex
   a65apps
   evtransforms

--- a/scripts/write-sdk-release.sh
+++ b/scripts/write-sdk-release.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+output="${SDK_RELEASE_FILE:-/etc/sdk-release}"
+sdk_release_ref="${SDK_RELEASE_REF:-unknown-nogit}"
+platform_version="${BASE_SDK_VERSION:-2.1.2}"
+platform_base="${platform_version%%~pre*}"
+platform_channel="${SDK_APT_CHANNEL:-release}"
+requested_pre_release_base="${REQUESTED_PRE_RELEASE_BASE:-none}"
+sdk_git_branch="${SDK_GIT_BRANCH:-unknown}"
+sdk_git_hash="${SDK_GIT_HASH:-nogit}"
+
+if [[ -z "${requested_pre_release_base}" ]]; then
+  requested_pre_release_base="none"
+fi
+
+case "${platform_channel}" in
+  release)
+    sdk_profile="full"
+    platform_repository="https://repo.sima.ai/elxr/deb/release"
+    core_status="bundled"
+    ;;
+  pre-release)
+    sdk_profile="platform-cross"
+    platform_repository="https://debian.neat.sima.ai/pre-release"
+    core_status="not bundled"
+    ;;
+  *)
+    echo "Unsupported SDK_APT_CHANNEL: ${platform_channel}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${sdk_release_ref}" =~ ^v[0-9]+[.][0-9]+[.][0-9]+ ]]; then
+  sdk_version="${platform_version}_Palette_SDK_neat_${sdk_release_ref}"
+  elxr_version="${platform_version}_release_neat_${sdk_release_ref}"
+else
+  sdk_version="${platform_version}_Palette_SDK_neat_${sdk_git_branch}_${sdk_git_hash}"
+  elxr_version="${platform_version}_release_neat_${sdk_git_branch}_${sdk_git_hash}"
+fi
+
+cat > "${output}" <<EOF
+SDK Release = ${sdk_release_ref}
+SDK Profile = ${sdk_profile}
+Platform Version = ${platform_version}
+Platform Base = ${platform_base}
+Platform Channel = ${platform_channel}
+Platform Repository = ${platform_repository}
+Requested Pre-release Base = ${requested_pre_release_base}
+Neat Core = ${core_status}
+SDK Version = ${sdk_version}
+eLXr Version = ${elxr_version}
+EOF

--- a/tests/sdk/README.md
+++ b/tests/sdk/README.md
@@ -10,7 +10,12 @@ container after `sima-cli sdk setup -y -n` starts it.
   invokes `run-in-container.sh`. It also runs host-side tests that need to
   validate Docker-published ports.
 - `run-in-container.sh` runs inside the SDK container and acts as the index for
-  individual SDK smoke tests.
+  individual SDK smoke tests. For a `platform-cross` image it validates release
+  metadata, absence of bundled Core resources, the Modalix cross toolchain, and
+  the sysroot overlay without running Core-dependent examples.
+- `test-resolve-platform-config.sh`, `test-write-sdk-release.sh`, and
+  `test-devkit-platform-profile.sh` cover pre-release selection, image
+  provenance, protected release refs, and intentional Core-sync skipping.
 - `neat-status/` validates the `neat --json` assembly/status contract.
 - `insight-video-routing/` downloads a small H.264 video, streams it from the
   runner into the SDK container's published Insight video UDP port with

--- a/tests/sdk/run-in-container.sh
+++ b/tests/sdk/run-in-container.sh
@@ -10,6 +10,7 @@ REPRESENTATIVE_WORK="${WORK_DIR}/representative-builds"
 STATUS_JSON="${WORK_DIR}/neat-status.json"
 INSIGHT_WAIT_SECONDS="${NEAT_SDK_INSIGHT_WAIT_SECONDS:-30}"
 SDK_DEPS_MANIFEST="${SDK_DEPS_MANIFEST:-/usr/local/share/sima-sdk/deps/manifest.json}"
+SDK_RELEASE_FILE="${SDK_RELEASE_FILE:-/etc/sdk-release}"
 
 setup_sdk_environment() {
   if [[ -f /opt/bin/simaai-init-build-env ]]; then
@@ -254,12 +255,51 @@ test_hello_neat_python() {
   echo "Skipping Python runtime example; pyneat is validated on the DevKit side."
 }
 
+sdk_release_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '
+    $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+      value = $2
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      print value
+      exit
+    }
+  ' "${SDK_RELEASE_FILE}"
+}
+
+test_platform_cross_profile() {
+  local profile core_status platform_version platform_channel
+
+  test -r "${SDK_RELEASE_FILE}"
+  profile="$(sdk_release_value "SDK Profile")"
+  core_status="$(sdk_release_value "Neat Core")"
+  platform_version="$(sdk_release_value "Platform Version")"
+  platform_channel="$(sdk_release_value "Platform Channel")"
+
+  test "${profile}" = "platform-cross"
+  test "${core_status}" = "not bundled"
+  test "${platform_channel}" = "pre-release"
+  [[ "${platform_version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+~pre[0-9]+$ ]]
+  test ! -e /neat-resources/core-extra
+  test ! -e /neat-resources/core-src
+  test ! -e /neat-resources/apps-src
+}
+
 setup_sdk_environment
 
 rm -rf "${WORK_DIR}"
 mkdir -p "${HELLO_WORK}" "${REPRESENTATIVE_WORK}" "$(dirname "${STATUS_JSON}")"
 cp -a "${HELLO_SRC}/." "${HELLO_WORK}/"
 cp -a "${REPRESENTATIVE_SRC}/." "${REPRESENTATIVE_WORK}/"
+
+if [[ -r "${SDK_RELEASE_FILE}" ]] && [[ "$(sdk_release_value "SDK Profile")" == "platform-cross" ]]; then
+  run_test "Platform-only SDK profile" test_platform_cross_profile
+  run_test "Modalix cross toolchain" test_modalix_cross_toolchain
+  run_test "Representative sysroot overlay install" test_sysroot_overlay_representative
+  printf '\nPlatform-only SDK smoke tests passed.\n'
+  exit 0
+fi
 
 run_test "SDK status: neat --json" test_neat_status
 run_test "Modalix cross toolchain" test_modalix_cross_toolchain

--- a/tests/sdk/test-devkit-platform-profile.sh
+++ b/tests/sdk/test-devkit-platform-profile.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+DEVKIT_SH_FUNCTIONS_ONLY=1 source "${ROOT_DIR}/scripts/devkit.sh"
+
+cat > "${tmpdir}/platform-release" <<'EOF'
+SDK Profile = platform-cross
+Platform Version = 2.1.3~pre4460
+Neat Core = not bundled
+EOF
+
+platform_output="$(
+  SDK_RELEASE_FILE="${tmpdir}/platform-release" \
+  DEVKIT_NEAT_SYNC_REQUIRED=ON \
+  DEVKIT_NEAT_SYNC_CACHE_DIR="${tmpdir}/missing-cache" \
+    sync_neat_framework_to_devkit sima 192.0.2.1 22
+)" || fail "platform profile should skip Core sync successfully"
+
+grep -Fq 'Neat Core is not bundled in this platform SDK; skipping DevKit Core synchronization.' \
+  <<< "${platform_output}" || fail "platform profile did not explain the Core sync skip"
+
+cat > "${tmpdir}/full-release" <<'EOF'
+SDK Profile = full
+Platform Version = 2.1.2
+Neat Core = bundled
+EOF
+
+full_output="$(
+  SDK_RELEASE_FILE="${tmpdir}/full-release" \
+  DEVKIT_NEAT_SYNC=OFF \
+    sync_neat_framework_to_devkit sima 192.0.2.1 22
+)" || fail "full profile with sync disabled should succeed"
+
+grep -Fq 'Neat framework DevKit sync disabled' <<< "${full_output}" || \
+  fail "full profile no longer follows the existing sync switch"
+
+echo "devkit platform profile tests passed"

--- a/tests/sdk/test-resolve-platform-config.sh
+++ b/tests/sdk/test-resolve-platform-config.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RESOLVER="${ROOT_DIR}/scripts/resolve-platform-config.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+cat > "${tmpdir}/Packages" <<'EOF'
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4040
+Architecture: arm64
+
+Package: another-package
+Version: 9.9.9
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4460
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.2~pre9999
+Architecture: arm64
+EOF
+
+cat > "${tmpdir}/dpkg" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "--compare-versions" && "$3" == "gt" ]]
+left="${2##*~pre}"
+right="${4##*~pre}"
+(( left > right ))
+EOF
+chmod 755 "${tmpdir}/dpkg"
+
+run_resolver() {
+  PRE_RELEASE_PACKAGES_FILE="${tmpdir}/Packages" \
+    DPKG_COMMAND="${tmpdir}/dpkg" \
+    STABLE_BASE_SDK_VERSION=2.1.2 \
+    "${RESOLVER}"
+}
+
+stable="$(PRE_RELEASE_BASE= GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_resolver)"
+grep -Fxq 'sdk_apt_channel=release' <<< "${stable}" || fail "stable channel was not selected"
+grep -Fxq 'base_sdk_version=2.1.2' <<< "${stable}" || fail "stable version was incorrect"
+
+floating="$(PRE_RELEASE_BASE=2.1.3 GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_resolver)"
+grep -Fxq 'sdk_apt_channel=pre-release' <<< "${floating}" || fail "pre-release channel was not selected"
+grep -Fxq 'base_sdk_version=2.1.3~pre4460' <<< "${floating}" || fail "floating selector did not choose the newest Debian version"
+
+pinned="$(PRE_RELEASE_BASE=2.1.3~pre4040 GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main run_resolver)"
+grep -Fxq 'base_sdk_version=2.1.3~pre4040' <<< "${pinned}" || fail "pinned selector changed versions"
+
+for protected_ref in main release-2.1; do
+  if PRE_RELEASE_BASE=2.1.3 GITHUB_REF_TYPE=branch GITHUB_REF_NAME="${protected_ref}" run_resolver >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+    fail "floating selector was accepted for protected branch ${protected_ref}"
+  fi
+  grep -Fq 'floating PRE_RELEASE_BASE=2.1.3 is not allowed' "${tmpdir}/err" || fail "protected branch error was unclear"
+done
+
+if PRE_RELEASE_BASE=2.1.3 GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v2.1.3 run_resolver >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "floating selector was accepted for a tag"
+fi
+
+if PRE_RELEASE_BASE=2.1.3~pre9999 GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_resolver >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "missing pinned version was accepted"
+fi
+grep -Fq 'is not present' "${tmpdir}/err" || fail "missing pinned version error was unclear"
+
+if PRE_RELEASE_BASE=latest GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_resolver >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "malformed selector was accepted"
+fi
+
+echo "platform config resolver tests passed"

--- a/tests/sdk/test-resolve-platform-config.sh
+++ b/tests/sdk/test-resolve-platform-config.sh
@@ -31,6 +31,39 @@ Version: 2.1.2~pre9999
 Architecture: arm64
 EOF
 
+cat > "${tmpdir}/CurrentPackages" <<'EOF'
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4460
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4593
+Architecture: arm64
+EOF
+gzip -c "${tmpdir}/CurrentPackages" > "${tmpdir}/CurrentPackages.gz"
+if command -v sha256sum >/dev/null 2>&1; then
+  current_packages_digest="$(sha256sum "${tmpdir}/CurrentPackages.gz" | awk '{print $1}')"
+else
+  current_packages_digest="$(shasum -a 256 "${tmpdir}/CurrentPackages.gz" | awk '{print $1}')"
+fi
+cat > "${tmpdir}/Release" <<EOF
+Acquire-By-Hash: yes
+SHA256:
+ ${current_packages_digest} $(wc -c < "${tmpdir}/CurrentPackages.gz" | tr -d ' ') non-free/binary-arm64/Packages.gz
+EOF
+
+cat > "${tmpdir}/curl" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+case "\${url}" in
+  */Release) cat "${tmpdir}/Release" ;;
+  */by-hash/SHA256/${current_packages_digest}) cat "${tmpdir}/CurrentPackages.gz" ;;
+  *) echo "unexpected URL: \${url}" >&2; exit 1 ;;
+esac
+EOF
+chmod 755 "${tmpdir}/curl"
+
 cat > "${tmpdir}/dpkg" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -42,7 +75,7 @@ EOF
 chmod 755 "${tmpdir}/dpkg"
 
 run_resolver() {
-  PRE_RELEASE_PACKAGES_FILE="${tmpdir}/Packages" \
+  PRE_RELEASE_PACKAGES_FILE="${PRE_RELEASE_PACKAGES_FILE-${tmpdir}/Packages}" \
     DPKG_COMMAND="${tmpdir}/dpkg" \
     STABLE_BASE_SDK_VERSION=2.1.2 \
     "${RESOLVER}"
@@ -55,6 +88,30 @@ grep -Fxq 'base_sdk_version=2.1.2' <<< "${stable}" || fail "stable version was i
 floating="$(PRE_RELEASE_BASE=2.1.3 GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_resolver)"
 grep -Fxq 'sdk_apt_channel=pre-release' <<< "${floating}" || fail "pre-release channel was not selected"
 grep -Fxq 'base_sdk_version=2.1.3~pre4460' <<< "${floating}" || fail "floating selector did not choose the newest Debian version"
+
+by_hash_floating="$(
+  PRE_RELEASE_BASE=2.1.3 \
+    PRE_RELEASE_PACKAGES_FILE= \
+    PRE_RELEASE_RELEASE_URL=https://mirror.test/pre-release/dists/bookworm/Release \
+    CURL_COMMAND="${tmpdir}/curl" \
+    GITHUB_REF_TYPE=branch \
+    GITHUB_REF_NAME=develop \
+    run_resolver
+)"
+grep -Fxq 'base_sdk_version=2.1.3~pre4593' <<< "${by_hash_floating}" || \
+  fail "floating selector did not use the current by-hash package index"
+
+by_hash_pinned="$(
+  PRE_RELEASE_BASE=2.1.3~pre4460 \
+    PRE_RELEASE_PACKAGES_FILE= \
+    PRE_RELEASE_RELEASE_URL=https://mirror.test/pre-release/dists/bookworm/Release \
+    CURL_COMMAND="${tmpdir}/curl" \
+    GITHUB_REF_TYPE=branch \
+    GITHUB_REF_NAME=develop \
+    run_resolver
+)"
+grep -Fxq 'base_sdk_version=2.1.3~pre4460' <<< "${by_hash_pinned}" || \
+  fail "exact pre-release selector did not remain pinned"
 
 pinned="$(PRE_RELEASE_BASE=2.1.3~pre4040 GITHUB_REF_TYPE=branch GITHUB_REF_NAME=main run_resolver)"
 grep -Fxq 'base_sdk_version=2.1.3~pre4040' <<< "${pinned}" || fail "pinned selector changed versions"

--- a/tests/sdk/test-resolve-platform-config.sh
+++ b/tests/sdk/test-resolve-platform-config.sh
@@ -79,4 +79,15 @@ if PRE_RELEASE_BASE=latest GITHUB_REF_TYPE=branch GITHUB_REF_NAME=develop run_re
   fail "malformed selector was accepted"
 fi
 
+patterns_file="${ROOT_DIR}/config/platform-package-patterns.txt"
+grep -Fxq 'simaai-palette-modalix' "${patterns_file}" || fail "Modalix palette is not platform-versioned"
+grep -Fxq 'simaai-palette-davinci' "${patterns_file}" || fail "Davinci palette is not platform-versioned"
+if grep -Fxq 'simaai-palette-*' "${patterns_file}"; then
+  fail "palette wildcard incorrectly forces simaai-palette-upgrade to the platform version"
+fi
+if grep -Fq '"simaai-palette-*"' "${ROOT_DIR}/scripts/simaai_setup_sdk.py" || \
+   grep -Fq '  simaai-palette-*' "${ROOT_DIR}/scripts/validate-sysroot-package-versions.sh"; then
+  fail "fallback platform patterns still classify simaai-palette-upgrade as platform-versioned"
+fi
+
 echo "platform config resolver tests passed"

--- a/tests/sdk/test-resolve-platform-config.sh
+++ b/tests/sdk/test-resolve-platform-config.sh
@@ -90,4 +90,10 @@ if grep -Fq '"simaai-palette-*"' "${ROOT_DIR}/scripts/simaai_setup_sdk.py" || \
   fail "fallback platform patterns still classify simaai-palette-upgrade as platform-versioned"
 fi
 
+apt_config_script="${ROOT_DIR}/scripts/configure-apt-repos.sh"
+grep -Fq 'sdk_fallback_repository="https://repo.sima.ai/elxr/deb/release"' "${apt_config_script}" || \
+  fail "pre-release APT configuration does not retain the release repository fallback"
+grep -Fq 'deb [trusted=yes] ${sdk_fallback_repository} bookworm non-free' "${apt_config_script}" || \
+  fail "release fallback is not written to the APT source list"
+
 echo "platform config resolver tests passed"

--- a/tests/sdk/test-resolve-platform-config.sh
+++ b/tests/sdk/test-resolve-platform-config.sh
@@ -153,4 +153,10 @@ grep -Fq 'sdk_fallback_repository="https://repo.sima.ai/elxr/deb/release"' "${ap
 grep -Fq 'deb [trusted=yes] ${sdk_fallback_repository} bookworm non-free' "${apt_config_script}" || \
   fail "release fallback is not written to the APT source list"
 
+docker_workflow="${ROOT_DIR}/.github/workflows/docker-build.yml"
+grep -Fq 'pre_release_base:' "${docker_workflow}" || \
+  fail "manual workflow dispatch does not expose a pre-release selector"
+grep -Fq 'PRE_RELEASE_BASE: ${{ inputs.pre_release_base || vars.PRE_RELEASE_BASE }}' "${docker_workflow}" || \
+  fail "manual pre-release selector does not override the repository variable"
+
 echo "platform config resolver tests passed"

--- a/tests/sdk/test-write-sdk-release.sh
+++ b/tests/sdk/test-write-sdk-release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRITER="${ROOT_DIR}/scripts/write-sdk-release.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+SDK_RELEASE_FILE="${tmpdir}/platform-release" \
+SDK_RELEASE_REF=develop-abcdef1 \
+BASE_SDK_VERSION=2.1.3~pre4460 \
+SDK_APT_CHANNEL=pre-release \
+REQUESTED_PRE_RELEASE_BASE=2.1.3 \
+SDK_GIT_BRANCH=develop \
+SDK_GIT_HASH=abcdef1 \
+  "${WRITER}"
+
+grep -Fxq 'SDK Profile = platform-cross' "${tmpdir}/platform-release" || fail "profile missing"
+grep -Fxq 'Platform Version = 2.1.3~pre4460' "${tmpdir}/platform-release" || fail "exact platform version missing"
+grep -Fxq 'Platform Base = 2.1.3' "${tmpdir}/platform-release" || fail "platform base missing"
+grep -Fxq 'Platform Channel = pre-release' "${tmpdir}/platform-release" || fail "channel missing"
+grep -Fxq 'Requested Pre-release Base = 2.1.3' "${tmpdir}/platform-release" || fail "requested selector missing"
+grep -Fxq 'Neat Core = not bundled' "${tmpdir}/platform-release" || fail "Core status missing"
+
+SDK_RELEASE_FILE="${tmpdir}/stable-release" \
+SDK_RELEASE_REF=v2.1.2 \
+BASE_SDK_VERSION=2.1.2 \
+SDK_APT_CHANNEL=release \
+  "${WRITER}"
+
+grep -Fxq 'Neat Core = bundled' "${tmpdir}/stable-release" || fail "stable Core status changed"
+grep -Fxq 'SDK Version = 2.1.2_Palette_SDK_neat_v2.1.2' "${tmpdir}/stable-release" || fail "tag release format changed"
+
+echo "sdk release metadata tests passed"


### PR DESCRIPTION
## Summary

- resolve floating or pinned `PRE_RELEASE_BASE` once before the architecture build matrix
- allow manual workflow runs to override the repository variable with an optional exact or floating selector
- follow the mirror `Release` metadata to the current Acquire-By-Hash package index for floating and pinned selectors
- reject floating pre-release selectors on `main`, `release-*`, and tag refs
- build pre-release images from `debian.neat.sima.ai` without bundling Neat Core
- record the exact platform version, channel, repository, SDK profile, and Core status in `/etc/sdk-release`
- let `devkit.sh` pair platform-only SDK images while intentionally skipping Core synchronization
- keep stable/full SDK behavior unchanged when `PRE_RELEASE_BASE` is unset

Closes #142.

## Implementation notes

`build.sh` remains a thin wrapper. CI resolves the floating selector and passes only the exact `BASE_SDK_VERSION`, `SDK_APT_CHANNEL`, and requested selector to Docker. Redundant platform base, repository, profile, and Core flags are derived in image scripts.

## Validation

- all `tests/sdk/test-*.sh` scripts
- shell syntax validation for build, SDK scripts, and test scripts
- GitHub Actions workflow YAML parse
- live mirror lookup confirms floating `2.1.3` resolves to `2.1.3~pre4593`
- live mirror lookup confirms pinned `2.1.3~pre4460` remains exactly `2.1.3~pre4460`

An image-level build was not run locally because Docker is unavailable on the Mac; branch CI is expected to provide that validation.