### PR TITLE
Add pre-release sysroot overlay updates

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,7 @@ jobs:
           tests/sdk/test-resolve-platform-config.sh
           tests/sdk/test-write-sdk-release.sh
           tests/sdk/test-devkit-platform-profile.sh
+          tests/sdk/test-sysroot-unprivileged-dry-run.sh
           tests/sdk/test-sysroot-update.sh
           python3 tests/sdk/test-sysroot-progress.py
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,8 @@ jobs:
           tests/sdk/test-resolve-platform-config.sh
           tests/sdk/test-write-sdk-release.sh
           tests/sdk/test-devkit-platform-profile.sh
+          tests/sdk/test-sysroot-update.sh
+          python3 tests/sdk/test-sysroot-progress.py
 
   build:
     name: Build on ${{ matrix.arch }}

--- a/config/profile.d/neat-sdk-prompt.sh
+++ b/config/profile.d/neat-sdk-prompt.sh
@@ -15,8 +15,13 @@ if [[ $- == *i* ]]; then
   SDK_PROMPT_HOSTNAME="${SDK_BASE_PROMPT_HOSTNAME}"
   _sdk_sysroot_overlay="${SYSROOT:-/opt/toolchain/aarch64/modalix}/var/lib/sima-sdk/sysroot-overlay"
   if [[ -r "${_sdk_sysroot_overlay}" ]]; then
+    _sdk_overlay_state="$(awk -F ' = ' '$1 == "Overlay State" { print $2; exit }' "${_sdk_sysroot_overlay}")"
     _sdk_overlay_revision="$(awk -F ' = ' '$1 == "Platform Revision" { print $2; exit }' "${_sdk_sysroot_overlay}")"
-    SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME}-overlay-$(_sdk_prompt_slug "${_sdk_overlay_revision:-active}")"
+    if [[ "${_sdk_overlay_state}" == "active" ]]; then
+      SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME}-overlay-$(_sdk_prompt_slug "${_sdk_overlay_revision:-unknown}")"
+    else
+      SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME}-overlay-$(_sdk_prompt_slug "${_sdk_overlay_state:-unknown}")-$(_sdk_prompt_slug "${_sdk_overlay_revision:-unknown}")"
+    fi
   fi
   export SDK_PROMPT_HOSTNAME
   _sdk_rewrite_prompt_hostname() {

--- a/config/profile.d/neat-sdk-prompt.sh
+++ b/config/profile.d/neat-sdk-prompt.sh
@@ -11,7 +11,14 @@ if [[ $- == *i* ]]; then
     value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9-]+/-/g; s/-+/-/g; s/^-|-$//g')"
     printf '%s' "${value:-unknown}"
   }
-  export SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME:-neat-sdk-$(_sdk_prompt_slug "${SDK_PROMPT_REF}")}"
+  export SDK_BASE_PROMPT_HOSTNAME="${SDK_BASE_PROMPT_HOSTNAME:-${SDK_PROMPT_HOSTNAME:-neat-sdk-$(_sdk_prompt_slug "${SDK_PROMPT_REF}")}}"
+  SDK_PROMPT_HOSTNAME="${SDK_BASE_PROMPT_HOSTNAME}"
+  _sdk_sysroot_overlay="${SYSROOT:-/opt/toolchain/aarch64/modalix}/var/lib/sima-sdk/sysroot-overlay"
+  if [[ -r "${_sdk_sysroot_overlay}" ]]; then
+    _sdk_overlay_revision="$(awk -F ' = ' '$1 == "Platform Revision" { print $2; exit }' "${_sdk_sysroot_overlay}")"
+    SDK_PROMPT_HOSTNAME="${SDK_PROMPT_HOSTNAME}-overlay-$(_sdk_prompt_slug "${_sdk_overlay_revision:-active}")"
+  fi
+  export SDK_PROMPT_HOSTNAME
   _sdk_rewrite_prompt_hostname() {
     local prompt="${1-}"
     prompt="${prompt//\\h/${SDK_PROMPT_HOSTNAME}}"

--- a/docs/building-sdk-image.md
+++ b/docs/building-sdk-image.md
@@ -138,12 +138,83 @@ For OpenCV CMake component names, `sysroot` can resolve names such as `opencv_dn
 sudo sysroot install opencv_dnn
 ```
 
-Packages installed through `sysroot install` are tracked in lightweight manifests, so they can be listed or removed later:
+Packages installed through `sysroot install` are tracked in lightweight
+manifests so they can be removed later. `sysroot list` reports the complete
+image or overlay inventory:
 
 ```bash
 sysroot list
 sudo sysroot remove libzix-dev
 ```
+
+### Test a Pre-release Platform Sysroot Overlay
+
+To test a newer pre-release platform revision without rebuilding the SDK
+image, use `sysroot update` inside the SDK container. With no revision, the
+command queries the public pre-release mirror and offers only revisions that
+match the immutable image's `Platform Base` from `/etc/sdk-release`:
+
+```bash
+sudo sysroot update
+```
+
+Providing an exact revision is noninteractive and is suitable for automation:
+
+```bash
+sudo sysroot update 2.1.3~pre4617
+```
+
+Following the newest eligible revision requires explicit confirmation in
+noninteractive environments. A dry run downloads and validates the dependency
+cohort without extracting it into the sysroot:
+
+```bash
+sudo sysroot update --latest --yes
+sudo sysroot update 2.1.3~pre4617 --dry-run
+```
+
+This command is deliberately restricted to pre-release development and
+testing. It refuses stable versions and revisions outside the SDK's Platform
+Base. For example, an SDK with `Platform Base = 2.1.3` cannot update its
+sysroot to `2.2.0~preN`.
+
+An update creates a visible **sysroot overlay** rather than changing the
+immutable SDK image identity. Inspect both states with:
+
+```bash
+sysroot status
+```
+
+List the complete package inventory for either the image-default sysroot or
+the active overlay with:
+
+```bash
+sysroot list
+```
+
+The table includes package name, architecture, exact version, and summarized
+payload locations relative to the displayed sysroot. A package may show
+multiple locations because Debian packages commonly contain both headers and
+libraries. Manual `sysroot install` and `sysroot remove` operations update the
+same inventory.
+
+New interactive shells include the active overlay revision in the SDK prompt.
+The overlay descriptor and exact package inventory are stored under
+`/opt/toolchain/aarch64/modalix/var/lib/sima-sdk/`. Recreate the SDK container
+to discard the overlay and restore the image-default sysroot. Because this is
+an in-place overlay, recreating the container is also the way to guarantee that
+files removed between platform revisions are absent from the sysroot.
+
+Package downloads use eight workers by default and validated downloads are
+cached per platform revision under `/tmp`. Override the concurrency when
+needed, for example `SIMAAI_DOWNLOAD_WORKERS=16 sudo -E sysroot update ...`.
+Retries of the same revision reuse valid cached packages. Interactive terminals
+show animated download and extraction progress; CI logs receive periodic
+plain-text progress updates.
+
+The pre-release repository currently uses HTTPS transport with APT
+`trusted=yes`; this is not equivalent to signed APT repository metadata. The
+command prints this trust mode before every update.
 
 ## NEAT Insight Version
 

--- a/scripts/setup-sdk-sysroot.sh
+++ b/scripts/setup-sdk-sysroot.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 base_sdk_version="${1:?Usage: setup-sdk-sysroot.sh BASE_SDK_VERSION SDK_PKG_LIST}"
 sdk_pkg_list="${2:-}"
+sysroot="${SYSROOT:-/opt/toolchain/aarch64/modalix}"
+download_dir="${SYSROOT_UPDATE_DOWNLOAD_DIR:-/tmp/modalix}"
+python_command="${SDK_SYSROOT_PYTHON:-/usr/bin/python3}"
 sysroot_pref=/etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
 if [[ "${SDK_APT_CHANNEL:-release}" == "pre-release" ]]; then
   sdk_apt_origin="debian.neat.sima.ai"
@@ -46,5 +49,7 @@ EOF
   trap cleanup_sysroot_pref EXIT
 fi
 
-python3 /opt/bin/simaai_setup_sdk.py modalix "${base_sdk_version}" "${sdk_pkg_list}"
-validate-sysroot-package-versions.sh "${base_sdk_version}" /tmp/modalix /opt/toolchain/aarch64/modalix
+SIMAAI_SYSROOT="${sysroot}" \
+SIMAAI_DOWNLOAD_DIR="${download_dir}" \
+"${python_command}" /opt/bin/simaai_setup_sdk.py modalix "${base_sdk_version}" "${sdk_pkg_list}"
+validate-sysroot-package-versions.sh "${base_sdk_version}" "${download_dir}" "${sysroot}"

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -10,6 +10,8 @@ Local SDK image changes:
   dependency is unversioned.
 - Never fall back to the newest candidate for SDK-versioned packages.
 - Validate downloaded SDK-versioned packages before extraction.
+- For an explicit local sysroot overlay, prefer the selected ~preN build
+  cohort for dependencies whose package versions carry that build suffix.
 - Keep extraction deterministic and extract platform-owned packages after
   generic build dependencies.
 - Skip libdlpack-dev because the SiMa TVM package owns the compatible
@@ -17,12 +19,15 @@ Local SDK image changes:
 """
 
 import apt
+import concurrent.futures
 import fnmatch
 import glob
+import hashlib
 import os
 import shutil
 import subprocess
 import sys
+import threading
 import time
 
 
@@ -81,6 +86,156 @@ def load_platform_package_patterns():
 
 
 PLATFORM_PACKAGE_PATTERNS = load_platform_package_patterns()
+PLATFORM_BUILD_REVISION = os.environ.get("SIMAAI_PLATFORM_BUILD_REVISION", "")
+DOWNLOAD_WORKERS = max(1, int(os.environ.get("SIMAAI_DOWNLOAD_WORKERS", "8")))
+
+
+class DownloadProgress:
+    """TTY spinner and log-safe progress checkpoints for package downloads."""
+
+    SPINNER = ("|", "/", "-", "\\")
+
+    def __init__(self):
+        self.started_at = time.monotonic()
+        self.known = set()
+        self.completed = set()
+        self.cached = set()
+        self.lock = threading.Lock()
+        self.stop_event = None
+        self.thread = None
+        self.is_tty = sys.stdout.isatty()
+        self.last_log_at = self.started_at
+
+    def discover(self, names):
+        with self.lock:
+            self.known.update(names)
+
+    def complete(self, name, cached):
+        with self.lock:
+            self.completed.add(name)
+            if cached:
+                self.cached.add(name)
+
+    def snapshot(self):
+        with self.lock:
+            ready = len(self.completed)
+            total = len(self.known)
+            cached = len(self.cached)
+        elapsed = int(time.monotonic() - self.started_at)
+        return ready, total, cached, elapsed
+
+    def message(self, frame=0):
+        ready, total, cached, elapsed = self.snapshot()
+        downloaded = ready - cached
+        spinner = self.SPINNER[frame % len(self.SPINNER)]
+        return (
+            f"{spinner} Packages ready: {ready}/{total} "
+            f"(downloaded {downloaded}, cached {cached}) [{elapsed}s]"
+        )
+
+    def render_loop(self):
+        frame = 0
+        interval = 0.2 if self.is_tty else 15
+        while not self.stop_event.wait(interval):
+            if self.is_tty:
+                print(f"\r\033[2K{self.message(frame)}", end="", flush=True)
+            else:
+                print(self.message(frame), flush=True)
+                self.last_log_at = time.monotonic()
+            frame += 1
+
+    def begin_batch(self, names):
+        self.discover(names)
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(target=self.render_loop, daemon=True)
+        self.thread.start()
+
+    def end_batch(self):
+        if self.stop_event is not None:
+            self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join()
+        if self.is_tty:
+            print(f"\r\033[2K{self.message()} ", flush=True)
+        elif time.monotonic() - self.last_log_at >= 15:
+            print(self.message(), flush=True)
+            self.last_log_at = time.monotonic()
+        self.stop_event = None
+        self.thread = None
+
+    def finish(self):
+        ready, total, cached, elapsed = self.snapshot()
+        print(
+            f"Package transfer complete: {ready}/{total} ready "
+            f"({ready - cached} downloaded, {cached} cached) in {elapsed}s.",
+            flush=True,
+        )
+
+
+class ExtractionProgress:
+    """Show activity while packages are extracted sequentially."""
+
+    SPINNER = DownloadProgress.SPINNER
+
+    def __init__(self, total):
+        self.total = total
+        self.completed = 0
+        self.current = "waiting"
+        self.started_at = time.monotonic()
+        self.lock = threading.Lock()
+        self.stop_event = threading.Event()
+        self.is_tty = sys.stdout.isatty()
+        self.thread = threading.Thread(target=self.render_loop, daemon=True)
+
+    def message(self, frame=0):
+        with self.lock:
+            completed = self.completed
+            current = self.current
+        elapsed = int(time.monotonic() - self.started_at)
+        spinner = self.SPINNER[frame % len(self.SPINNER)]
+        return (
+            f"{spinner} Extracting packages: {completed}/{self.total} "
+            f"(current: {current}) [{elapsed}s]"
+        )
+
+    def render_loop(self):
+        frame = 0
+        interval = 0.2 if self.is_tty else 15
+        while not self.stop_event.wait(interval):
+            if self.is_tty:
+                print(f"\r\033[2K{self.message(frame)}", end="", flush=True)
+            else:
+                print(self.message(frame), flush=True)
+            frame += 1
+
+    def start(self):
+        self.thread.start()
+
+    def begin_package(self, filename):
+        with self.lock:
+            self.current = filename
+
+    def complete_package(self):
+        with self.lock:
+            self.completed += 1
+
+    def finish(self, succeeded=True):
+        self.stop_event.set()
+        self.thread.join()
+        elapsed = int(time.monotonic() - self.started_at)
+        if self.is_tty:
+            print("\r\033[2K", end="", flush=True)
+        state = "complete" if succeeded else "stopped"
+        print(
+            f"Package extraction {state}: {self.completed}/{self.total} in {elapsed}s.",
+            flush=True,
+        )
+
+
+def matches_platform_build_revision(package_version, build_revision):
+    if not build_revision or not build_revision.isdigit():
+        return False
+    return package_version.endswith(f"~pre{build_revision}")
 
 
 def update_apt_cache(cache):
@@ -123,6 +278,97 @@ def normalize_arm64_name(pkgname):
 
 def package_field(deb_path, field):
     return subprocess.check_output(["dpkg-deb", "-f", deb_path, field], text=True).strip()
+
+
+def package_control_fields(deb_path, *wanted_fields):
+    """Read several Debian control fields with one dpkg-deb process."""
+
+    output = subprocess.check_output(
+        ["dpkg-deb", "-f", deb_path, *wanted_fields], text=True
+    )
+    values = {}
+    for line in output.splitlines():
+        field, separator, value = line.partition(":")
+        if separator:
+            values[field] = value.strip()
+    missing = [field for field in wanted_fields if field not in values]
+    if missing:
+        raise RuntimeError(
+            f"Missing control fields {', '.join(missing)} in {deb_path}"
+        )
+    return tuple(values[field] for field in wanted_fields)
+
+
+def package_payload_locations(deb_path):
+    """Summarize the primary sysroot directories populated by a package."""
+
+    listing = subprocess.check_output(["dpkg-deb", "-c", deb_path], text=True)
+    locations = set()
+    for line in listing.splitlines():
+        fields = line.split(maxsplit=5)
+        if len(fields) < 6:
+            continue
+        path = fields[5].split(" ->", 1)[0].removeprefix("./").lstrip("/")
+        if not path or path.endswith("/"):
+            continue
+        parts = path.split("/")
+        if len(parts) >= 3 and parts[:2] == ["usr", "lib"] and parts[2].endswith("linux-gnu"):
+            locations.add("/" + "/".join(parts[:3]))
+        elif len(parts) >= 2:
+            locations.add("/" + "/".join(parts[:2]))
+        else:
+            locations.add("/" + parts[0])
+    return ",".join(sorted(locations))
+
+
+def write_sysroot_package_inventory(download_dir, sysroot):
+    """Record every package represented by the resolved sysroot cohort."""
+
+    deb_paths = sorted(
+        os.path.join(download_dir, filename)
+        for filename in os.listdir(download_dir)
+        if filename.endswith(".deb")
+        and os.path.isfile(os.path.join(download_dir, filename))
+    )
+    if not deb_paths:
+        raise RuntimeError("Cannot record an empty sysroot package inventory")
+
+    print(
+        f"Recording package inventory for {len(deb_paths)} packages...",
+        flush=True,
+    )
+
+    def inspect_package(deb_path):
+        package, architecture, version = package_control_fields(
+            deb_path, "Package", "Architecture", "Version"
+        )
+        return (
+            package,
+            architecture,
+            version,
+            package_payload_locations(deb_path),
+        )
+
+    entries = {}
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(DOWNLOAD_WORKERS, len(deb_paths))
+    ) as executor:
+        inspected = executor.map(inspect_package, deb_paths)
+    for package, architecture, version, locations in inspected:
+        entries[(package, architecture)] = (
+            version,
+            locations,
+        )
+
+    inventory_dir = os.path.join(sysroot, "var/lib/sima-sdk")
+    inventory = os.path.join(inventory_dir, "sysroot-packages.tsv")
+    temporary = f"{inventory}.tmp"
+    os.makedirs(inventory_dir, exist_ok=True)
+    with open(temporary, "wt", encoding="utf-8") as wf:
+        for (package, architecture), (version, locations) in sorted(entries.items()):
+            wf.write(f"{package}\t{architecture}\t{version}\t{locations}\n")
+    os.replace(temporary, inventory)
+    print(f"Recorded {len(entries)} package inventory entries.", flush=True)
 
 
 def main(pkg_name, version, libc_ver, dldir, installdir):
@@ -199,12 +445,14 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
                 return None
             return None
 
-        return pkg.candidate
+        if PLATFORM_BUILD_REVISION:
+            for candidate in pkg.versions:
+                if matches_platform_build_revision(
+                    candidate.version, PLATFORM_BUILD_REVISION
+                ):
+                    return candidate
 
-    def expected_download_version(pkgname, requested_version):
-        if is_platform_package(pkgname):
-            return requested_version or version
-        return ""
+        return pkg.candidate
 
     def collect_rdeps(candidate, recursive):
         """Collect the runtime dependencies of the package."""
@@ -233,49 +481,127 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
                     collect_rdeps(get_candidate(name, ver), recursive)
 
     expected_versions_manifest = os.path.join(dldir, "expected-package-versions.tsv")
+    expected_versions_lock = threading.Lock()
+    selected_downloads = set()
+    selected_downloads_lock = threading.Lock()
+    download_progress = DownloadProgress()
 
     def record_expected_version(pkg, expected_version):
         if expected_version:
-            with open(expected_versions_manifest, "at", encoding="utf-8") as wf:
-                wf.write(f"{pkg}\t{expected_version}\n")
+            with expected_versions_lock:
+                with open(expected_versions_manifest, "at", encoding="utf-8") as wf:
+                    wf.write(f"{pkg}\t{expected_version}\n")
 
-    def download(uri, dlname, expected_version):
+    def file_sha256(path):
+        digest = hashlib.sha256()
+        with open(path, "rb") as rf:
+            for chunk in iter(lambda: rf.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def downloaded_package_matches(
+        dlname, expected_package, expected_version, expected_sha256
+    ):
+        if not os.path.isfile(dlname):
+            return False
+        try:
+            pkg = package_field(dlname, "Package")
+            ver = package_field(dlname, "Version")
+        except (OSError, subprocess.SubprocessError):
+            return False
+        if pkg != expected_package or ver != expected_version:
+            return False
+        return not expected_sha256 or file_sha256(dlname) == expected_sha256
+
+    def download(uri, dlname, expected_package, expected_version, expected_sha256):
         """Download a package and validate the resolved package version."""
 
-        cmd = ["wget", uri, "-O", dlname]
-        ret = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        if ret.returncode != 0:
-            print(f"Error while downloading OSS package {dlname}:\n{ret.stderr}")
-            return
+        cached = downloaded_package_matches(
+            dlname, expected_package, expected_version, expected_sha256
+        )
+        if not cached:
+            partial = f"{dlname}.partial"
+            try:
+                os.unlink(partial)
+            except FileNotFoundError:
+                pass
+            cmd = ["wget", "--timeout=30", "--tries=3", uri, "-O", partial]
+            try:
+                subprocess.run(cmd, capture_output=True, text=True, check=True)
+                if expected_sha256 and file_sha256(partial) != expected_sha256:
+                    raise RuntimeError(
+                        f"SHA256 mismatch for downloaded package {expected_package}"
+                    )
+                os.replace(partial, dlname)
+            except (subprocess.CalledProcessError, RuntimeError) as exc:
+                try:
+                    os.unlink(partial)
+                except FileNotFoundError:
+                    pass
+                detail = getattr(exc, "stderr", None) or str(exc)
+                raise RuntimeError(
+                    f"Error while downloading OSS package {dlname}:\n{detail}"
+                ) from exc
 
         pkg = package_field(dlname, "Package")
         ver = package_field(dlname, "Version")
+        if pkg != expected_package:
+            raise RuntimeError(f"Unexpected package {pkg}; expected {expected_package}")
         if expected_version and ver != expected_version:
             raise RuntimeError(f"Unexpected {pkg} version {ver}; expected {expected_version}")
         record_expected_version(pkg, expected_version)
+        with selected_downloads_lock:
+            selected_downloads.add(os.path.abspath(dlname))
+        return cached
 
-    def collect_bdeps(candidate, name):
-        """Collect the build-time dependencies."""
+    def download_candidates(candidates):
+        """Download candidate tuples concurrently, then surface every failure."""
 
-        if candidate is None:
+        if not candidates:
             return
+        download_progress.begin_batch(name for name, _candidate in candidates)
+        try:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(DOWNLOAD_WORKERS, len(candidates))
+            ) as executor:
+                futures = {
+                    executor.submit(
+                        download,
+                        candidate.uri,
+                        os.path.join(dldir, f"{name}.deb"),
+                        base_package_name(name),
+                        candidate.version,
+                        candidate.record.get("SHA256", ""),
+                    ): name
+                    for name, candidate in candidates
+                }
+                for future in concurrent.futures.as_completed(futures):
+                    name = futures[future]
+                    download_progress.complete(name, future.result())
+        finally:
+            download_progress.end_batch()
 
-        dlname = dldir + "/" + name + ".deb"
-        # Need to download the package first to run dpkg-deb and find build
-        # dependencies.
-        download(candidate.uri, dlname, expected_download_version(name, ""))
+    def collect_bdeps(initial_packages):
+        """Collect build dependencies in parallel breadth-first batches."""
 
-        bdep_list = get_build_depends_list(dlname)
-
-        if bdep_list:
-            for bdep in bdep_list:
-                if not bdep:
-                    continue
-                if bdep in graph or bdep in shadow or bdep in blacklist:
-                    continue
-                ver = ""
-                shadow[bdep] = ver
-                collect_bdeps(get_candidate(bdep, ver), bdep)
+        pending = {
+            name: candidate
+            for name, candidate in initial_packages
+            if candidate is not None
+        }
+        while pending:
+            batch = list(pending.items())
+            download_candidates(batch)
+            pending = {}
+            for name, _candidate in batch:
+                dlname = os.path.join(dldir, f"{name}.deb")
+                for bdep in get_build_depends_list(dlname):
+                    if not bdep or bdep in graph or bdep in shadow or bdep in blacklist:
+                        continue
+                    shadow[bdep] = ""
+                    candidate = get_candidate(bdep, "")
+                    if candidate is not None:
+                        pending[bdep] = candidate
 
     def extract(filename):
         """Extract a package into the sysroot."""
@@ -405,14 +731,16 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
     graph["linux-libc-dev:arm64"] = libc_ver
 
     shadow.clear()
-    shutil.rmtree(dldir, ignore_errors=True)
+    if not PLATFORM_BUILD_REVISION:
+        shutil.rmtree(dldir, ignore_errors=True)
     os.makedirs(dldir, exist_ok=True)
     with open(expected_versions_manifest, "wt", encoding="utf-8"):
         pass
 
     print("Collecting buildtime dependencies...")
-    for name, ver in graph.items():
-        collect_bdeps(get_candidate(name, ver), name)
+    collect_bdeps(
+        (name, get_candidate(name, ver)) for name, ver in graph.items()
+    )
 
     full = graph.copy()
     full.update(shadow)
@@ -423,10 +751,25 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
 
     full.update(graph)
 
-    for name, ver in graph.items():
-        c = get_candidate(name, ver)
-        if c is not None:
-            download(c.uri, dldir + "/" + name + ".deb", expected_download_version(name, ver))
+    download_candidates(
+        [
+            (name, candidate)
+            for name, ver in graph.items()
+            if (candidate := get_candidate(name, ver)) is not None
+        ]
+    )
+    download_progress.finish()
+
+    for filename in os.listdir(dldir):
+        path = os.path.abspath(os.path.join(dldir, filename))
+        if filename.endswith(".partial") or (
+            filename.endswith(".deb") and path not in selected_downloads
+        ):
+            os.unlink(path)
+
+    if os.environ.get("SIMAAI_SETUP_DOWNLOAD_ONLY") == "1":
+        print("SDK package download and dependency validation completed; skipping extraction.")
+        return
 
     os.makedirs(installdir, exist_ok=True)
 
@@ -436,10 +779,21 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
         for filename in os.listdir(dldir)
         if os.path.isfile(os.path.join(dldir, filename)) and filename.endswith(".deb")
     ]
-    for filename in sorted(deb_files, key=extraction_sort_key):
-        extract(filename)
+    sorted_deb_files = sorted(deb_files, key=extraction_sort_key)
+    extraction_progress = ExtractionProgress(len(sorted_deb_files))
+    extraction_succeeded = False
+    extraction_progress.start()
+    try:
+        for filename in sorted_deb_files:
+            extraction_progress.begin_package(filename)
+            extract(filename)
+            extraction_progress.complete_package()
+        extraction_succeeded = True
+    finally:
+        extraction_progress.finish(extraction_succeeded)
 
     validate_tvm_dlpack_header()
+    write_sysroot_package_inventory(dldir, installdir)
 
     pcpath = "usr/lib/aarch64-linux-gnu/pkgconfig/"
     tweak_conf(installdir + "/" + pcpath + "*.pc", "=/usr", "=" + installdir + "/usr")
@@ -473,7 +827,9 @@ if __name__ == "__main__":
         whitelist = []
 
     pkg_name = f"simaai-palette-{platform}:arm64"
-    installdir = f"/opt/toolchain/aarch64/{platform}"
-    dldir = f"/tmp/{platform}"
+    installdir = os.environ.get(
+        "SIMAAI_SYSROOT", f"/opt/toolchain/aarch64/{platform}"
+    )
+    dldir = os.environ.get("SIMAAI_DOWNLOAD_DIR", f"/tmp/{platform}")
 
     main(pkg_name, palette_ver, libc_ver, dldir, installdir)

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -71,23 +71,23 @@ def rewrite_config_paths(data, old, new):
     """Replace config paths without rewriting an already-prefixed value."""
     if not old or old == new:
         return data
-    if not new.endswith(old):
-        return data.replace(old, new)
 
-    prefix = new[: -len(old)]
     rewritten = []
     cursor = 0
     while True:
-        position = data.find(old, cursor)
-        if position < 0:
+        old_position = data.find(old, cursor)
+        new_position = data.find(new, cursor)
+        if old_position < 0:
             rewritten.append(data[cursor:])
             break
-        rewritten.append(data[cursor:position])
-        if prefix and data[max(0, position - len(prefix)) : position] == prefix:
-            rewritten.append(old)
-        else:
-            rewritten.append(new)
-        cursor = position + len(old)
+        if new_position >= 0 and new_position <= old_position:
+            end = new_position + len(new)
+            rewritten.append(data[cursor:end])
+            cursor = end
+            continue
+        rewritten.append(data[cursor:old_position])
+        rewritten.append(new)
+        cursor = old_position + len(old)
     return "".join(rewritten)
 
 

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -67,6 +67,30 @@ SKIP_PACKAGES = {
 APT_UPDATE_RETRY_DELAYS_SECONDS = (10, 30)
 
 
+def rewrite_config_paths(data, old, new):
+    """Replace config paths without rewriting an already-prefixed value."""
+    if not old or old == new:
+        return data
+    if not new.endswith(old):
+        return data.replace(old, new)
+
+    prefix = new[: -len(old)]
+    rewritten = []
+    cursor = 0
+    while True:
+        position = data.find(old, cursor)
+        if position < 0:
+            rewritten.append(data[cursor:])
+            break
+        rewritten.append(data[cursor:position])
+        if prefix and data[max(0, position - len(prefix)) : position] == prefix:
+            rewritten.append(old)
+        else:
+            rewritten.append(new)
+        cursor = position + len(old)
+    return "".join(rewritten)
+
+
 def load_platform_package_patterns():
     patterns_file = os.environ.get(
         "PLATFORM_PACKAGE_PATTERNS_FILE",
@@ -658,7 +682,7 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
 
             with open(f, "rt", encoding="utf-8") as rf:
                 data = rf.read()
-                data = data.replace(old, new)
+                data = rewrite_config_paths(data, old, new)
             with open(f, "wt", encoding="utf-8") as wf:
                 wf.write(data)
 

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -1044,6 +1044,11 @@ cmd_install() {
     exit 1
   fi
 
+  # Restore an active overlay's exact APT source and pin before translating
+  # component aliases. Alias discovery must see the same package universe as
+  # the installer, including during a dry run.
+  configure_active_overlay_apt
+
   resolved=()
   normalized=()
   for pkg in "${args[@]}"; do
@@ -1067,7 +1072,6 @@ cmd_install() {
     exit 0
   fi
 
-  configure_active_overlay_apt
   run_as_root "${INSTALLER}" "${sysroot}" "${normalized[@]}"
 
   workdir="$(mktemp -d)"

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -787,6 +787,27 @@ cleanup_update_apt() {
   fi
 }
 
+configure_active_overlay_apt() {
+  local overlay state revision repository
+
+  overlay="$(sysroot_overlay_path "${sysroot}")"
+  [[ -r "${overlay}" ]] || return
+  state="$(read_release_field "${overlay}" "Overlay State")"
+  [[ "${state}" == "active" ]] || \
+    die "sysroot overlay state is ${state:-unknown}; rerun the update or recreate the SDK container before installing packages"
+  revision="$(read_release_field "${overlay}" "Platform Revision")"
+  repository="$(read_release_field "${overlay}" "Platform Repository")"
+  [[ "${revision}" =~ ^[0-9]+\.[0-9]+\.[0-9]+~pre[0-9]+$ ]] || \
+    die "active sysroot overlay has an invalid platform revision: ${revision:-<missing>}"
+  [[ -n "${repository}" ]] || die "active sysroot overlay repository is missing"
+
+  PRE_RELEASE_REPOSITORY="${repository}"
+  export SDK_APT_CHANNEL=pre-release
+  trap cleanup_update_apt EXIT
+  configure_update_apt "${revision}"
+  echo "Using active sysroot overlay package selection: ${revision} (${repository})"
+}
+
 cleanup_update_transaction() {
   cleanup_update_apt
   if [[ "${update_overlay_pending:-0}" == "1" ]]; then
@@ -797,6 +818,14 @@ cleanup_update_transaction() {
       "${update_target_revision}" \
       "incomplete"
   fi
+}
+
+cleanup_install_transaction() {
+  if [[ -n "${install_workdir:-}" ]]; then
+    rm -rf "${install_workdir}"
+  fi
+  rm -f /etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref
+  cleanup_update_apt
 }
 
 apply_sysroot_update() {
@@ -1009,10 +1038,12 @@ cmd_install() {
     exit 0
   fi
 
+  configure_active_overlay_apt
   run_as_root "${INSTALLER}" "${sysroot}" "${normalized[@]}"
 
   workdir="$(mktemp -d)"
-  trap 'rm -rf "${workdir}"; rm -f /etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref' EXIT
+  install_workdir="${workdir}"
+  trap cleanup_install_transaction EXIT
   download_for_manifest "${arch}" "${workdir}" "${normalized[@]}"
   record_manifests "${sysroot}" "${arch}" "${workdir}/archives"
   merge_package_inventory "${sysroot}" "${workdir}/archives"

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -5,6 +5,11 @@ program_name="$(basename "$0")"
 DEFAULT_SYSROOT="/opt/toolchain/aarch64/modalix"
 DEFAULT_ARCH="arm64"
 INSTALLER="${SYSROOT_INSTALLER:-/usr/local/bin/install-sysroot-overlay.sh}"
+PLATFORM_SETUP="${SYSROOT_PLATFORM_SETUP:-/usr/local/bin/setup-sdk-sysroot.sh}"
+SDK_RELEASE_FILE="${SDK_RELEASE_FILE:-/etc/sdk-release}"
+PRE_RELEASE_REPOSITORY="${SYSROOT_PRE_RELEASE_REPOSITORY:-https://debian.neat.sima.ai/pre-release}"
+PRE_RELEASE_ANCHOR_PACKAGE="${PRE_RELEASE_ANCHOR_PACKAGE:-simaai-palette-modalix}"
+PLATFORM_PATTERNS_FILE="${PLATFORM_PACKAGE_PATTERNS_FILE:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
 
 usage() {
   cat <<EOF
@@ -12,6 +17,8 @@ Usage:
   ${program_name} install [options] package [package ...]
   ${program_name} remove  [options] package [package ...]
   ${program_name} list    [options]
+  ${program_name} status  [options]
+  ${program_name} update  [options] [X.Y.Z~preN]
   ${program_name} help
 
 Manages Debian package payloads in the SDK sysroot. Install downloads packages
@@ -23,6 +30,8 @@ Options:
   --sysroot PATH  Sysroot to operate on (default: \${SYSROOT:-${DEFAULT_SYSROOT}})
   --arch ARCH     Target architecture for unqualified packages (default: ${DEFAULT_ARCH})
   --dry-run       Print actions without changing the sysroot
+  --latest        Select the newest pre-release for the SDK Platform Base
+  --yes           Confirm a --latest update without an interactive prompt
   -h, --help      Show this help
 
 Examples:
@@ -30,6 +39,10 @@ Examples:
   sudo ${program_name} install opencv_dnn
   ${program_name} list
   sudo ${program_name} remove libpgm-dev
+  sudo ${program_name} update
+  sudo ${program_name} update 2.1.3~pre4617
+  sudo ${program_name} update --latest --yes
+  ${program_name} status
 EOF
 }
 
@@ -65,9 +78,10 @@ has_dry_run_arg() {
 
 reexec_as_root_if_needed() {
   local command="$1"
+  local name
   shift
 
-  if [[ "$(id -u)" -eq 0 ]] || has_dry_run_arg "$@"; then
+  if [[ "$(id -u)" -eq 0 ]] || { [[ "${command}" != "update" ]] && has_dry_run_arg "$@"; }; then
     return
   fi
 
@@ -82,6 +96,26 @@ reexec_as_root_if_needed() {
     if [[ -n "${SYSROOT_INSTALLER:-}" ]]; then
       sudo_cmd+=("SYSROOT_INSTALLER=${SYSROOT_INSTALLER}")
     fi
+    for name in \
+      SDK_PKG_LIST \
+      SDK_RELEASE_FILE \
+      SDK_SYSROOT_PYTHON \
+      SIMAAI_DOWNLOAD_WORKERS \
+      SYSROOT_PLATFORM_SETUP \
+      SYSROOT_PRE_RELEASE_REPOSITORY \
+      PRE_RELEASE_ANCHOR_PACKAGE \
+      PLATFORM_PACKAGE_PATTERNS_FILE \
+      PRE_RELEASE_PACKAGES_FILE \
+      PRE_RELEASE_RELEASE_URL \
+      PRE_RELEASE_PACKAGES_URL \
+      PRE_RELEASE_PACKAGES_PATH \
+      SYSROOT_UPDATE_APT_SOURCE_FILE \
+      SYSROOT_UPDATE_APT_PREFERENCES_FILE \
+      SYSROOT_UPDATE_DOWNLOAD_DIR; do
+      if declare -p "${name}" >/dev/null 2>&1; then
+        sudo_cmd+=("${name}=${!name}")
+      fi
+    done
     sudo_cmd+=("${BASH_SOURCE[0]}" "${command}" "$@")
     exec "${sudo_cmd[@]}"
   fi
@@ -180,6 +214,103 @@ manifest_path() {
   local arch="$3"
   printf '%s/%s_%s.manifest\n' "$(manifest_root "${sysroot}")" "${pkg}" "${arch}"
 }
+
+sysroot_overlay_path() {
+  printf '%s/var/lib/sima-sdk/sysroot-overlay\n' "$1"
+}
+
+sysroot_inventory_path() {
+  printf '%s/var/lib/sima-sdk/sysroot-packages.tsv\n' "$1"
+}
+
+summarize_payload_paths() {
+  awk '
+    function remember(path, parts, count, root) {
+      sub(/^\.\//, "", path)
+      sub(/^\//, "", path)
+      if (path == "" || path ~ /\/$/) return
+      count = split(path, parts, "/")
+      if (parts[1] == "usr" && parts[2] == "lib" && count >= 3 && parts[3] ~ /linux-gnu$/) {
+        root = "/" parts[1] "/" parts[2] "/" parts[3]
+      } else if (count >= 2) {
+        root = "/" parts[1] "/" parts[2]
+      } else {
+        root = "/" parts[1]
+      }
+      roots[root] = 1
+    }
+    { remember($0) }
+    END { for (root in roots) print root }
+  ' | sort | paste -sd ',' -
+}
+
+package_locations_from_deb() {
+  local deb="$1"
+
+  dpkg-deb -c "${deb}" |
+    awk '{ path = $6; sub(/ ->.*$/, "", path); print path }' |
+    summarize_payload_paths
+}
+
+package_locations_from_manifest() {
+  local manifest="$1"
+
+  awk 'seen_blank { print } /^$/ { seen_blank = 1 }' "${manifest}" |
+    summarize_payload_paths
+}
+
+read_release_field() {
+  local path="$1"
+  local field="$2"
+
+  [[ -r "${path}" ]] || return 1
+  awk -F ' = ' -v wanted="${field}" '$1 == wanted { print substr($0, index($0, " = ") + 3); exit }' "${path}"
+}
+
+list_pre_release_versions() (
+  set -euo pipefail
+
+  local platform_base="$1"
+  local workdir packages_file release_file packages_digest packages_url
+  local release_url packages_path
+
+  release_url="${PRE_RELEASE_RELEASE_URL:-${PRE_RELEASE_REPOSITORY}/dists/bookworm/Release}"
+  packages_url="${PRE_RELEASE_PACKAGES_URL:-}"
+  packages_path="${PRE_RELEASE_PACKAGES_PATH:-non-free/binary-arm64/Packages.gz}"
+  workdir="$(mktemp -d)"
+  trap 'rm -rf "${workdir}"' EXIT
+  packages_file="${workdir}/Packages"
+
+  if [[ -n "${PRE_RELEASE_PACKAGES_FILE:-}" ]]; then
+    [[ -r "${PRE_RELEASE_PACKAGES_FILE}" ]] || die "Packages fixture is not readable: ${PRE_RELEASE_PACKAGES_FILE}"
+    cp "${PRE_RELEASE_PACKAGES_FILE}" "${packages_file}"
+  else
+    command -v curl >/dev/null 2>&1 || die "curl is required to query the pre-release mirror"
+    command -v gzip >/dev/null 2>&1 || die "gzip is required to read the pre-release package index"
+    if [[ -z "${packages_url}" ]]; then
+      release_file="${workdir}/Release"
+      curl -fsSL --retry 4 --retry-all-errors "${release_url}" > "${release_file}"
+      packages_digest="$(
+        awk -v wanted="${packages_path}" '
+          $0 == "SHA256:" { in_sha256 = 1; next }
+          in_sha256 && $0 !~ /^ / { in_sha256 = 0 }
+          in_sha256 && $3 == wanted { print $1; exit }
+        ' "${release_file}"
+      )"
+      [[ "${packages_digest}" =~ ^[0-9a-fA-F]{64}$ ]] || \
+        die "Release does not contain a valid SHA256 for ${packages_path}"
+      packages_url="${release_url%/*}/${packages_path%/*}/by-hash/SHA256/${packages_digest}"
+    fi
+    curl -fsSL --retry 4 --retry-all-errors "${packages_url}" | gzip -dc > "${packages_file}"
+  fi
+
+  awk -v package="${PRE_RELEASE_ANCHOR_PACKAGE}" '
+    $1 == "Package:" { current_package = $2 }
+    $1 == "Version:" && current_package == package { print $2 }
+  ' "${packages_file}" |
+    awk -v prefix="${platform_base}~pre" 'index($0, prefix) == 1 && substr($0, length(prefix) + 1) ~ /^[0-9]+$/ { print }' |
+    sort -Vu -r
+)
 
 apt_package_exists() {
   local pkg="$1"
@@ -336,12 +467,13 @@ record_manifests() {
   local sysroot="$1"
   local arch="$2"
   local debdir="$3"
+  local quiet="${4:-0}"
   local root
 
   root="$(manifest_root "${sysroot}")"
   mkdir -p "${root}"
 
-  find "${debdir}" -maxdepth 1 -type f -name '*.deb' -print0 |
+  find "${debdir}" -maxdepth 1 \( -type f -o -type l \) -name '*.deb' -print0 |
     while IFS= read -r -d '' deb; do
       deb_arch="$(dpkg-deb -f "${deb}" Architecture)"
       if [[ "${deb_arch}" != "all" && "${deb_arch}" != "${arch}" ]]; then
@@ -374,11 +506,477 @@ record_manifests() {
       } > "${tmp_manifest}"
 
       mv "${tmp_manifest}" "${manifest}"
-      echo "Recorded ${deb_pkg}:${deb_arch} ${deb_version}"
+      if [[ "${quiet}" != "1" ]]; then
+        echo "Recorded ${deb_pkg}:${deb_arch} ${deb_version}"
+      fi
     done
 }
 
+refresh_tracked_manifests() {
+  local sysroot="$1"
+  local arch="$2"
+  local debdir="$3"
+  local root workdir manifest package package_arch candidate target matched
+
+  root="$(manifest_root "${sysroot}")"
+  [[ -d "${root}" ]] || return
+  workdir="$(mktemp -d)"
+  while IFS= read -r -d '' manifest; do
+    package="$(awk -F ': ' '$1 == "Package" { print $2; exit }' "${manifest}")"
+    package_arch="$(awk -F ': ' '$1 == "Architecture" { print $2; exit }' "${manifest}")"
+    matched=""
+    for candidate in \
+      "${debdir}/${package}:${package_arch}.deb" \
+      "${debdir}/${package}.deb"; do
+      if [[ -f "${candidate}" ]] && \
+         [[ "$(dpkg-deb -f "${candidate}" Package)" == "${package}" ]] && \
+         [[ "$(dpkg-deb -f "${candidate}" Architecture)" == "${package_arch}" ]]; then
+        matched="${candidate}"
+        break
+      fi
+    done
+    if [[ -z "${matched}" ]]; then
+      while IFS= read -r -d '' candidate; do
+        if [[ "$(dpkg-deb -f "${candidate}" Package)" == "${package}" ]] && \
+           [[ "$(dpkg-deb -f "${candidate}" Architecture)" == "${package_arch}" ]]; then
+          matched="${candidate}"
+          break
+        fi
+      done < <(find "${debdir}" -maxdepth 1 -type f -name '*.deb' -print0)
+    fi
+    if [[ -n "${matched}" ]]; then
+      target="${workdir}/${package}:${package_arch}.deb"
+      ln "${matched}" "${target}" 2>/dev/null || ln -s "${matched}" "${target}"
+    fi
+  done < <(find "${root}" -maxdepth 1 -type f -name '*.manifest' -print0)
+
+  if find "${workdir}" -maxdepth 1 \( -type f -o -type l \) -name '*.deb' -print -quit | grep -q .; then
+    record_manifests "${sysroot}" "${arch}" "${workdir}" 1
+  fi
+  rm -rf "${workdir}"
+}
+
+write_package_inventory() {
+  local sysroot="$1"
+  local debdir="$2"
+  local inventory tmp_inventory
+
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  mkdir -p "$(dirname "${inventory}")"
+  tmp_inventory="${inventory}.tmp"
+  find "${debdir}" -maxdepth 1 -type f -name '*.deb' -print0 |
+    while IFS= read -r -d '' deb; do
+      printf '%s\t%s\t%s\t%s\n' \
+        "$(dpkg-deb -f "${deb}" Package)" \
+        "$(dpkg-deb -f "${deb}" Architecture)" \
+        "$(dpkg-deb -f "${deb}" Version)" \
+        "$(package_locations_from_deb "${deb}")"
+    done |
+    sort -u > "${tmp_inventory}"
+  [[ -s "${tmp_inventory}" ]] || die "no package inventory was produced from ${debdir}"
+  mv "${tmp_inventory}" "${inventory}"
+}
+
+merge_package_inventory() {
+  local sysroot="$1"
+  local debdir="$2"
+  local inventory additions merged
+
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  mkdir -p "$(dirname "${inventory}")"
+  additions="${inventory}.additions"
+  merged="${inventory}.tmp"
+  find "${debdir}" -maxdepth 1 -type f -name '*.deb' -print0 |
+    while IFS= read -r -d '' deb; do
+      printf '%s\t%s\t%s\t%s\n' \
+        "$(dpkg-deb -f "${deb}" Package)" \
+        "$(dpkg-deb -f "${deb}" Architecture)" \
+        "$(dpkg-deb -f "${deb}" Version)" \
+        "$(package_locations_from_deb "${deb}")"
+    done > "${additions}"
+  [[ -s "${additions}" ]] || die "no package inventory additions were produced from ${debdir}"
+  {
+    if [[ -r "${inventory}" ]]; then
+      cat "${inventory}"
+    else
+      find "$(manifest_root "${sysroot}")" -maxdepth 1 -type f -name '*.manifest' -print0 2>/dev/null |
+        while IFS= read -r -d '' manifest; do
+          printf '%s\t%s\t%s\t%s\n' \
+            "$(awk -F ': ' '$1 == "Package" { print $2; exit }' "${manifest}")" \
+            "$(awk -F ': ' '$1 == "Architecture" { print $2; exit }' "${manifest}")" \
+            "$(awk -F ': ' '$1 == "Version" { print $2; exit }' "${manifest}")" \
+            "$(package_locations_from_manifest "${manifest}")"
+        done
+    fi
+    cat "${additions}"
+  } |
+    awk -F '\t' 'NF >= 3 { entry[$1 FS $2] = $0 } END { for (key in entry) print entry[key] }' |
+    sort > "${merged}"
+  mv "${merged}" "${inventory}"
+  rm -f "${additions}"
+}
+
+remove_package_from_inventory() {
+  local sysroot="$1"
+  local package="$2"
+  local architecture="$3"
+  local inventory temporary
+
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  [[ -r "${inventory}" ]] || return
+  temporary="${inventory}.tmp"
+  awk -F '\t' -v package="${package}" -v architecture="${architecture}" \
+    'NF < 3 || $1 != package || $2 != architecture' "${inventory}" > "${temporary}"
+  mv "${temporary}" "${inventory}"
+}
+
+write_overlay_metadata() {
+  local sysroot="$1"
+  local platform_base="$2"
+  local platform_revision="$3"
+  local overlay tmp_overlay inventory
+
+  overlay="$(sysroot_overlay_path "${sysroot}")"
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  mkdir -p "$(dirname "${overlay}")"
+  tmp_overlay="${overlay}.tmp"
+  cat > "${tmp_overlay}" <<EOF
+Overlay State = active
+Platform Base = ${platform_base}
+Platform Revision = ${platform_revision}
+Platform Channel = pre-release
+Platform Repository = ${PRE_RELEASE_REPOSITORY}
+Updated At = $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Package Inventory = ${inventory}
+EOF
+  mv "${tmp_overlay}" "${overlay}"
+}
+
+write_overlay_transition() {
+  local sysroot="$1"
+  local platform_base="$2"
+  local previous_revision="$3"
+  local target_revision="$4"
+  local state="$5"
+  local overlay tmp_overlay
+
+  overlay="$(sysroot_overlay_path "${sysroot}")"
+  mkdir -p "$(dirname "${overlay}")"
+  tmp_overlay="${overlay}.tmp"
+  cat > "${tmp_overlay}" <<EOF
+Overlay State = ${state}
+Platform Base = ${platform_base}
+Platform Revision = ${target_revision}
+Previous Platform Revision = ${previous_revision}
+Platform Channel = pre-release
+Platform Repository = ${PRE_RELEASE_REPOSITORY}
+Updated At = $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Package Inventory = $(sysroot_inventory_path "${sysroot}")
+EOF
+  mv "${tmp_overlay}" "${overlay}"
+}
+
+parse_update_options() {
+  sysroot="${SYSROOT:-${DEFAULT_SYSROOT}}"
+  arch="${SYSROOT_ARCH:-${DEFAULT_ARCH}}"
+  dry_run=0
+  update_latest=0
+  assume_yes=0
+  args=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --sysroot)
+        [[ $# -ge 2 ]] || die "--sysroot requires a value"
+        sysroot="$2"
+        shift 2
+        ;;
+      --sysroot=*)
+        sysroot="${1#*=}"
+        shift
+        ;;
+      --arch)
+        [[ $# -ge 2 ]] || die "--arch requires a value"
+        arch="$2"
+        shift 2
+        ;;
+      --arch=*)
+        arch="${1#*=}"
+        shift
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --latest)
+        update_latest=1
+        shift
+        ;;
+      -y|--yes)
+        assume_yes=1
+        shift
+        ;;
+      --)
+        shift
+        while [[ $# -gt 0 ]]; do
+          args+=("$1")
+          shift
+        done
+        ;;
+      -*)
+        die "unsupported update option: $1"
+        ;;
+      *)
+        args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  validate_sysroot "${sysroot}"
+  validate_arch "${arch}"
+  [[ "${arch}" == "arm64" ]] || die "sysroot update supports only the Modalix arm64 sysroot"
+  [[ ${#args[@]} -le 1 ]] || die "update accepts at most one pinned platform revision"
+  if [[ "${update_latest}" == "1" && ${#args[@]} -ne 0 ]]; then
+    die "--latest cannot be combined with an exact platform revision"
+  fi
+}
+
+configure_update_apt() {
+  local platform_revision="$1"
+  local source_file preferences_file platform_packages
+
+  source_file="${SYSROOT_UPDATE_APT_SOURCE_FILE:-/etc/apt/sources.list.d/00-sima-sdk-sysroot-pre-release.list}"
+  preferences_file="${SYSROOT_UPDATE_APT_PREFERENCES_FILE:-/etc/apt/preferences.d/00-sima-sdk-sysroot-pre-release.pref}"
+  update_source_created=0
+  update_preferences_created=0
+
+  if ! grep -RhsF "${PRE_RELEASE_REPOSITORY}" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | grep -q .; then
+    [[ ! -e "${source_file}" ]] || die "temporary APT source already exists: ${source_file}"
+    mkdir -p "$(dirname "${source_file}")"
+    printf 'deb [arch=arm64 trusted=yes] %s bookworm non-free\n' "${PRE_RELEASE_REPOSITORY}" > "${source_file}"
+    update_source_created=1
+  fi
+
+  [[ ! -e "${preferences_file}" ]] || die "temporary APT preferences already exist: ${preferences_file}"
+  [[ -r "${PLATFORM_PATTERNS_FILE}" ]] || die "platform package patterns are unavailable: ${PLATFORM_PATTERNS_FILE}"
+  platform_packages="$(
+    sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${PLATFORM_PATTERNS_FILE}" |
+      tr '\n' ' ' |
+      sed 's/[[:space:]]*$//'
+  )"
+  mkdir -p "$(dirname "${preferences_file}")"
+  cat > "${preferences_file}" <<EOF
+Package: ${platform_packages}
+Pin: version ${platform_revision}
+Pin-Priority: 1002
+EOF
+  update_preferences_created=1
+}
+
+cleanup_update_apt() {
+  if [[ "${update_source_created:-0}" == "1" ]]; then
+    rm -f "${SYSROOT_UPDATE_APT_SOURCE_FILE:-/etc/apt/sources.list.d/00-sima-sdk-sysroot-pre-release.list}"
+  fi
+  if [[ "${update_preferences_created:-0}" == "1" ]]; then
+    rm -f "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:-/etc/apt/preferences.d/00-sima-sdk-sysroot-pre-release.pref}"
+  fi
+}
+
+cleanup_update_transaction() {
+  cleanup_update_apt
+  if [[ "${update_overlay_pending:-0}" == "1" ]]; then
+    write_overlay_transition \
+      "${sysroot}" \
+      "${update_platform_base}" \
+      "${update_previous_revision}" \
+      "${update_target_revision}" \
+      "incomplete"
+  fi
+}
+
+apply_sysroot_update() {
+  local platform_base="$1"
+  local platform_revision="$2"
+  local previous_revision="$3"
+  local download_dir
+
+  [[ -x "${PLATFORM_SETUP}" ]] || die "platform sysroot setup command is unavailable: ${PLATFORM_SETUP}"
+  download_dir="${SYSROOT_UPDATE_DOWNLOAD_DIR:-/tmp/modalix-overlay-${platform_revision}}"
+  update_platform_base="${platform_base}"
+  update_previous_revision="${previous_revision}"
+  update_target_revision="${platform_revision}"
+  update_overlay_pending=0
+  trap cleanup_update_transaction EXIT
+  configure_update_apt "${platform_revision}"
+  if [[ "${dry_run}" != "1" ]]; then
+    write_overlay_transition \
+      "${sysroot}" "${platform_base}" "${previous_revision}" "${platform_revision}" "updating"
+    update_overlay_pending=1
+  fi
+  echo "Resolving and validating the complete ${platform_revision} package cohort..."
+  if ! SYSROOT="${sysroot}" \
+    SYSROOT_UPDATE_DOWNLOAD_DIR="${download_dir}" \
+    SDK_APT_CHANNEL=pre-release \
+    SIMAAI_PLATFORM_BUILD_REVISION="${platform_revision##*~pre}" \
+    SIMAAI_SETUP_DOWNLOAD_ONLY="${dry_run}" \
+    "${PLATFORM_SETUP}" "${platform_revision}" "${SDK_PKG_LIST:-}"; then
+    if [[ "${dry_run}" != "1" ]]; then
+      echo "${program_name}: update failed while extracting packages; recreate the SDK container to guarantee a clean sysroot." >&2
+    fi
+    return 1
+  fi
+
+  if [[ "${dry_run}" == "1" ]]; then
+    echo "Dry run complete: ${platform_revision} resolved and validated; the sysroot was not modified."
+    return
+  fi
+
+  if [[ ! -s "$(sysroot_inventory_path "${sysroot}")" ]]; then
+    write_package_inventory "${sysroot}" "${download_dir}"
+  fi
+  refresh_tracked_manifests "${sysroot}" "${arch}" "${download_dir}"
+  write_overlay_metadata "${sysroot}" "${platform_base}" "${platform_revision}"
+  update_overlay_pending=0
+  echo "Sysroot overlay is active at ${platform_revision}."
+  echo "Run '${program_name} status' to inspect it; recreate the SDK container to restore the image-default sysroot."
+  echo "Start a new shell to display the overlay revision in the SDK prompt."
+}
+
+cmd_status() {
+  local platform_base image_revision overlay overlay_state overlay_revision
+
+  parse_common_options "$@"
+  [[ ${#args[@]} -eq 0 ]] || die "status does not accept positional arguments"
+  [[ -r "${SDK_RELEASE_FILE}" ]] || die "SDK release metadata is unavailable: ${SDK_RELEASE_FILE}"
+  platform_base="$(read_release_field "${SDK_RELEASE_FILE}" "Platform Base")"
+  image_revision="$(read_release_field "${SDK_RELEASE_FILE}" "Platform Version")"
+  [[ -n "${platform_base}" ]] || die "Platform Base is missing from ${SDK_RELEASE_FILE}"
+  [[ -n "${image_revision}" ]] || die "Platform Version is missing from ${SDK_RELEASE_FILE}"
+
+  overlay="$(sysroot_overlay_path "${sysroot}")"
+  overlay_state="inactive"
+  overlay_revision="none"
+  if [[ -r "${overlay}" ]]; then
+    overlay_state="$(read_release_field "${overlay}" "Overlay State")"
+    overlay_revision="$(read_release_field "${overlay}" "Platform Revision")"
+  fi
+
+  printf 'SDK image platform:       %s\n' "${image_revision}"
+  printf 'Platform Base:            %s\n' "${platform_base}"
+  printf 'Sysroot overlay state:    %s\n' "${overlay_state:-active}"
+  printf 'Sysroot overlay revision: %s\n' "${overlay_revision:-unknown}"
+  if [[ -r "${overlay}" ]]; then
+    printf 'Sysroot channel:          %s\n' "$(read_release_field "${overlay}" "Platform Channel")"
+    printf 'Sysroot repository:       %s\n' "$(read_release_field "${overlay}" "Platform Repository")"
+    printf 'Sysroot updated at:       %s\n' "$(read_release_field "${overlay}" "Updated At")"
+    if [[ "${overlay_state}" != "active" ]]; then
+      printf 'Previous revision:        %s\n' "$(read_release_field "${overlay}" "Previous Platform Revision")"
+      echo "WARNING: The sysroot overlay is not complete; rerun the update or recreate the SDK container."
+    fi
+  fi
+}
+
+cmd_update() {
+  local platform_base image_revision current_revision current_state target_revision selection answer
+  local explicit_revision=0 candidate_found=0 candidate
+  local -a available_versions
+
+  parse_update_options "$@"
+  [[ -r "${SDK_RELEASE_FILE}" ]] || die "SDK release metadata is unavailable: ${SDK_RELEASE_FILE}"
+  platform_base="$(read_release_field "${SDK_RELEASE_FILE}" "Platform Base")"
+  image_revision="$(read_release_field "${SDK_RELEASE_FILE}" "Platform Version")"
+  [[ "${platform_base}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || \
+    die "invalid or missing Platform Base in ${SDK_RELEASE_FILE}: ${platform_base:-<missing>}"
+  [[ -n "${image_revision}" ]] || die "Platform Version is missing from ${SDK_RELEASE_FILE}"
+
+  mapfile -t available_versions < <(list_pre_release_versions "${platform_base}")
+  [[ ${#available_versions[@]} -gt 0 ]] || \
+    die "no ${platform_base}~preN revisions are available for ${PRE_RELEASE_ANCHOR_PACKAGE}"
+
+  cat <<EOF
+WARNING: This operation installs pre-release SiMa.ai platform software into
+the SDK sysroot. It is intended only for development and testing.
+
+SDK Platform Base: ${platform_base}
+Repository:        ${PRE_RELEASE_REPOSITORY}
+Repository trust:  HTTPS transport with APT trusted=yes (unsigned metadata)
+EOF
+
+  if [[ ${#args[@]} -eq 1 ]]; then
+    target_revision="${args[0]}"
+    explicit_revision=1
+  elif [[ "${update_latest}" == "1" ]]; then
+    target_revision="${available_versions[0]}"
+  else
+    [[ -t 0 ]] || die "interactive revision selection requires a TTY; pass X.Y.Z~preN or --latest --yes"
+    echo
+    echo "Available revisions:"
+    for selection in "${!available_versions[@]}"; do
+      printf '  %d. %s' "$((selection + 1))" "${available_versions[selection]}"
+      if [[ "${selection}" -eq 0 ]]; then
+        printf ' (latest)'
+      fi
+      printf '\n'
+    done
+    printf '  %d. Cancel\n' "$(( ${#available_versions[@]} + 1 ))"
+    read -r -p "Select a revision: " selection
+    [[ "${selection}" =~ ^[0-9]+$ ]] || die "invalid revision selection: ${selection}"
+    if (( selection == ${#available_versions[@]} + 1 )); then
+      echo "Cancelled."
+      return
+    fi
+    (( selection >= 1 && selection <= ${#available_versions[@]} )) || die "revision selection is out of range"
+    target_revision="${available_versions[selection - 1]}"
+  fi
+
+  if [[ ! "${target_revision}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)~pre[0-9]+$ ]]; then
+    die "update revision must use X.Y.Z~preN: ${target_revision}"
+  fi
+  [[ "${BASH_REMATCH[1]}" == "${platform_base}" ]] || \
+    die "SDK Platform Base is ${platform_base}; refusing revision ${target_revision}"
+  for candidate in "${available_versions[@]}"; do
+    if [[ "${candidate}" == "${target_revision}" ]]; then
+      candidate_found=1
+      break
+    fi
+  done
+  [[ "${candidate_found}" == "1" ]] || \
+    die "revision ${target_revision} is not available for ${PRE_RELEASE_ANCHOR_PACKAGE}"
+
+  current_revision="${image_revision}"
+  current_state="active"
+  if [[ -r "$(sysroot_overlay_path "${sysroot}")" ]]; then
+    current_revision="$(read_release_field "$(sysroot_overlay_path "${sysroot}")" "Platform Revision")"
+    current_state="$(read_release_field "$(sysroot_overlay_path "${sysroot}")" "Overlay State")"
+  fi
+  if [[ "${current_state}" == "active" && "${current_revision}" == "${target_revision}" ]]; then
+    echo "Sysroot is already at ${target_revision}; no changes are required."
+    return
+  fi
+
+  echo
+  echo "Updating Modalix sysroot: ${current_revision} -> ${target_revision}"
+  if [[ "${dry_run}" != "1" && "${explicit_revision}" != "1" && "${assume_yes}" != "1" ]]; then
+    [[ -t 0 ]] || die "confirmation requires a TTY; rerun with --latest --yes"
+    read -r -p "Continue? [y/N] " answer
+    case "${answer}" in
+      y|Y|yes|YES) ;;
+      *) echo "Cancelled."; return ;;
+    esac
+  fi
+
+  apply_sysroot_update "${platform_base}" "${target_revision}" "${current_revision}"
+}
+
 cmd_install() {
+  local -a resolved normalized
+  local pkg resolved_pkg workdir i
+
   parse_common_options "$@"
   if [[ ${#args[@]} -eq 0 ]]; then
     die "install requires at least one package"
@@ -417,6 +1015,7 @@ cmd_install() {
   trap 'rm -rf "${workdir}"; rm -f /etc/apt/preferences.d/00-sima-sdk-sysroot-target.pref' EXIT
   download_for_manifest "${arch}" "${workdir}" "${normalized[@]}"
   record_manifests "${sysroot}" "${arch}" "${workdir}/archives"
+  merge_package_inventory "${sysroot}" "${workdir}/archives"
 }
 
 file_owned_elsewhere() {
@@ -450,6 +1049,9 @@ remove_empty_parents() {
 }
 
 cmd_remove() {
+  local -a manifests
+  local root pkg normalized base pkg_arch manifest all_manifest
+
   parse_common_options "$@"
   if [[ ${#args[@]} -eq 0 ]]; then
     die "remove requires at least one package"
@@ -508,14 +1110,36 @@ cmd_remove() {
       echo "Would remove manifest ${manifest}"
     else
       rm -f "${manifest}"
+      remove_package_from_inventory "${sysroot}" "${pkg}" "${pkg_arch}"
     fi
   done
 }
 
 cmd_list() {
+  local inventory root manifest pkg pkg_arch version
+  local -a manifests
+
   parse_common_options "$@"
   if [[ ${#args[@]} -ne 0 ]]; then
     die "list does not accept package arguments"
+  fi
+
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  if [[ -s "${inventory}" ]]; then
+    printf '%-38s %-8s %-28s %s\n' \
+      "PACKAGE" "ARCH" "VERSION" "LOCATION(S) IN ${sysroot}"
+    sort -t $'\t' -k1,1 -k2,2 "${inventory}" |
+      while IFS=$'\t' read -r pkg pkg_arch version locations; do
+        if [[ -z "${locations:-}" ]]; then
+          manifest="$(manifest_path "${sysroot}" "${pkg}" "${pkg_arch}")"
+          if [[ -r "${manifest}" ]]; then
+            locations="$(package_locations_from_manifest "${manifest}")"
+          fi
+        fi
+        printf '%-38s %-8s %-28s %s\n' \
+          "${pkg}" "${pkg_arch}" "${version}" "${locations:-(not recorded)}"
+      done
+    return
   fi
 
   root="$(manifest_root "${sysroot}")"
@@ -532,13 +1156,16 @@ cmd_list() {
     return
   fi
 
+  printf '%-38s %-8s %-28s %s\n' \
+    "PACKAGE" "ARCH" "VERSION" "LOCATION(S) IN ${sysroot}"
   printf '%s\0' "${manifests[@]}" |
     sort -z |
     while IFS= read -r -d '' manifest; do
       pkg="$(awk -F': ' '$1 == "Package" {print $2; exit}' "${manifest}")"
       pkg_arch="$(awk -F': ' '$1 == "Architecture" {print $2; exit}' "${manifest}")"
       version="$(awk -F': ' '$1 == "Version" {print $2; exit}' "${manifest}")"
-      printf '%s:%s %s\n' "${pkg}" "${pkg_arch}" "${version}"
+      printf '%-38s %-8s %-28s %s\n' \
+        "${pkg}" "${pkg_arch}" "${version}" "$(package_locations_from_manifest "${manifest}")"
     done
 }
 
@@ -560,6 +1187,15 @@ case "${command}" in
   list)
     shift
     cmd_list "$@"
+    ;;
+  status)
+    shift
+    cmd_status "$@"
+    ;;
+  update)
+    shift
+    reexec_as_root_if_needed update "$@"
+    cmd_update "$@"
     ;;
   *)
     echo "${program_name}: unsupported command: ${command}" >&2

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -616,6 +616,34 @@ merge_package_inventory() {
   rm -f "${additions}"
 }
 
+merge_tracked_manifests_into_inventory() {
+  local sysroot="$1"
+  local inventory root manifest_entries merged manifest
+
+  inventory="$(sysroot_inventory_path "${sysroot}")"
+  root="$(manifest_root "${sysroot}")"
+  [[ -s "${inventory}" && -d "${root}" ]] || return
+  manifest_entries="${inventory}.manifests"
+  merged="${inventory}.tmp"
+  : > "${manifest_entries}"
+  while IFS= read -r -d '' manifest; do
+    printf '%s\t%s\t%s\t%s\n' \
+      "$(awk -F ': ' '$1 == "Package" { print $2; exit }' "${manifest}")" \
+      "$(awk -F ': ' '$1 == "Architecture" { print $2; exit }' "${manifest}")" \
+      "$(awk -F ': ' '$1 == "Version" { print $2; exit }' "${manifest}")" \
+      "$(package_locations_from_manifest "${manifest}")" \
+      >> "${manifest_entries}"
+  done < <(find "${root}" -maxdepth 1 -type f -name '*.manifest' -print0)
+
+  # Manifest entries are emitted first so a package from the newly resolved
+  # platform cohort wins when the same package exists in both sources.
+  cat "${manifest_entries}" "${inventory}" |
+    awk -F '\t' 'NF >= 3 { entry[$1 FS $2] = $0 } END { for (key in entry) print entry[key] }' |
+    sort > "${merged}"
+  mv "${merged}" "${inventory}"
+  rm -f "${manifest_entries}"
+}
+
 remove_package_from_inventory() {
   local sysroot="$1"
   local package="$2"
@@ -868,6 +896,7 @@ apply_sysroot_update() {
   if [[ ! -s "$(sysroot_inventory_path "${sysroot}")" ]]; then
     write_package_inventory "${sysroot}" "${download_dir}"
   fi
+  merge_tracked_manifests_into_inventory "${sysroot}"
   refresh_tracked_manifests "${sysroot}" "${arch}" "${download_dir}"
   write_overlay_metadata "${sysroot}" "${platform_base}" "${platform_revision}"
   update_overlay_pending=0

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -10,6 +10,8 @@ SDK_RELEASE_FILE="${SDK_RELEASE_FILE:-/etc/sdk-release}"
 PRE_RELEASE_REPOSITORY="${SYSROOT_PRE_RELEASE_REPOSITORY:-https://debian.neat.sima.ai/pre-release}"
 PRE_RELEASE_ANCHOR_PACKAGE="${PRE_RELEASE_ANCHOR_PACKAGE:-simaai-palette-modalix}"
 PLATFORM_PATTERNS_FILE="${PLATFORM_PACKAGE_PATTERNS_FILE:-/usr/local/share/sima-sdk/platform-package-patterns.txt}"
+apt_cache_options=()
+overlay_apt_workdir=""
 
 usage() {
   cat <<EOF
@@ -317,7 +319,7 @@ apt_package_exists() {
   local arch="$2"
 
   command -v apt-cache >/dev/null 2>&1 || return 1
-  apt-cache policy "${pkg}:${arch}" 2>/dev/null | grep -q 'Candidate: [^(]'
+  apt-cache "${apt_cache_options[@]}" policy "${pkg}:${arch}" 2>/dev/null | grep -q 'Candidate: [^(]'
 }
 
 resolve_component_name() {
@@ -343,8 +345,8 @@ resolve_component_name() {
       if command -v apt-cache >/dev/null 2>&1; then
         mapfile -t candidates < <(
           {
-            apt-cache search "^libopencv-${component}[0-9]+$" 2>/dev/null | awk '{print $1}'
-            apt-cache search "^libopencv-${component}-dev$" 2>/dev/null | awk '{print $1}'
+            apt-cache "${apt_cache_options[@]}" search "^libopencv-${component}[0-9]+$" 2>/dev/null | awk '{print $1}'
+            apt-cache "${apt_cache_options[@]}" search "^libopencv-${component}-dev$" 2>/dev/null | awk '{print $1}'
           } | awk '!seen[$0]++'
         )
         if [[ ${#candidates[@]} -eq 1 ]]; then
@@ -783,7 +785,8 @@ configure_update_apt() {
   update_source_created=0
   update_preferences_created=0
 
-  if ! grep -RhsF "${PRE_RELEASE_REPOSITORY}" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | grep -q .; then
+  if [[ "${dry_run:-0}" == "1" ]] || \
+    ! grep -RhsF "${PRE_RELEASE_REPOSITORY}" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null | grep -q .; then
     [[ ! -e "${source_file}" ]] || die "temporary APT source already exists: ${source_file}"
     mkdir -p "$(dirname "${source_file}")"
     printf 'deb [arch=arm64 trusted=yes] %s bookworm non-free\n' "${PRE_RELEASE_REPOSITORY}" > "${source_file}"
@@ -813,6 +816,11 @@ cleanup_update_apt() {
   if [[ "${update_preferences_created:-0}" == "1" ]]; then
     rm -f "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:-/etc/apt/preferences.d/00-sima-sdk-sysroot-pre-release.pref}"
   fi
+  if [[ -n "${overlay_apt_workdir:-}" ]]; then
+    rm -rf "${overlay_apt_workdir}"
+    overlay_apt_workdir=""
+  fi
+  apt_cache_options=()
 }
 
 configure_active_overlay_apt() {
@@ -832,6 +840,15 @@ configure_active_overlay_apt() {
   PRE_RELEASE_REPOSITORY="${repository}"
   export SDK_APT_CHANNEL=pre-release
   trap cleanup_update_apt EXIT
+  if [[ "${dry_run}" == "1" ]]; then
+    overlay_apt_workdir="$(mktemp -d)"
+    SYSROOT_UPDATE_APT_SOURCE_FILE="${overlay_apt_workdir}/sources.list"
+    SYSROOT_UPDATE_APT_PREFERENCES_FILE="${overlay_apt_workdir}/preferences"
+    apt_cache_options=(
+      -o "Dir::Etc::sourcelist=${SYSROOT_UPDATE_APT_SOURCE_FILE}"
+      -o "Dir::Etc::preferences=${SYSROOT_UPDATE_APT_PREFERENCES_FILE}"
+    )
+  fi
   configure_update_apt "${revision}"
   echo "Using active sysroot overlay package selection: ${revision} (${repository})"
 }

--- a/tests/sdk/README.md
+++ b/tests/sdk/README.md
@@ -19,6 +19,8 @@ container after `sima-cli sdk setup -y -n` starts it.
 - `test-sysroot-update.sh` covers interactive safety, exact and latest
   pre-release resolution, Platform Base enforcement, dry-run validation,
   overlay provenance, idempotence, and the shell prompt overlay marker.
+- `test-sysroot-unprivileged-dry-run.sh` verifies that an ordinary user can
+  resolve overlay package aliases without writing under the system APT paths.
 - `test-sysroot-progress.py` verifies package download/cache and extraction
   progress summaries used by `sysroot update`.
 - `neat-status/` validates the `neat --json` assembly/status contract.

--- a/tests/sdk/README.md
+++ b/tests/sdk/README.md
@@ -16,6 +16,11 @@ container after `sima-cli sdk setup -y -n` starts it.
 - `test-resolve-platform-config.sh`, `test-write-sdk-release.sh`, and
   `test-devkit-platform-profile.sh` cover pre-release selection, image
   provenance, protected release refs, and intentional Core-sync skipping.
+- `test-sysroot-update.sh` covers interactive safety, exact and latest
+  pre-release resolution, Platform Base enforcement, dry-run validation,
+  overlay provenance, idempotence, and the shell prompt overlay marker.
+- `test-sysroot-progress.py` verifies package download/cache and extraction
+  progress summaries used by `sysroot update`.
 - `neat-status/` validates the `neat --json` assembly/status contract.
 - `insight-video-routing/` downloads a small H.264 video, streams it from the
   runner into the SDK container's published Insight video UDP port with

--- a/tests/sdk/test-sysroot-progress.py
+++ b/tests/sdk/test-sysroot-progress.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+"""Regression tests for sysroot update progress reporting."""
+
+import contextlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tempfile
+import types
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.modules.setdefault("apt", types.ModuleType("apt"))
+spec = importlib.util.spec_from_file_location(
+    "simaai_setup_sdk", ROOT / "scripts" / "simaai_setup_sdk.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+output = io.StringIO()
+with contextlib.redirect_stdout(output):
+    downloads = module.DownloadProgress()
+    downloads.begin_batch(["downloaded", "cached"])
+    downloads.complete("downloaded", False)
+    downloads.complete("cached", True)
+    downloads.end_batch()
+    downloads.finish()
+
+    extraction = module.ExtractionProgress(2)
+    extraction.start()
+    extraction.begin_package("first.deb")
+    extraction.complete_package()
+    extraction.begin_package("second.deb")
+    extraction.complete_package()
+    extraction.finish(True)
+
+text = output.getvalue()
+assert "2/2 ready (1 downloaded, 1 cached)" in text
+assert "Package extraction complete: 2/2" in text
+
+with tempfile.TemporaryDirectory() as temporary:
+    root = pathlib.Path(temporary)
+    downloads = root / "downloads"
+    sysroot = root / "sysroot"
+    downloads.mkdir()
+    (downloads / "alpha.deb").touch()
+    (downloads / "beta.deb").touch()
+    fields = {
+        "alpha.deb": {"Package": "alpha", "Architecture": "arm64", "Version": "1.2.3"},
+        "beta.deb": {"Package": "beta", "Architecture": "all", "Version": "4.5.6"},
+    }
+    original_control_fields = module.package_control_fields
+    original_payload_locations = module.package_payload_locations
+    module.package_control_fields = lambda path, *wanted: tuple(
+        fields[pathlib.Path(path).name][field] for field in wanted
+    )
+    module.package_payload_locations = lambda path: (
+        "/usr/include,/usr/lib/aarch64-linux-gnu"
+        if pathlib.Path(path).name == "alpha.deb"
+        else "/usr/share"
+    )
+    try:
+        module.write_sysroot_package_inventory(str(downloads), str(sysroot))
+    finally:
+        module.package_control_fields = original_control_fields
+        module.package_payload_locations = original_payload_locations
+    inventory = sysroot / "var/lib/sima-sdk/sysroot-packages.tsv"
+    assert inventory.read_text(encoding="utf-8") == (
+        "alpha\tarm64\t1.2.3\t/usr/include,/usr/lib/aarch64-linux-gnu\n"
+        "beta\tall\t4.5.6\t/usr/share\n"
+    )
+
+print("sysroot progress tests passed")

--- a/tests/sdk/test-sysroot-progress.py
+++ b/tests/sdk/test-sysroot-progress.py
@@ -52,6 +52,23 @@ assert (
     == rewritten_config
 )
 
+custom_sysroot_usr = "/usr/local/modalix/usr"
+mixed_config = (
+    'set(SIMA_INCLUDE_DIR "/usr/include")\n'
+    'set(SIMA_LIBRARY_DIR "/usr/local/modalix/usr/lib")\n'
+)
+custom_rewritten_config = module.rewrite_config_paths(
+    mixed_config, "/usr", custom_sysroot_usr
+)
+assert custom_rewritten_config == (
+    'set(SIMA_INCLUDE_DIR "/usr/local/modalix/usr/include")\n'
+    'set(SIMA_LIBRARY_DIR "/usr/local/modalix/usr/lib")\n'
+)
+assert (
+    module.rewrite_config_paths(custom_rewritten_config, "/usr", custom_sysroot_usr)
+    == custom_rewritten_config
+)
+
 with tempfile.TemporaryDirectory() as temporary:
     root = pathlib.Path(temporary)
     downloads = root / "downloads"

--- a/tests/sdk/test-sysroot-progress.py
+++ b/tests/sdk/test-sysroot-progress.py
@@ -41,6 +41,17 @@ text = output.getvalue()
 assert "2/2 ready (1 downloaded, 1 cached)" in text
 assert "Package extraction complete: 2/2" in text
 
+sysroot_usr = "/opt/toolchain/aarch64/modalix/usr"
+cmake_config = 'set(SIMA_INCLUDE_DIR "/usr/include")\n'
+rewritten_config = module.rewrite_config_paths(cmake_config, "/usr", sysroot_usr)
+assert rewritten_config == (
+    'set(SIMA_INCLUDE_DIR "/opt/toolchain/aarch64/modalix/usr/include")\n'
+)
+assert (
+    module.rewrite_config_paths(rewritten_config, "/usr", sysroot_usr)
+    == rewritten_config
+)
+
 with tempfile.TemporaryDirectory() as temporary:
     root = pathlib.Path(temporary)
     downloads = root / "downloads"

--- a/tests/sdk/test-sysroot-unprivileged-dry-run.sh
+++ b/tests/sdk/test-sysroot-unprivileged-dry-run.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYSROOT_COMMAND="${ROOT_DIR}/scripts/sysroot.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  fail "this test must run as an unprivileged user"
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+sysroot="${tmpdir}/sysroot"
+mkdir -p "${sysroot}/var/lib/sima-sdk" "${tmpdir}/bin"
+cat > "${sysroot}/var/lib/sima-sdk/sysroot-overlay" <<'EOF'
+Overlay State = active
+Platform Revision = 2.1.3~pre4617
+Platform Repository = https://debian.neat.sima.ai/pre-release
+EOF
+
+cat > "${tmpdir}/bin/apt-cache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_file=""
+preferences_file=""
+while [[ "${1:-}" == "-o" ]]; do
+  case "${2:-}" in
+    Dir::Etc::sourcelist=*) source_file="${2#*=}" ;;
+    Dir::Etc::preferences=*) preferences_file="${2#*=}" ;;
+  esac
+  shift 2
+done
+
+[[ -r "${source_file}" ]]
+[[ -r "${preferences_file}" ]]
+[[ "${source_file}" != "${SIMA_FORBIDDEN_APT_SOURCE_FILE:?}" ]]
+[[ "${preferences_file}" != "${SIMA_FORBIDDEN_APT_PREFERENCES_FILE:?}" ]]
+grep -Fq 'deb [arch=arm64 trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free' \
+  "${source_file}"
+grep -Fq 'Pin: version 2.1.3~pre4617' "${preferences_file}"
+
+case "${1:-}" in
+  policy)
+    printf '%s\n' '  Candidate: (none)'
+    ;;
+  search)
+    if [[ "${2:-}" == '^libopencv-dnn[0-9]+$' ]]; then
+      printf '%s\n' 'libopencv-dnn4 - unprivileged overlay test'
+    fi
+    ;;
+esac
+EOF
+chmod 755 "${tmpdir}/bin/apt-cache"
+
+forbidden_source="/root/sima-sdk-test/sources.list"
+forbidden_preferences="/root/sima-sdk-test/preferences"
+output="$(
+  PATH="${tmpdir}/bin:${PATH}" \
+  SYSROOT="${sysroot}" \
+  PLATFORM_PACKAGE_PATTERNS_FILE="${ROOT_DIR}/config/platform-package-patterns.txt" \
+  SYSROOT_UPDATE_APT_SOURCE_FILE="${forbidden_source}" \
+  SYSROOT_UPDATE_APT_PREFERENCES_FILE="${forbidden_preferences}" \
+  SIMA_FORBIDDEN_APT_SOURCE_FILE="${forbidden_source}" \
+  SIMA_FORBIDDEN_APT_PREFERENCES_FILE="${forbidden_preferences}" \
+    "${SYSROOT_COMMAND}" install opencv_dnn --dry-run
+)"
+
+grep -Fq 'Resolved opencv_dnn -> libopencv-dnn4' <<< "${output}" || \
+  fail "unprivileged dry run did not resolve the overlay component alias"
+grep -Fq 'Dry run install:' <<< "${output}" || \
+  fail "unprivileged dry run did not print the planned install"
+[[ ! -e "${forbidden_source}" ]] || fail "dry run wrote the forbidden APT source"
+[[ ! -e "${forbidden_preferences}" ]] || fail "dry run wrote the forbidden APT preferences"
+
+echo "unprivileged sysroot dry-run tests passed"

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -226,7 +226,22 @@ EOF
 cat > "${tmpdir}/bin/apt-cache" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-grep -Fq 'Pin: version 2.1.3~pre4617' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+source_file="${SYSROOT_UPDATE_APT_SOURCE_FILE:?}"
+preferences_file="${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+while [[ "${1:-}" == "-o" ]]; do
+  case "${2:-}" in
+    Dir::Etc::sourcelist=*) source_file="${2#*=}" ;;
+    Dir::Etc::preferences=*) preferences_file="${2#*=}" ;;
+  esac
+  shift 2
+done
+if [[ "${SIMA_EXPECT_UNPRIVILEGED_DRY_RUN:-0}" == "1" ]]; then
+  [[ "${source_file}" != "${SYSROOT_UPDATE_APT_SOURCE_FILE:?}" ]]
+  [[ "${preferences_file}" != "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}" ]]
+fi
+grep -Fq 'deb [arch=arm64 trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free' \
+  "${source_file}"
+grep -Fq 'Pin: version 2.1.3~pre4617' "${preferences_file}"
 case "${1:-}" in
   policy)
     printf '%s\n' '  Candidate: (none)'
@@ -242,6 +257,7 @@ chmod 755 "${tmpdir}/fake-installer" "${tmpdir}/bin/apt-get" "${tmpdir}/bin/apt-
 overlay_dry_run="$(
   env "${common_env[@]}" \
     PATH="${tmpdir}/bin:${PATH}" \
+    SIMA_EXPECT_UNPRIVILEGED_DRY_RUN=1 \
     "${SYSROOT_COMMAND}" install opencv_dnn --dry-run
 )"
 grep -Fq 'Resolved opencv_dnn -> libopencv-dnn4' <<< "${overlay_dry_run}" || \

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -163,6 +163,12 @@ grep -Fq 'Sysroot overlay state:    incomplete' <<< "${failed_status}" || \
   fail "failed update did not leave visible incomplete overlay state"
 grep -Fq 'WARNING: The sysroot overlay is not complete' <<< "${failed_status}" || \
   fail "incomplete overlay did not report recovery guidance"
+if env "${common_env[@]}" SYSROOT_INSTALLER=/bin/true \
+  "${SYSROOT_COMMAND}" install test-package:arm64 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "package install proceeded against an incomplete overlay"
+fi
+grep -Fq 'sysroot overlay state is incomplete' "${tmpdir}/err" || \
+  fail "package install did not explain the incomplete overlay rejection"
 
 update_output="$(run_sysroot update 2.1.3~pre4617)"
 grep -Fq 'Sysroot overlay is active at 2.1.3~pre4617' <<< "${update_output}" || \
@@ -183,6 +189,51 @@ grep -Fxq 'Version: 2.1.3~pre4617' \
   fail "update did not refresh an existing tracked package manifest"
 grep -Fxq $'2.1.3~pre4617\t0\t4617' "${tmpdir}/setup.log" || \
   fail "actual update did not constrain dependencies to the selected build cohort"
+
+mkdir -p "${tmpdir}/bin"
+cat > "${tmpdir}/fake-installer" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${SDK_APT_CHANNEL:-}" == "pre-release" ]]
+grep -Fq 'Pin: version 2.1.3~pre4617' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+printf 'overlay-selection-ok\n' > "${SYSROOT_UPDATE_INSTALL_TEST_LOG:?}"
+EOF
+cat > "${tmpdir}/bin/apt-get" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+archive_dir=""
+for argument in "$@"; do
+  case "${argument}" in
+    Dir::Cache::archives=*) archive_dir="${argument#*=}" ;;
+  esac
+done
+if [[ -n "${archive_dir}" ]]; then
+  mkdir -p "${archive_dir}"
+  cp "${SYSROOT_UPDATE_DOWNLOAD_DIR}"/*.deb "${archive_dir}/"
+fi
+EOF
+chmod 755 "${tmpdir}/fake-installer" "${tmpdir}/bin/apt-get"
+env "${common_env[@]}" \
+  PATH="${tmpdir}/bin:${PATH}" \
+  SYSROOT_INSTALLER="${tmpdir}/fake-installer" \
+  SYSROOT_UPDATE_INSTALL_TEST_LOG="${tmpdir}/install.log" \
+  "${SYSROOT_COMMAND}" install test-package:arm64 >/dev/null
+grep -Fxq 'overlay-selection-ok' "${tmpdir}/install.log" || \
+  fail "package install did not reconstruct active overlay APT selection"
+
+incomplete_prompt_output="$(
+  cp "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay" "${tmpdir}/active-overlay"
+  sed -i 's/^Overlay State = active$/Overlay State = incomplete/' \
+    "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay"
+  SYSROOT="${tmpdir}/sysroot" \
+  SDK_PROMPT_HOSTNAME=neat-sdk-test \
+  bash --noprofile --norc -ic \
+    "source '${ROOT_DIR}/config/profile.d/neat-sdk-prompt.sh'; printf '%s\\n' \"\${SDK_PROMPT_HOSTNAME}\"" \
+    2>/dev/null
+)"
+mv "${tmpdir}/active-overlay" "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay"
+grep -Fq 'neat-sdk-test-overlay-incomplete-2-1-3-pre4617' <<< "${incomplete_prompt_output}" || \
+  fail "interactive prompt mislabeled an incomplete overlay as active"
 
 setup_count_before="$(wc -l < "${tmpdir}/setup.log" | tr -d ' ')"
 idempotent_output="$(run_sysroot update 2.1.3~pre4617)"

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -236,8 +236,8 @@ while [[ "${1:-}" == "-o" ]]; do
   shift 2
 done
 if [[ "${SIMA_EXPECT_UNPRIVILEGED_DRY_RUN:-0}" == "1" ]]; then
-  [[ "${source_file}" != "${SYSROOT_UPDATE_APT_SOURCE_FILE:?}" ]]
-  [[ "${preferences_file}" != "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}" ]]
+  [[ "${source_file}" != "${SIMA_ORIGINAL_APT_SOURCE_FILE:?}" ]]
+  [[ "${preferences_file}" != "${SIMA_ORIGINAL_APT_PREFERENCES_FILE:?}" ]]
 fi
 grep -Fq 'deb [arch=arm64 trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free' \
   "${source_file}"
@@ -258,6 +258,8 @@ overlay_dry_run="$(
   env "${common_env[@]}" \
     PATH="${tmpdir}/bin:${PATH}" \
     SIMA_EXPECT_UNPRIVILEGED_DRY_RUN=1 \
+    SIMA_ORIGINAL_APT_SOURCE_FILE="${tmpdir}/apt/sources/pre-release.list" \
+    SIMA_ORIGINAL_APT_PREFERENCES_FILE="${tmpdir}/apt/preferences/pre-release.pref" \
     "${SYSROOT_COMMAND}" install opencv_dnn --dry-run
 )"
 grep -Fq 'Resolved opencv_dnn -> libopencv-dnn4' <<< "${overlay_dry_run}" || \

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -206,6 +206,7 @@ cat > "${tmpdir}/fake-installer" <<'EOF'
 set -euo pipefail
 [[ "${SDK_APT_CHANNEL:-}" == "pre-release" ]]
 grep -Fq 'Pin: version 2.1.3~pre4617' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+[[ "${2:-}" == "libopencv-dnn4:arm64" ]]
 printf 'overlay-selection-ok\n' > "${SYSROOT_UPDATE_INSTALL_TEST_LOG:?}"
 EOF
 cat > "${tmpdir}/bin/apt-get" <<'EOF'
@@ -222,12 +223,38 @@ if [[ -n "${archive_dir}" ]]; then
   cp "${SYSROOT_UPDATE_DOWNLOAD_DIR}"/*.deb "${archive_dir}/"
 fi
 EOF
-chmod 755 "${tmpdir}/fake-installer" "${tmpdir}/bin/apt-get"
+cat > "${tmpdir}/bin/apt-cache" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+grep -Fq 'Pin: version 2.1.3~pre4617' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+case "${1:-}" in
+  policy)
+    printf '%s\n' '  Candidate: (none)'
+    ;;
+  search)
+    if [[ "${2:-}" == '^libopencv-dnn[0-9]+$' ]]; then
+      printf '%s\n' 'libopencv-dnn4 - test overlay component'
+    fi
+    ;;
+esac
+EOF
+chmod 755 "${tmpdir}/fake-installer" "${tmpdir}/bin/apt-get" "${tmpdir}/bin/apt-cache"
+overlay_dry_run="$(
+  env "${common_env[@]}" \
+    PATH="${tmpdir}/bin:${PATH}" \
+    "${SYSROOT_COMMAND}" install opencv_dnn --dry-run
+)"
+grep -Fq 'Resolved opencv_dnn -> libopencv-dnn4' <<< "${overlay_dry_run}" || \
+  fail "dry-run component alias resolution did not use active overlay APT selection"
+[[ ! -e "${tmpdir}/apt/sources/pre-release.list" ]] || \
+  fail "dry-run component alias resolution did not clean up its temporary APT source"
+[[ ! -e "${tmpdir}/apt/preferences/pre-release.pref" ]] || \
+  fail "dry-run component alias resolution did not clean up its temporary APT pin"
 env "${common_env[@]}" \
   PATH="${tmpdir}/bin:${PATH}" \
   SYSROOT_INSTALLER="${tmpdir}/fake-installer" \
   SYSROOT_UPDATE_INSTALL_TEST_LOG="${tmpdir}/install.log" \
-  "${SYSROOT_COMMAND}" install test-package:arm64 >/dev/null
+  "${SYSROOT_COMMAND}" install opencv_dnn >/dev/null
 grep -Fxq 'overlay-selection-ok' "${tmpdir}/install.log" || \
   fail "package install did not reconstruct active overlay APT selection"
 

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SYSROOT_COMMAND="${ROOT_DIR}/scripts/sysroot.sh"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  exec sudo env PATH="${PATH}" "${BASH_SOURCE[0]}"
+fi
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+cat > "${tmpdir}/sdk-release" <<'EOF'
+SDK Release = develop-test
+SDK Profile = platform-cross
+Platform Version = 2.1.3~pre4460
+Platform Base = 2.1.3
+Platform Channel = pre-release
+Platform Repository = https://debian.neat.sima.ai/pre-release
+EOF
+
+cat > "${tmpdir}/Packages" <<'EOF'
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4593
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.2.0~pre9000
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4617
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.3
+Architecture: arm64
+
+Package: simaai-palette-modalix
+Version: 2.1.3~pre4617
+Architecture: arm64
+EOF
+
+cat > "${tmpdir}/fake-platform-setup" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+revision="$1"
+download_dir="${SYSROOT_UPDATE_DOWNLOAD_DIR:?}"
+sysroot="${SYSROOT:?}"
+printf '%s\t%s\t%s\n' \
+  "${revision}" \
+  "${SIMAAI_SETUP_DOWNLOAD_ONLY:-0}" \
+  "${SIMAAI_PLATFORM_BUILD_REVISION:-}" >> "${SYSROOT_UPDATE_TEST_LOG:?}"
+rm -rf "${download_dir}"
+mkdir -p "${download_dir}"
+package_root="$(mktemp -d)"
+trap 'rm -rf "${package_root}"' EXIT
+mkdir -p "${package_root}/DEBIAN" "${package_root}/usr/lib/aarch64-linux-gnu"
+cat > "${package_root}/DEBIAN/control" <<CONTROL
+Package: simaai-palette-modalix
+Version: ${revision}
+Architecture: arm64
+Maintainer: SDK Test <sdk-test@example.invalid>
+Description: sysroot update test fixture
+CONTROL
+printf '%s\n' "${revision}" > "${package_root}/usr/lib/aarch64-linux-gnu/sysroot-update-test.txt"
+dpkg-deb --build "${package_root}" "${download_dir}/simaai-palette-modalix_${revision}_arm64.deb" >/dev/null
+if [[ "${SYSROOT_UPDATE_TEST_FAIL:-0}" == "1" ]]; then
+  exit 42
+fi
+if [[ "${SIMAAI_SETUP_DOWNLOAD_ONLY:-0}" != "1" ]]; then
+  mkdir -p "${sysroot}/usr/lib/aarch64-linux-gnu"
+  cp "${package_root}/usr/lib/aarch64-linux-gnu/sysroot-update-test.txt" \
+    "${sysroot}/usr/lib/aarch64-linux-gnu/sysroot-update-test.txt"
+  mkdir -p "${sysroot}/var/lib/sima-sdk"
+  printf 'simaai-palette-modalix\tarm64\t%s\t/usr/lib/aarch64-linux-gnu\n' "${revision}" > \
+    "${sysroot}/var/lib/sima-sdk/sysroot-packages.tsv"
+fi
+EOF
+chmod 755 "${tmpdir}/fake-platform-setup"
+
+common_env=(
+  "SYSROOT=${tmpdir}/sysroot"
+  "SDK_RELEASE_FILE=${tmpdir}/sdk-release"
+  "SYSROOT_PLATFORM_SETUP=${tmpdir}/fake-platform-setup"
+  "PLATFORM_PACKAGE_PATTERNS_FILE=${ROOT_DIR}/config/platform-package-patterns.txt"
+  "PRE_RELEASE_PACKAGES_FILE=${tmpdir}/Packages"
+  "SYSROOT_UPDATE_APT_SOURCE_FILE=${tmpdir}/apt/sources/pre-release.list"
+  "SYSROOT_UPDATE_APT_PREFERENCES_FILE=${tmpdir}/apt/preferences/pre-release.pref"
+  "SYSROOT_UPDATE_DOWNLOAD_DIR=${tmpdir}/downloads"
+  "SYSROOT_UPDATE_TEST_LOG=${tmpdir}/setup.log"
+)
+
+run_sysroot() {
+  env "${common_env[@]}" "${SYSROOT_COMMAND}" "$@"
+}
+
+mkdir -p "${tmpdir}/sysroot/var/lib/sima-sdk"
+printf 'base-sdk-package\tarm64\t1.0.0\t/usr/lib\n' > \
+  "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages.tsv"
+mkdir -p "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages"
+cat > "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages/simaai-palette-modalix_arm64.manifest" <<'EOF'
+Package: simaai-palette-modalix
+Architecture: arm64
+Version: 2.1.3~pre4460
+
+usr/lib/aarch64-linux-gnu/old-file.txt
+EOF
+initial_list="$(run_sysroot list)"
+grep -Eq '^base-sdk-package[[:space:]]+arm64[[:space:]]+1\.0\.0[[:space:]]+/usr/lib$' \
+  <<< "${initial_list}" || \
+  fail "list did not read the image-default package inventory"
+
+initial_status="$(run_sysroot status)"
+grep -Fq 'Sysroot overlay state:    inactive' <<< "${initial_status}" || \
+  fail "clean SDK did not report an inactive overlay"
+
+if run_sysroot update >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "noninteractive update without a selector succeeded"
+fi
+grep -Fq 'interactive revision selection requires a TTY' "${tmpdir}/err" || \
+  fail "non-TTY error was unclear"
+
+if run_sysroot update 2.2.0~pre9000 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "cross-base update succeeded"
+fi
+grep -Fq 'SDK Platform Base is 2.1.3' "${tmpdir}/err" || \
+  fail "cross-base rejection was unclear"
+
+if run_sysroot update 2.1.3~pre9999 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "missing pre-release revision succeeded"
+fi
+grep -Fq 'is not available' "${tmpdir}/err" || fail "missing revision rejection was unclear"
+
+dry_run="$(run_sysroot update 2.1.3~pre4593 --dry-run)"
+grep -Fq 'Dry run complete: 2.1.3~pre4593 resolved and validated' <<< "${dry_run}" || \
+  fail "exact dry run did not validate the selected revision"
+[[ ! -e "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay" ]] || \
+  fail "dry run created overlay metadata"
+grep -Fxq $'2.1.3~pre4593\t1\t4593' "${tmpdir}/setup.log" || \
+  fail "exact dry run did not constrain dependencies to the selected build cohort"
+
+latest_dry_run="$(run_sysroot update --latest --yes --dry-run)"
+grep -Fq 'Dry run complete: 2.1.3~pre4617 resolved and validated' <<< "${latest_dry_run}" || \
+  fail "latest resolution did not select the newest eligible revision"
+grep -Fxq $'2.1.3~pre4617\t1\t4617' "${tmpdir}/setup.log" || \
+  fail "latest dry run did not constrain dependencies to the selected build cohort"
+
+if env "${common_env[@]}" SYSROOT_UPDATE_TEST_FAIL=1 \
+  "${SYSROOT_COMMAND}" update 2.1.3~pre4593 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
+  fail "failed platform setup was reported as successful"
+fi
+failed_status="$(run_sysroot status)"
+grep -Fq 'Sysroot overlay state:    incomplete' <<< "${failed_status}" || \
+  fail "failed update did not leave visible incomplete overlay state"
+grep -Fq 'WARNING: The sysroot overlay is not complete' <<< "${failed_status}" || \
+  fail "incomplete overlay did not report recovery guidance"
+
+update_output="$(run_sysroot update 2.1.3~pre4617)"
+grep -Fq 'Sysroot overlay is active at 2.1.3~pre4617' <<< "${update_output}" || \
+  fail "exact update did not activate the overlay"
+grep -Fxq '2.1.3~pre4617' "${tmpdir}/sysroot/usr/lib/aarch64-linux-gnu/sysroot-update-test.txt" || \
+  fail "platform setup did not update the sysroot"
+grep -Fxq 'Platform Revision = 2.1.3~pre4617' "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay" || \
+  fail "overlay revision was not recorded"
+awk -F '\t' '$1 == "simaai-palette-modalix" && $2 == "arm64" && $3 == "2.1.3~pre4617" && $4 == "/usr/lib/aarch64-linux-gnu" { found = 1 } END { exit !found }' \
+  "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages.tsv" || \
+  fail "package inventory was not recorded"
+updated_list="$(run_sysroot list)"
+grep -Eq '^simaai-palette-modalix[[:space:]]+arm64[[:space:]]+2\.1\.3~pre4617[[:space:]]+/usr/lib/aarch64-linux-gnu$' \
+  <<< "${updated_list}" || \
+  fail "list did not report the updated full package inventory"
+grep -Fxq 'Version: 2.1.3~pre4617' \
+  "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages/simaai-palette-modalix_arm64.manifest" || \
+  fail "update did not refresh an existing tracked package manifest"
+grep -Fxq $'2.1.3~pre4617\t0\t4617' "${tmpdir}/setup.log" || \
+  fail "actual update did not constrain dependencies to the selected build cohort"
+
+setup_count_before="$(wc -l < "${tmpdir}/setup.log" | tr -d ' ')"
+idempotent_output="$(run_sysroot update 2.1.3~pre4617)"
+setup_count_after="$(wc -l < "${tmpdir}/setup.log" | tr -d ' ')"
+grep -Fq 'no changes are required' <<< "${idempotent_output}" || \
+  fail "same-revision update was not reported as idempotent"
+[[ "${setup_count_before}" == "${setup_count_after}" ]] || \
+  fail "same-revision update invoked platform setup"
+
+overlay_status="$(run_sysroot status)"
+grep -Fq 'Sysroot overlay state:    active' <<< "${overlay_status}" || \
+  fail "active overlay state was not reported"
+grep -Fq 'Sysroot overlay revision: 2.1.3~pre4617' <<< "${overlay_status}" || \
+  fail "active overlay revision was not reported"
+
+prompt_output="$(
+  SYSROOT="${tmpdir}/sysroot" \
+  SDK_PROMPT_HOSTNAME=neat-sdk-test \
+  bash --noprofile --norc -ic \
+    "source '${ROOT_DIR}/config/profile.d/neat-sdk-prompt.sh'; printf '%s\\n' \"\${SDK_PROMPT_HOSTNAME}\"" \
+    2>/dev/null
+)"
+grep -Fq 'neat-sdk-test-overlay-2-1-3-pre4617' <<< "${prompt_output}" || \
+  fail "interactive prompt did not expose the active overlay"
+
+[[ ! -e "${tmpdir}/apt/sources/pre-release.list" ]] || fail "temporary APT source was not cleaned up"
+[[ ! -e "${tmpdir}/apt/preferences/pre-release.pref" ]] || fail "temporary APT preferences were not cleaned up"
+
+echo "sysroot update tests passed"

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -114,6 +114,13 @@ Version: 2.1.3~pre4460
 
 usr/lib/aarch64-linux-gnu/old-file.txt
 EOF
+cat > "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages/manual-package_arm64.manifest" <<'EOF'
+Package: manual-package
+Architecture: arm64
+Version: 9.8.7
+
+opt/manual-package/libmanual.so
+EOF
 initial_list="$(run_sysroot list)"
 grep -Eq '^base-sdk-package[[:space:]]+arm64[[:space:]]+1\.0\.0[[:space:]]+/usr/lib$' \
   <<< "${initial_list}" || \
@@ -184,6 +191,9 @@ updated_list="$(run_sysroot list)"
 grep -Eq '^simaai-palette-modalix[[:space:]]+arm64[[:space:]]+2\.1\.3~pre4617[[:space:]]+/usr/lib/aarch64-linux-gnu$' \
   <<< "${updated_list}" || \
   fail "list did not report the updated full package inventory"
+grep -Eq '^manual-package[[:space:]]+arm64[[:space:]]+9\.8\.7[[:space:]]+/opt/manual-package$' \
+  <<< "${updated_list}" || \
+  fail "platform update dropped a manually installed package from the inventory"
 grep -Fxq 'Version: 2.1.3~pre4617' \
   "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-packages/simaai-palette-modalix_arm64.manifest" || \
   fail "update did not refresh an existing tracked package manifest"


### PR DESCRIPTION
Closes #150.

## Summary

Add a supported local `sysroot update` workflow for testing SiMa.ai pre-release platform revisions inside an existing SDK container.

- query and filter the public pre-release mirror by the immutable `Platform Base`
- support interactive selection, exact noninteractive pins, `--latest --yes`, and `--dry-run`
- resolve and validate the complete package cohort, including independently versioned packages
- download in parallel with bounded retries, per-revision caching, APT-index SHA-256 verification, and terminal/CI progress reporting
- record the local change as a visible sysroot overlay without rewriting `/etc/sdk-release`
- expose `active`, `updating`, and `incomplete` transaction states through `sysroot status`
- mark interactive SDK prompts with the active overlay revision
- maintain a canonical package inventory and show package, architecture, version, and summarized sysroot locations through `sysroot list`
- keep explicit `sysroot install` manifests accurate without regenerating hundreds of unnecessary update-wide manifests

## Safety boundaries

The updater accepts only `X.Y.Z~preN` revisions matching the SDK image's exact `Platform Base`. Stable versions, cross-base revisions, and unavailable revisions fail before mutation. Exact pins are noninteractive; a bare command requires a TTY.

The command discloses that the pre-release repository currently uses HTTPS with APT `trusted=yes`, which is not equivalent to signed repository metadata. Recreating the SDK container remains the clean reset path for an in-place overlay.

## Performance

The package transfer phase uses eight workers by default and reuses checksum-validated cached packages. A cached 410-package cohort validation completed in about 15 seconds locally. Removing duplicate update-wide manifest generation also makes activation effectively immediate after package validation.

## Validation

- shell syntax checks
- Python bytecode compilation
- ShellCheck
- actionlint
- existing platform resolver, SDK release metadata, and DevKit profile tests
- new sysroot update tests covering filtering, exact/latest selection, non-TTY behavior, cross-base rejection, dry-run, failed/incomplete transaction state, manifest refresh, provenance, prompt marker, and idempotence
- new package progress and canonical inventory tests
- real mirror-backed 2.1.3~pre4593 dry-run resolving and checksum-validating 410 packages
