### PR TITLE
Fix multi-architecture sysroot package validation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,6 +53,7 @@ jobs:
           tests/sdk/test-devkit-platform-profile.sh
           tests/sdk/test-sysroot-unprivileged-dry-run.sh
           tests/sdk/test-sysroot-update.sh
+          tests/sdk/test-sysroot-package-version-validator.sh
           python3 tests/sdk/test-sysroot-progress.py
 
   build:

--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -510,11 +510,11 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
     selected_downloads_lock = threading.Lock()
     download_progress = DownloadProgress()
 
-    def record_expected_version(pkg, expected_version):
+    def record_expected_version(pkg, architecture, expected_version):
         if expected_version:
             with expected_versions_lock:
                 with open(expected_versions_manifest, "at", encoding="utf-8") as wf:
-                    wf.write(f"{pkg}\t{expected_version}\n")
+                    wf.write(f"{pkg}\t{architecture}\t{expected_version}\n")
 
     def file_sha256(path):
         digest = hashlib.sha256()
@@ -524,24 +524,44 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
         return digest.hexdigest()
 
     def downloaded_package_matches(
-        dlname, expected_package, expected_version, expected_sha256
+        dlname,
+        expected_package,
+        expected_architecture,
+        expected_version,
+        expected_sha256,
     ):
         if not os.path.isfile(dlname):
             return False
         try:
             pkg = package_field(dlname, "Package")
+            architecture = package_field(dlname, "Architecture")
             ver = package_field(dlname, "Version")
         except (OSError, subprocess.SubprocessError):
             return False
-        if pkg != expected_package or ver != expected_version:
+        if (
+            pkg != expected_package
+            or architecture != expected_architecture
+            or ver != expected_version
+        ):
             return False
         return not expected_sha256 or file_sha256(dlname) == expected_sha256
 
-    def download(uri, dlname, expected_package, expected_version, expected_sha256):
+    def download(
+        uri,
+        dlname,
+        expected_package,
+        expected_architecture,
+        expected_version,
+        expected_sha256,
+    ):
         """Download a package and validate the resolved package version."""
 
         cached = downloaded_package_matches(
-            dlname, expected_package, expected_version, expected_sha256
+            dlname,
+            expected_package,
+            expected_architecture,
+            expected_version,
+            expected_sha256,
         )
         if not cached:
             partial = f"{dlname}.partial"
@@ -568,12 +588,18 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
                 ) from exc
 
         pkg = package_field(dlname, "Package")
+        architecture = package_field(dlname, "Architecture")
         ver = package_field(dlname, "Version")
         if pkg != expected_package:
             raise RuntimeError(f"Unexpected package {pkg}; expected {expected_package}")
+        if architecture != expected_architecture:
+            raise RuntimeError(
+                f"Unexpected {pkg} architecture {architecture}; "
+                f"expected {expected_architecture}"
+            )
         if expected_version and ver != expected_version:
             raise RuntimeError(f"Unexpected {pkg} version {ver}; expected {expected_version}")
-        record_expected_version(pkg, expected_version)
+        record_expected_version(pkg, architecture, expected_version)
         with selected_downloads_lock:
             selected_downloads.add(os.path.abspath(dlname))
         return cached
@@ -594,6 +620,7 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
                         candidate.uri,
                         os.path.join(dldir, f"{name}.deb"),
                         base_package_name(name),
+                        candidate.architecture,
                         candidate.version,
                         candidate.record.get("SHA256", ""),
                     ): name

--- a/scripts/validate-sysroot-package-versions.sh
+++ b/scripts/validate-sysroot-package-versions.sh
@@ -69,11 +69,15 @@ is_platform_package() {
 errors=0
 deb_count=0
 declare -A expected_versions=()
+declare -A legacy_expected_versions=()
 
 if [[ -f "${expected_versions_manifest}" ]]; then
-  while IFS=$'\t' read -r pkg ver; do
-    if [[ -n "${pkg}" && -n "${ver}" ]]; then
-      expected_versions["${pkg}"]="${ver}"
+  while IFS=$'\t' read -r pkg architecture ver; do
+    if [[ -n "${pkg}" && -n "${architecture}" && -n "${ver}" ]]; then
+      expected_versions["${pkg}:${architecture}"]="${ver}"
+    elif [[ -n "${pkg}" && -n "${architecture}" ]]; then
+      # Compatibility with manifests generated before architecture was added.
+      legacy_expected_versions["${pkg}"]="${architecture}"
     fi
   done < "${expected_versions_manifest}"
 fi
@@ -81,9 +85,13 @@ fi
 while IFS= read -r -d '' deb; do
   deb_count=$((deb_count + 1))
   pkg="$(dpkg-deb -f "${deb}" Package)"
+  architecture="$(dpkg-deb -f "${deb}" Architecture)"
   ver="$(dpkg-deb -f "${deb}" Version)"
 
-  expected_pkg_version="${expected_versions["${pkg}"]:-}"
+  expected_pkg_version="${expected_versions["${pkg}:${architecture}"]:-}"
+  if [[ -z "${expected_pkg_version}" ]]; then
+    expected_pkg_version="${legacy_expected_versions["${pkg}"]:-}"
+  fi
   if [[ -z "${expected_pkg_version}" ]] && is_platform_package "${pkg}"; then
     expected_pkg_version="${expected_version}"
   fi

--- a/tests/sdk/test-sysroot-package-version-validator.sh
+++ b/tests/sdk/test-sysroot-package-version-validator.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="${ROOT_DIR}/scripts/validate-sysroot-package-versions.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+mkdir -p "${WORK_DIR}/bin" "${WORK_DIR}/debs"
+touch "${WORK_DIR}/debs/bzip2-amd64.deb" "${WORK_DIR}/debs/bzip2-arm64.deb"
+
+cat > "${WORK_DIR}/bin/dpkg-deb" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+deb="$2"
+field="$3"
+filename="$(basename "${deb}")"
+
+case "${field}" in
+  Package) echo bzip2 ;;
+  Architecture)
+    case "${filename}" in
+      *-amd64.deb) echo amd64 ;;
+      *-arm64.deb) echo arm64 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  Version)
+    case "${filename}" in
+      *-amd64.deb) echo 1.0.8-5.1build0.1 ;;
+      *-arm64.deb) echo 1.0.8-5+b1 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "${WORK_DIR}/bin/dpkg-deb"
+
+cat > "${WORK_DIR}/debs/expected-package-versions.tsv" <<'EOF'
+bzip2	amd64	1.0.8-5.1build0.1
+bzip2	arm64	1.0.8-5+b1
+EOF
+
+PATH="${WORK_DIR}/bin:${PATH}" "${VALIDATOR}" 2.1.3~pre4617 "${WORK_DIR}/debs"
+
+cat > "${WORK_DIR}/debs/expected-package-versions.tsv" <<'EOF'
+bzip2	amd64	1.0.8-5.1build0.1
+bzip2	arm64	incorrect-version
+EOF
+
+if PATH="${WORK_DIR}/bin:${PATH}" \
+  "${VALIDATOR}" 2.1.3~pre4617 "${WORK_DIR}/debs" 2>/dev/null; then
+  echo "Validator accepted an incorrect architecture-specific package version." >&2
+  exit 1
+fi
+
+rm "${WORK_DIR}/debs/bzip2-arm64.deb"
+cat > "${WORK_DIR}/debs/expected-package-versions.tsv" <<'EOF'
+bzip2	1.0.8-5.1build0.1
+EOF
+
+PATH="${WORK_DIR}/bin:${PATH}" "${VALIDATOR}" 2.1.3~pre4617 "${WORK_DIR}/debs"
+
+echo "Sysroot package version validator tests passed."


### PR DESCRIPTION
## Summary

- key expected sysroot package versions by package name and architecture
- validate cached and newly downloaded packages against the expected architecture
- retain compatibility with legacy two-column expected-version manifests
- add regression coverage for simultaneous amd64 and arm64 variants with different valid versions

## Context

This fixes the x86 SDK build regression exposed after #151, where concurrent manifest writes made a package-name-only lookup select the arm64 version while validating the amd64 package (or vice versa).

## Validation

- mixed-architecture validator regression test on the x86 private runner
- incorrect architecture-specific version rejection
- legacy two-column manifest compatibility
- `python3 tests/sdk/test-sysroot-progress.py`
- `tests/sdk/test-resolve-platform-config.sh`
- Python compilation and shell syntax checks