### PR TITLE
Pin sima-cli installer used by SDK builds

### DIFF
--- a/scripts/install-sima-cli.sh
+++ b/scripts/install-sima-cli.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 root_venv=/root/.sima-cli/.venv
 install_venv=/opt/sima-cli/venv
 installer=/tmp/sima-cli-install.py
-installer_url=https://artifacts.neat.sima.ai/sima-cli/install.py
+# Keep the installer source and checksum immutable. The floating CDN path is
+# updated whenever sima-cli main publishes and can otherwise break an SDK build
+# whose expected checksum intentionally remains pinned.
+installer_source_commit=6c29a46682bc74a5e95dd2410e8653c7c5264c53
+installer_url="https://raw.githubusercontent.com/sima-neat/sima-cli/${installer_source_commit}/scripts/install/install.py"
 installer_sha256=9d7acf0bfb24f7b32abd305754359744f1034bbd1a440b6310037eef90696c25
 sima_cli_ref="${SIMA_CLI_REF:?SIMA_CLI_REF is required}"
 sima_cli_version="${SIMA_CLI_VERSION:?SIMA_CLI_VERSION is required}"

--- a/tests/sdk/test-build-script.sh
+++ b/tests/sdk/test-build-script.sh
@@ -95,4 +95,13 @@ if (( release_marker_line <= resource_install_line )); then
   exit 1
 fi
 
+installer_script="${ROOT_DIR}/scripts/install-sima-cli.sh"
+grep -Fq 'installer_source_commit=6c29a46682bc74a5e95dd2410e8653c7c5264c53' "${installer_script}"
+grep -Fq 'raw.githubusercontent.com/sima-neat/sima-cli/${installer_source_commit}/scripts/install/install.py' "${installer_script}"
+grep -Fq 'installer_sha256=9d7acf0bfb24f7b32abd305754359744f1034bbd1a440b6310037eef90696c25' "${installer_script}"
+if grep -Fq 'artifacts.neat.sima.ai/sima-cli/install.py' "${installer_script}"; then
+  echo "The SDK must not checksum a mutable sima-cli installer URL." >&2
+  exit 1
+fi
+
 echo "SDK build helper tests passed."


### PR DESCRIPTION
Fixes #148

## Summary

- download the sima-cli installer from the immutable commit behind `v2.1.15`
- retain the existing verified SHA-256 checksum
- prevent future sima-cli `main` publications from changing the installer beneath stable SDK builds
- add regression checks rejecting the mutable installer URL

Fixes the checksum failure in [develop run 31507954877](https://github.com/sima-neat/sdk/actions/runs/31507954877/job/93834329634).

## Validation

- all `tests/sdk/test-*.sh`
- `bash -n scripts/install-sima-cli.sh`
- downloaded the commit-pinned installer and verified SHA-256 `9d7acf0bfb24f7b32abd305754359744f1034bbd1a440b6310037eef90696c25`
- `git diff --check`