### PR TITLE
Fix sysroot overlay completion state

### DIFF
--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -521,7 +521,9 @@ refresh_tracked_manifests() {
   local root workdir manifest package package_arch candidate target matched
 
   root="$(manifest_root "${sysroot}")"
-  [[ -d "${root}" ]] || return
+  # A newly built SDK has no per-package manifests until the user installs a
+  # package with `sysroot install`.  That is a successful no-op, not an error.
+  [[ -d "${root}" ]] || return 0
   workdir="$(mktemp -d)"
   while IFS= read -r -d '' manifest; do
     package="$(awk -F ': ' '$1 == "Package" { print $2; exit }' "${manifest}")"
@@ -624,7 +626,9 @@ merge_tracked_manifests_into_inventory() {
 
   inventory="$(sysroot_inventory_path "${sysroot}")"
   root="$(manifest_root "${sysroot}")"
-  [[ -s "${inventory}" && -d "${root}" ]] || return
+  # The image inventory can exist without any user-managed package manifests.
+  # Return success so `set -e` does not abort a completed platform update.
+  [[ -s "${inventory}" && -d "${root}" ]] || return 0
   manifest_entries="${inventory}.manifests"
   merged="${inventory}.tmp"
   : > "${manifest_entries}"
@@ -653,7 +657,7 @@ remove_package_from_inventory() {
   local inventory temporary
 
   inventory="$(sysroot_inventory_path "${sysroot}")"
-  [[ -r "${inventory}" ]] || return
+  [[ -r "${inventory}" ]] || return 0
   temporary="${inventory}.tmp"
   awk -F '\t' -v package="${package}" -v architecture="${architecture}" \
     'NF < 3 || $1 != package || $2 != architecture' "${inventory}" > "${temporary}"
@@ -827,7 +831,7 @@ configure_active_overlay_apt() {
   local overlay state revision repository
 
   overlay="$(sysroot_overlay_path "${sysroot}")"
-  [[ -r "${overlay}" ]] || return
+  [[ -r "${overlay}" ]] || return 0
   state="$(read_release_field "${overlay}" "Overlay State")"
   [[ "${state}" == "active" ]] || \
     die "sysroot overlay state is ${state:-unknown}; rerun the update or recreate the SDK container before installing packages"

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -161,6 +161,23 @@ grep -Fq 'Dry run complete: 2.1.3~pre4617 resolved and validated' <<< "${latest_
 grep -Fxq $'2.1.3~pre4617\t1\t4617' "${tmpdir}/setup.log" || \
   fail "latest dry run did not constrain dependencies to the selected build cohort"
 
+# A fresh SDK image has an image inventory but no manifests created by
+# `sysroot install`.  Optional manifest bookkeeping must remain a successful
+# no-op so a fully extracted update can still be committed as active.
+fresh_sysroot="${tmpdir}/fresh-sysroot"
+mkdir -p "${fresh_sysroot}/var/lib/sima-sdk"
+printf 'base-sdk-package\tarm64\t1.0.0\t/usr/lib\n' > \
+  "${fresh_sysroot}/var/lib/sima-sdk/sysroot-packages.tsv"
+fresh_update_output="$(
+  env "${common_env[@]}" SYSROOT="${fresh_sysroot}" \
+    "${SYSROOT_COMMAND}" update 2.1.3~pre4593
+)"
+grep -Fq 'Sysroot overlay is active at 2.1.3~pre4593' <<< "${fresh_update_output}" || \
+  fail "fresh SDK update without tracked manifests did not activate the overlay"
+grep -Fxq 'Overlay State = active' \
+  "${fresh_sysroot}/var/lib/sima-sdk/sysroot-overlay" || \
+  fail "fresh SDK update was left incomplete"
+
 if env "${common_env[@]}" SYSROOT_UPDATE_TEST_FAIL=1 \
   "${SYSROOT_COMMAND}" update 2.1.3~pre4593 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
   fail "failed platform setup was reported as successful"


### PR DESCRIPTION
## Summary

- make optional sysroot bookkeeping paths return successful no-op status explicitly
- prevent `set -e` from aborting a successfully extracted platform update when a fresh SDK has no user-managed package manifests
- add a regression case for updating a fresh SDK sysroot and committing the overlay as active

## Root cause

The manifest merge and refresh helpers used `condition || return`. When their optional manifest directory was absent, bare `return` propagated status 1. After all platform packages had been extracted and validated, `set -e` terminated the command and the EXIT trap recorded the transaction as incomplete.

## User impact

A successful `sysroot update` now finishes by recording `Overlay State = active` instead of telling users to rerun or recreate the container.

## Validation

- `bash -n scripts/sysroot.sh tests/sdk/test-sysroot-update.sh`
- fresh-sysroot regression reaches `Overlay State = active`
- repaired the reported local SDK and successfully updated it to `2.1.3~pre4666`; `sysroot status` reports the overlay active

Closes #153