### PR TITLE
Fix target package downgrades during sysroot updates

### DIFF
--- a/scripts/sysroot.sh
+++ b/scripts/sysroot.sh
@@ -782,6 +782,7 @@ parse_update_options() {
 
 configure_update_apt() {
   local platform_revision="$1"
+  local target_priority="${2:-990}"
   local source_file preferences_file platform_packages
 
   source_file="${SYSROOT_UPDATE_APT_SOURCE_FILE:-/etc/apt/sources.list.d/00-sima-sdk-sysroot-pre-release.list}"
@@ -812,23 +813,23 @@ Pin-Priority: 1002
 
 Package: *
 Pin: origin "debian.neat.sima.ai"
-Pin-Priority: 990
+Pin-Priority: ${target_priority}
 
 Package: *
 Pin: origin "repo.sima.ai"
-Pin-Priority: 990
+Pin-Priority: ${target_priority}
 
 Package: *
 Pin: origin "mirror.elxr.dev"
-Pin-Priority: 990
+Pin-Priority: ${target_priority}
 
 Package: *
 Pin: origin "deb.debian.org"
-Pin-Priority: 990
+Pin-Priority: ${target_priority}
 
 Package: *
 Pin: origin "security.debian.org"
-Pin-Priority: 990
+Pin-Priority: ${target_priority}
 
 Package: *
 Pin: release o=Ubuntu
@@ -914,7 +915,7 @@ apply_sysroot_update() {
   update_target_revision="${platform_revision}"
   update_overlay_pending=0
   trap cleanup_update_transaction EXIT
-  configure_update_apt "${platform_revision}"
+  configure_update_apt "${platform_revision}" 1001
   if [[ "${dry_run}" != "1" ]]; then
     write_overlay_transition \
       "${sysroot}" "${platform_base}" "${previous_revision}" "${platform_revision}" "updating"

--- a/tests/sdk/test-sysroot-apt-candidate.py
+++ b/tests/sdk/test-sysroot-apt-candidate.py
@@ -1,0 +1,161 @@
+import argparse
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+PACKAGE = "libgcc-s1"
+ARCH = "arm64"
+INSTALLED_VERSION = "14.2.0-4ubuntu2~24.04.1"
+TARGET_VERSION = "12.2.0-14+deb12u1"
+TARGET_ORIGIN = 'origin "debian.neat.sima.ai"'
+
+
+def read_target_priority(path: Path) -> int:
+    stanza = ""
+    for candidate in path.read_text(encoding="utf-8").split("\n\n"):
+        if f"Pin: {TARGET_ORIGIN}" in candidate:
+            stanza = candidate
+            break
+    if not stanza:
+        raise AssertionError(f"missing target-origin stanza: {TARGET_ORIGIN}")
+
+    match = re.search(r"^Pin-Priority:\s*(\d+)\s*$", stanza, re.MULTILINE)
+    if match is None:
+        raise AssertionError("target-origin stanza has no numeric priority")
+    return int(match.group(1))
+
+
+def apt_options(root: Path) -> list[str]:
+    return [
+        "-o",
+        f"Dir::State::status={root / 'status'}",
+        "-o",
+        f"Dir::State::lists={root / 'lists'}",
+        "-o",
+        f"Dir::Etc::sourcelist={root / 'sources.list'}",
+        "-o",
+        "Dir::Etc::sourceparts=-",
+        "-o",
+        f"APT::Architecture={ARCH}",
+        "-o",
+        f"APT::Architectures::={ARCH}",
+    ]
+
+
+def write_fixture(root: Path) -> None:
+    status = root / "status"
+    lists = root / "lists"
+    (lists / "partial").mkdir(parents=True)
+    repository = root / "repository"
+    repository.mkdir()
+    cache = root / "cache"
+    (cache / "archives" / "partial").mkdir(parents=True)
+    status.write_text(
+        f"""Package: {PACKAGE}
+Status: install ok installed
+Priority: required
+Section: libs
+Installed-Size: 1
+Maintainer: SDK Test <sdk-test@example.invalid>
+Architecture: {ARCH}
+Multi-Arch: same
+Version: {INSTALLED_VERSION}
+Description: installed Ubuntu fixture
+
+""",
+        encoding="utf-8",
+    )
+    (repository / "Packages").write_text(
+        f"""Package: {PACKAGE}
+Architecture: {ARCH}
+Version: {TARGET_VERSION}
+Priority: required
+Section: libs
+Filename: pool/{PACKAGE}_{TARGET_VERSION}_{ARCH}.deb
+Size: 1
+Description: approved target fixture
+
+""",
+        encoding="utf-8",
+    )
+    sources = root / "sources.list"
+    sources.write_text(
+        f"deb [trusted=yes] file:{repository} ./\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            "apt-get",
+            *apt_options(root),
+            "-o",
+            f"Dir::Cache={cache}",
+            "update",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def candidate_for(root: Path, priority: int) -> tuple[str, str]:
+    preferences_dir = root / "preferences.d"
+    preferences_dir.mkdir(exist_ok=True)
+    preferences = preferences_dir / "target.pref"
+    preferences.write_text(
+        f"""Package: {PACKAGE}
+Pin: version {TARGET_VERSION}
+Pin-Priority: {priority}
+
+""",
+        encoding="utf-8",
+    )
+    command = [
+        "apt-cache",
+        *apt_options(root),
+        "-o",
+        "Dir::Etc::preferences=/dev/null",
+        "-o",
+        f"Dir::Etc::preferencesparts={preferences_dir}",
+        "policy",
+        f"{PACKAGE}:{ARCH}",
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    match = re.search(r"^\s*Candidate:\s*(\S+)\s*$", result.stdout, re.MULTILINE)
+    if match is None:
+        raise AssertionError(f"apt-cache did not report a candidate:\n{result.stdout}")
+    return match.group(1), result.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("preferences", type=Path)
+    args = parser.parse_args()
+
+    target_priority = read_target_priority(args.preferences)
+    with tempfile.TemporaryDirectory(prefix="sysroot-apt-candidate-") as tmpdir:
+        root = Path(tmpdir)
+        write_fixture(root)
+
+        baseline, baseline_policy = candidate_for(root, 990)
+        if baseline != INSTALLED_VERSION:
+            raise AssertionError(
+                f"priority 990 selected {baseline}, expected installed "
+                f"{INSTALLED_VERSION}:\n{baseline_policy}"
+            )
+
+        patched, patched_policy = candidate_for(root, target_priority)
+        if patched != TARGET_VERSION:
+            raise AssertionError(
+                f"priority {target_priority} selected {patched}, expected target "
+                f"{TARGET_VERSION}:\n{patched_policy}"
+            )
+
+    print(
+        f"APT candidate regression passed: 990 -> {baseline}; "
+        f"{target_priority} -> {patched}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk/test-sysroot-update.sh
+++ b/tests/sdk/test-sysroot-update.sh
@@ -59,11 +59,22 @@ printf '%s\t%s\t%s\n' \
   "${revision}" \
   "${SIMAAI_SETUP_DOWNLOAD_ONLY:-0}" \
   "${SIMAAI_PLATFORM_BUILD_REVISION:-}" >> "${SYSROOT_UPDATE_TEST_LOG:?}"
-grep -Fq 'Pin: origin "deb.debian.org"' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
-grep -Fq 'Pin: origin "mirror.elxr.dev"' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+for origin in \
+  debian.neat.sima.ai \
+  repo.sima.ai \
+  mirror.elxr.dev \
+  deb.debian.org \
+  security.debian.org; do
+  grep -A1 -F "Pin: origin \"${origin}\"" "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}" | \
+    grep -Fq 'Pin-Priority: 1001'
+done
 grep -A1 -F 'Pin: release o=Ubuntu' "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}" | \
   grep -Fq 'Pin-Priority: 100'
 [[ "${SIMAAI_VALIDATE_TARGET_ORIGIN:-}" == "1" ]]
+if [[ -n "${SYSROOT_UPDATE_APT_CANDIDATE_TEST:-}" ]]; then
+  python3 "${SYSROOT_UPDATE_APT_CANDIDATE_TEST}" \
+    "${SYSROOT_UPDATE_APT_PREFERENCES_FILE:?}"
+fi
 rm -rf "${download_dir}"
 mkdir -p "${download_dir}"
 package_root="$(mktemp -d)"
@@ -152,7 +163,11 @@ if run_sysroot update 2.1.3~pre9999 >"${tmpdir}/out" 2>"${tmpdir}/err"; then
 fi
 grep -Fq 'is not available' "${tmpdir}/err" || fail "missing revision rejection was unclear"
 
-dry_run="$(run_sysroot update 2.1.3~pre4593 --dry-run)"
+dry_run="$(
+  env "${common_env[@]}" \
+    SYSROOT_UPDATE_APT_CANDIDATE_TEST="${ROOT_DIR}/tests/sdk/test-sysroot-apt-candidate.py" \
+    "${SYSROOT_COMMAND}" update 2.1.3~pre4593 --dry-run
+)"
 grep -Fq 'Dry run complete: 2.1.3~pre4593 resolved and validated' <<< "${dry_run}" || \
   fail "exact dry run did not validate the selected revision"
 [[ ! -e "${tmpdir}/sysroot/var/lib/sima-sdk/sysroot-overlay" ]] || \
@@ -263,6 +278,15 @@ fi
 grep -Fq 'deb [arch=arm64 trusted=yes] https://debian.neat.sima.ai/pre-release bookworm non-free' \
   "${source_file}"
 grep -Fq 'Pin: version 2.1.3~pre4617' "${preferences_file}"
+for origin in \
+  debian.neat.sima.ai \
+  repo.sima.ai \
+  mirror.elxr.dev \
+  deb.debian.org \
+  security.debian.org; do
+  grep -A1 -F "Pin: origin \"${origin}\"" "${preferences_file}" | \
+    grep -Fq 'Pin-Priority: 990'
+done
 case "${1:-}" in
   policy)
     printf '%s\n' '  Candidate: (none)'


### PR DESCRIPTION
## Why

`sysroot update` rejected a valid Modalix package cohort when an approved target dependency was older than the same ARM64 package installed from Ubuntu. With target repositories pinned at 990, APT retained the newer host version and the origin validator correctly rejected it.

## What Changed

- Use priority 1001 for approved target repositories only during `sysroot update`.
- Keep exact platform packages at 1002, Ubuntu at 100, and active-overlay explicit installs at 990.
- Add an offline real-APT regression covering the `libgcc-s1` downgrade from Ubuntu 14.2 to the approved target 12.2 package.

## Validation

- A fresh `develop-fb2b046` SDK container completed `sysroot update --dry-run 2.1.3~pre4744` and validated all 405 packages without modifying the sysroot.
- The same clean container completed the real update, produced an active `2.1.3~pre4744` overlay, and recorded `libgcc-s1:arm64=12.2.0-14+deb12u1`.
- The APT regression proves priority 990 retains the installed Ubuntu version while 1001 selects the older target version.
- Unprivileged dry-run, package-version validator, progress, syntax, staged-change, simplification, and exact-SHA review checks passed.
- The full update shell test reaches the new checks but later encounters an unchanged OpenCV alias fixture failure that reproduces identically at the exact base commit.

## Risk

The downgrade-capable priority is limited to update transactions. Stable SDK construction, explicit install priorities, and target-origin validation remain unchanged.

## Notes

Vulcan staging and production snapshot promotion follow after this change merges and a fixed `develop` SDK image is available. Downstream Internals, LLiMa, Core, and Apps CI adoption remains separate.

Refs #157