### PR TITLE
Prevent host packages in sysroot updates

### DIFF
--- a/scripts/simaai_setup_sdk.py
+++ b/scripts/simaai_setup_sdk.py
@@ -16,9 +16,9 @@ Local SDK image changes:
   generic build dependencies.
 - Skip libdlpack-dev because the SiMa TVM package owns the compatible
   dlpack/dlpack.h header in this sysroot.
+- Reject SDK-host distribution packages before modifying the target sysroot.
 """
 
-import apt
 import concurrent.futures
 import fnmatch
 import glob
@@ -29,7 +29,9 @@ import subprocess
 import sys
 import threading
 import time
+from urllib.parse import urlparse
 
+import apt
 
 DEFAULT_PLATFORM_PACKAGE_PATTERNS = (
     "simaai-palette-modalix",
@@ -65,6 +67,19 @@ SKIP_PACKAGES = {
 }
 
 APT_UPDATE_RETRY_DELAYS_SECONDS = (10, 30)
+TARGET_PACKAGE_SITES = {
+    "debian.neat.sima.ai",
+    "repo.sima.ai",
+    "mirror.elxr.dev",
+    "deb.debian.org",
+    "security.debian.org",
+}
+HOST_DISTRIBUTION_ORIGINS = {"Ubuntu"}
+HOST_DISTRIBUTION_SITES = {
+    "archive.ubuntu.com",
+    "ports.ubuntu.com",
+    "security.ubuntu.com",
+}
 
 
 def rewrite_config_paths(data, old, new):
@@ -345,6 +360,51 @@ def package_payload_locations(deb_path):
     return ",".join(sorted(locations))
 
 
+def candidate_origin_details(candidate):
+    """Return stable source metadata for diagnostics and policy checks."""
+
+    details = []
+    for origin in candidate.origins:
+        details.append(
+            {
+                "origin": origin.origin or "",
+                "site": origin.site or "",
+                "archive": origin.archive or "",
+                "label": origin.label or "",
+            }
+        )
+    return details
+
+
+def validate_target_candidate(pkgname, candidate):
+    """Prevent an SDK-host package from entering the Modalix target sysroot."""
+
+    if candidate is None or os.environ.get("SIMAAI_VALIDATE_TARGET_ORIGIN") != "1":
+        return
+    details = candidate_origin_details(candidate)
+    origins = {item["origin"] for item in details if item["origin"]}
+    candidate_site = urlparse(candidate.uri).hostname or ""
+    if candidate_site in TARGET_PACKAGE_SITES:
+        return
+    if (
+        origins.intersection(HOST_DISTRIBUTION_ORIGINS)
+        or candidate_site in HOST_DISTRIBUTION_SITES
+    ):
+        source = ", ".join(
+            sorted(
+                {
+                    f"{item['origin'] or '<unknown>'}@{item['site'] or '<unknown>'}"
+                    for item in details
+                }
+            )
+        )
+        raise RuntimeError(
+            f"Refusing host-distribution package {pkgname} = {candidate.version} "
+            f"from {source}; the Modalix sysroot accepts target-repository "
+            "packages only"
+        )
+
+
 def write_sysroot_package_inventory(download_dir, sysroot):
     """Record every package represented by the resolved sysroot cohort."""
 
@@ -463,6 +523,7 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
         if requested_version:
             for candidate in pkg.versions:
                 if fnmatch.fnmatch(candidate.version, requested_version):
+                    validate_target_candidate(pkgname, candidate)
                     return candidate
             if is_platform_package(pkgname):
                 print(f"Skipping {pkgname}; no candidate matches platform version {version}")
@@ -474,8 +535,10 @@ def main(pkg_name, version, libc_ver, dldir, installdir):
                 if matches_platform_build_revision(
                     candidate.version, PLATFORM_BUILD_REVISION
                 ):
+                    validate_target_candidate(pkgname, candidate)
                     return candidate
 
+        validate_target_candidate(pkgname, pkg.candidate)
         return pkg.candidate
 
     def collect_rdeps(candidate, recursive):

--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -809,6 +809,30 @@ configure_update_apt() {
 Package: ${platform_packages}
 Pin: version ${platform_revision}
 Pin-Priority: 1002
+
+Package: *
+Pin: origin "debian.neat.sima.ai"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "repo.sima.ai"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "mirror.elxr.dev"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "deb.debian.org"
+Pin-Priority: 990
+
+Package: *
+Pin: origin "security.debian.org"
+Pin-Priority: 990
+
+Package: *
+Pin: release o=Ubuntu
+Pin-Priority: 100
 EOF
   update_preferences_created=1
 }
@@ -901,6 +925,7 @@ apply_sysroot_update() {
     SYSROOT_UPDATE_DOWNLOAD_DIR="${download_dir}" \
     SDK_APT_CHANNEL=pre-release \
     SIMAAI_PLATFORM_BUILD_REVISION="${platform_revision##*~pre}" \
+    SIMAAI_VALIDATE_TARGET_ORIGIN=1 \
     SIMAAI_SETUP_DOWNLOAD_ONLY="${dry_run}" \
     "${PLATFORM_SETUP}" "${platform_revision}" "${SDK_PKG_LIST:-}"; then
     if [[ "${dry_run}" != "1" ]]; then

--- a/tests/sdk/test-sysroot-progress.py
+++ b/tests/sdk/test-sysroot-progress.py
@@ -5,11 +5,11 @@
 import contextlib
 import importlib.util
 import io
+import os
 import pathlib
 import sys
 import tempfile
 import types
-
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 sys.modules.setdefault("apt", types.ModuleType("apt"))
@@ -18,6 +18,73 @@ spec = importlib.util.spec_from_file_location(
 )
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
+
+
+class FakeOrigin:
+    def __init__(self, origin, site, archive="", label=""):
+        self.origin = origin
+        self.site = site
+        self.archive = archive
+        self.label = label
+
+
+class FakeCandidate:
+    def __init__(self, version, uri, origins):
+        self.version = version
+        self.uri = uri
+        self.origins = origins
+
+
+os.environ["SIMAAI_VALIDATE_TARGET_ORIGIN"] = "1"
+try:
+    module.validate_target_candidate(
+        "libgstreamer1.0-0:arm64",
+        FakeCandidate(
+            "1.22.0-2+deb12u1",
+            "http://deb.debian.org/debian/pool/main/g/gstreamer1.0/package.deb",
+            [FakeOrigin("Debian", "deb.debian.org", "bookworm", "Debian")],
+        ),
+    )
+
+    try:
+        module.validate_target_candidate(
+            "libgstreamer1.0-0:arm64",
+            FakeCandidate(
+                "1.24.2-1ubuntu0.1",
+                "http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gstreamer1.0/package.deb",
+                [FakeOrigin("Ubuntu", "ports.ubuntu.com", "noble-updates", "Ubuntu")],
+            ),
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+        assert "Refusing host-distribution package libgstreamer1.0-0:arm64" in message
+        assert "1.24.2-1ubuntu0.1" in message
+        assert "Ubuntu@ports.ubuntu.com" in message
+    else:
+        raise AssertionError("Ubuntu host package was accepted for the Modalix sysroot")
+
+    # Unknown third-party repositories are not classified as the Ubuntu SDK host.
+    module.validate_target_candidate(
+        "vendor-library:arm64",
+        FakeCandidate(
+            "1.0.0",
+            "https://packages.vendor.example/pool/vendor-library.deb",
+            [FakeOrigin("Vendor", "packages.vendor.example", "stable", "Vendor")],
+        ),
+    )
+finally:
+    del os.environ["SIMAAI_VALIDATE_TARGET_ORIGIN"]
+
+# Stable SDK construction and explicit sysroot installs keep their existing
+# behavior unless the overlay-update entry point enables the origin gate.
+module.validate_target_candidate(
+    "libgstreamer1.0-0:arm64",
+    FakeCandidate(
+        "1.24.2-1ubuntu0.1",
+        "http://ports.ubuntu.com/ubuntu-ports/pool/main/g/gstreamer1.0/package.deb",
+        [FakeOrigin("Ubuntu", "ports.ubuntu.com", "noble-updates", "Ubuntu")],
+    ),
+)
 
 
 output = io.StringIO()

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -59,6 +59,11 @@ printf '%s\t%s\t%s\n' \
   "${revision}" \
   "${SIMAAI_SETUP_DOWNLOAD_ONLY:-0}" \
   "${SIMAAI_PLATFORM_BUILD_REVISION:-}" >> "${SYSROOT_UPDATE_TEST_LOG:?}"
+grep -Fq 'Pin: origin "deb.debian.org"' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+grep -Fq 'Pin: origin "mirror.elxr.dev"' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+grep -A1 -F 'Pin: release o=Ubuntu' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}" | \
+  grep -Fq 'Pin-Priority: 100'
+[[ "${SIMAAI_VALIDATE_TARGET_ORIGIN:-}" == "1" ]]
 rm -rf "${download_dir}"
 mkdir -p "${download_dir}"
 package_root="$(mktemp -d)"
@@ -216,7 +221,6 @@ grep -Fxq 'Version: 2.1.3~pre4617' \
   fail "update did not refresh an existing tracked package manifest"
 grep -Fxq $'2.1.3~pre4617\t0\t4617' "${tmpdir}/setup.log" || \
   fail "actual update did not constrain dependencies to the selected build cohort"
-
 mkdir -p "${tmpdir}/bin"
 cat > "${tmpdir}/fake-installer" <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
Closes #155

## Summary

- apply the established Modalix target-repository priorities during `sysroot update`
- keep the requested SiMa platform cohort pinned above the target dependency repositories
- lower Ubuntu host packages during overlay resolution
- reject an Ubuntu-origin candidate before extraction when the origin gate is enabled by `sysroot update`
- scope the new origin gate to overlay updates so stable SDK construction and explicit `sysroot install` behavior remain unchanged
- add regression coverage for Debian GStreamer acceptance, Ubuntu GStreamer rejection, APT preferences, and feature scoping

## Verification

- reproduced the original clean-container candidate: Ubuntu `libgstreamer1.0-0:arm64` 1.24.2 at priority 500 over Debian/eLxr 1.22 at priority 100
- real `sysroot update 2.1.3~pre4678 --dry-run`: 410 packages resolved and validated; GStreamer resolved to Debian 1.22
- real update in recreated `ghcr.io/sima-neat/sdk-develop:latest` container: 410 packages extracted and validated, overlay became active at `2.1.3~pre4678`, and `pkg-config --modversion gstreamer-1.0` remained `1.22.0`
- real Ubuntu 1.24.2 candidate was rejected with package/version/origin diagnostics
- sysroot progress, package-version validator, and unprivileged dry-run tests passed
- Python compilation, focused Ruff import/error checks, Bash syntax, and `git diff --check` passed
